### PR TITLE
Promote tide event text size increase to production

### DIFF
--- a/app/get_tides.py
+++ b/app/get_tides.py
@@ -262,10 +262,11 @@ if __name__ == "__main__":
     # -f -- specify the input file
     # -o -- specify the output file
     # -C text -- centered footer text
+    # -n font/size -- event text inside day boxes (pcal default is Helvetica-Narrow/6; 9 is ~50% larger)
     # mini-calendars for prev/next month shown by default (lower-right; -S suppresses)
 
     # Call the shell command to create the calendar page
-    subprocess.run(["pcal", "-f", pcal_filename, "-o", pcal_filename.replace('.txt', '.ps'), "-s", "0.0:0.0:1.0", "-m", "-C", "tidecalendar.xyz", str(args.month), str(args.year)])
+    subprocess.run(["pcal", "-f", pcal_filename, "-o", pcal_filename.replace('.txt', '.ps'), "-s", "0.0:0.0:1.0", "-n", "Helvetica-Narrow/9", "-m", "-C", "tidecalendar.xyz", str(args.month), str(args.year)])
 
     # Convert the PostScript file to PDF and save to /data/calendars
     subprocess.run(["ps2pdf", pcal_filename.replace('.txt', '.ps'), pdf_output_path])

--- a/app/routes.py
+++ b/app/routes.py
@@ -143,8 +143,9 @@ def index():
             year = int(year)
             month = int(month)
             current_year = datetime.utcnow().year
-            # NOAA tide predictions are not published beyond 2030.
-            max_year = min(current_year + 15, 2030)
+            # NOAA tide predictions are typically only published a few years
+            # out, so cap requests at current_year + 4.
+            max_year = current_year + 4
 
             # Validate ranges
             if not (1 <= month <= 12):

--- a/app/routes.py
+++ b/app/routes.py
@@ -143,7 +143,8 @@ def index():
             year = int(year)
             month = int(month)
             current_year = datetime.utcnow().year
-            max_year = current_year + 15
+            # NOAA tide predictions are not published beyond 2030.
+            max_year = min(current_year + 15, 2030)
 
             # Validate ranges
             if not (1 <= month <= 12):

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -141,10 +141,11 @@
         const currentYear = currentDate.getFullYear();
         const currentMonth = String(currentDate.getMonth() + 1).padStart(2, '0');
 
-        // Populate year dropdown from current year through 2030 (NOAA tide
-        // predictions are not published beyond 2030).
+        // Populate year dropdown from current year through current year + 4.
+        // NOAA tide predictions are typically only published a few years out,
+        // so anything further fails upstream with "PDF not found".
         const yearSelect = document.getElementById('year');
-        const endYear = Math.min(currentYear + 15, 2030);
+        const endYear = currentYear + 4;
         for (let year = currentYear; year <= endYear; year++) {
             const option = document.createElement('option');
             option.value = year;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -141,9 +141,10 @@
         const currentYear = currentDate.getFullYear();
         const currentMonth = String(currentDate.getMonth() + 1).padStart(2, '0');
 
-        // Populate year dropdown with options from current year to current year + 15
+        // Populate year dropdown from current year through 2030 (NOAA tide
+        // predictions are not published beyond 2030).
         const yearSelect = document.getElementById('year');
-        const endYear = currentYear + 15;
+        const endYear = Math.min(currentYear + 15, 2030);
         for (let year = currentYear; year <= endYear; year++) {
             const option = document.createElement('option');
             option.value = year;


### PR DESCRIPTION
Closing — development now also contains the year-cap fix which the user wants held until validated on dev. Replacing with a clean cherry-pick PR that contains only the text-size commit. See #75.