### PR TITLE
Promote tide event text size increase to production

### DIFF
--- a/app/get_tides.py
+++ b/app/get_tides.py
@@ -262,10 +262,11 @@ if __name__ == "__main__":
     # -f -- specify the input file
     # -o -- specify the output file
     # -C text -- centered footer text
+    # -n font/size -- event text inside day boxes (pcal default is Helvetica-Narrow/6; 9 is ~50% larger)
     # mini-calendars for prev/next month shown by default (lower-right; -S suppresses)
 
     # Call the shell command to create the calendar page
-    subprocess.run(["pcal", "-f", pcal_filename, "-o", pcal_filename.replace('.txt', '.ps'), "-s", "0.0:0.0:1.0", "-m", "-C", "tidecalendar.xyz", str(args.month), str(args.year)])
+    subprocess.run(["pcal", "-f", pcal_filename, "-o", pcal_filename.replace('.txt', '.ps'), "-s", "0.0:0.0:1.0", "-n", "Helvetica-Narrow/9", "-m", "-C", "tidecalendar.xyz", str(args.month), str(args.year)])
 
     # Convert the PostScript file to PDF and save to /data/calendars
     subprocess.run(["ps2pdf", pcal_filename.replace('.txt', '.ps'), pdf_output_path])


### PR DESCRIPTION
## Summary
- Cherry-pick of the text-size commit (`d535e49`) from development onto a branch off main, so this PR carries **only** the text-size change. The year-cap fix is held back for dev validation and will be promoted separately.
- pcal notes font goes from default `Helvetica-Narrow/6` to `Helvetica-Narrow/9` (~50% larger).

## Test plan
- [ ] After merge, confirm `/health` on tidecalendar.xyz shows the new commit.
- [ ] Clear prod PDF cache: `ssh captain "docker exec <prod-container> sh -c 'rm -f /data/calendars/*.pdf'"`
- [ ] Generate a calendar on prod and visually confirm larger event text.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P8mRUMa9E35yk7oo6CQwAh)_