### PR TITLE
Release: SEO fixes, dependency bumps, and dev tooling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,11 @@
-from flask import Flask
+from flask import Flask, request
 
 app = Flask(__name__)
+
+@app.context_processor
+def inject_noindex():
+    """Block search engine indexing on non-production domains (e.g. dev.tidecalendar.xyz)."""
+    host = request.host.split(':')[0]
+    return {'noindex': host != 'tidecalendar.xyz'}
 
 from app import routes

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,6 +8,7 @@
     <meta name="description" content="Generate free printable PDF tide calendars for over 2,200 USA and Canadian tide stations. Monthly high and low tide predictions you can print or save.">
     {% endblock %}
     <meta name="author" content="Matthew Manuel">
+    {% if noindex %}<meta name="robots" content="noindex, nofollow">{% endif %}
     <link rel="canonical" href="https://tidecalendar.xyz/">
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- **SEO fix**: Add `noindex` meta tag on non-production domains (`dev.tidecalendar.xyz`) to resolve Google Search Console duplicate content warnings
- **Security**: Bump Flask, Werkzeug, requests, and Docker base image from Python 3.9 → 3.12
- **Calendar improvements**: Add mini-calendars and site URL footer to generated PDFs; fix pcal `-s` flag parsing
- **Dev tooling**: Add Claude Code hooks, skills, deployment verifier, and codebase documentation
- **Tests**: Harden Playwright smoke tests against networkidle flakes, bump Node to 22

## Test plan
- [x] Dev deploy verified at `dev.tidecalendar.xyz` — commit `d4c4dc3` confirmed via `/health`
- [ ] Verify `noindex` tag appears on `dev.tidecalendar.xyz` (view source)
- [ ] Verify `noindex` tag does NOT appear on `tidecalendar.xyz` after merge
- [ ] Smoke tests pass against production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)