### PR TITLE
Cap year dropdown at current_year + 4

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -143,8 +143,9 @@ def index():
             year = int(year)
             month = int(month)
             current_year = datetime.utcnow().year
-            # NOAA tide predictions are not published beyond 2030.
-            max_year = min(current_year + 15, 2030)
+            # NOAA tide predictions are typically only published a few years
+            # out, so cap requests at current_year + 4.
+            max_year = current_year + 4
 
             # Validate ranges
             if not (1 <= month <= 12):

--- a/app/routes.py
+++ b/app/routes.py
@@ -143,7 +143,8 @@ def index():
             year = int(year)
             month = int(month)
             current_year = datetime.utcnow().year
-            max_year = current_year + 15
+            # NOAA tide predictions are not published beyond 2030.
+            max_year = min(current_year + 15, 2030)
 
             # Validate ranges
             if not (1 <= month <= 12):

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -141,10 +141,11 @@
         const currentYear = currentDate.getFullYear();
         const currentMonth = String(currentDate.getMonth() + 1).padStart(2, '0');
 
-        // Populate year dropdown from current year through 2030 (NOAA tide
-        // predictions are not published beyond 2030).
+        // Populate year dropdown from current year through current year + 4.
+        // NOAA tide predictions are typically only published a few years out,
+        // so anything further fails upstream with "PDF not found".
         const yearSelect = document.getElementById('year');
-        const endYear = Math.min(currentYear + 15, 2030);
+        const endYear = currentYear + 4;
         for (let year = currentYear; year <= endYear; year++) {
             const option = document.createElement('option');
             option.value = year;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -141,9 +141,10 @@
         const currentYear = currentDate.getFullYear();
         const currentMonth = String(currentDate.getMonth() + 1).padStart(2, '0');
 
-        // Populate year dropdown with options from current year to current year + 15
+        // Populate year dropdown from current year through 2030 (NOAA tide
+        // predictions are not published beyond 2030).
         const yearSelect = document.getElementById('year');
-        const endYear = currentYear + 15;
+        const endYear = Math.min(currentYear + 15, 2030);
         for (let year = currentYear; year <= endYear; year++) {
             const option = document.createElement('option');
             option.value = year;


### PR DESCRIPTION
## Summary
- USA calendar requests for 2031+ fail with "PDF not found" because NOAA tide predictions aren't published that far out.
- Caps the client-side year dropdown (`index.html`) and server-side validation (`routes.py`) at `current_year + 4` so users can't request a year the upstream API won't serve. Rolls forward automatically as NOAA publishes more years.

## Test plan
- [ ] Wait for dev.tidecalendar.xyz deploy; check `/health` for the new commit hash.
- [ ] Load the form on dev and confirm the year dropdown ends at 2030 (today is 2026).
- [ ] Manually POST year=2031 and confirm a friendly "Invalid input" error renders instead of a generic PDF failure.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P8mRUMa9E35yk7oo6CQwAh)_