### PR TITLE
Promote smoke-test health-check retry to production

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,8 +36,12 @@ jobs:
 
     - name: Health check production site
       run: |
-        curl -f https://www.tidecalendar.xyz/ || {
-          echo "Production site is down"
+        # Retry to absorb transient blips (brief redeploys, TLS/network
+        # hiccups) so a single momentary non-2xx doesn't fail the whole run.
+        curl -f --connect-timeout 10 --max-time 30 \
+          --retry 3 --retry-delay 5 --retry-all-errors \
+          https://www.tidecalendar.xyz/ || {
+          echo "Production site is down (failed after retries)"
           exit 1
         }
 


### PR DESCRIPTION
## Summary
Promotes the health-check hardening from `development` (merged via #77) to `main`.

Adds retry + timeout flags to the `curl` health-check gate in `.github/workflows/playwright.yml`. The daily scheduled smoke run [#410](https://github.com/matt-the-ogre/tide-calendar-site/actions/runs/26677518594) (2026-05-30) failed only at the "Health check production site" step — a single `curl -f` hit a momentary non-2xx and the Playwright suite was skipped. The same `main` commit had passed the prior 9 daily runs, so this was a transient production blip, not a regression.

The retry (`--retry 3 --retry-all-errors --retry-delay 5`, plus connect/max timeouts) means a single momentary non-2xx no longer fails the whole run. A genuine sustained outage still fails (exit 1 after retries are exhausted). Worst-case runtime ≈ 135s, well under the job's `timeout-minutes: 5`.

## Scope
- CI-only change — one file (`.github/workflows/playwright.yml`), +6/−2. No app/runtime impact.

## Test plan
- [x] Smoke test green on the change (PR #77): health check passed with the new retry logic **and** the full Playwright suite ran against live production and passed.
- [ ] After merge, confirm the next scheduled/push Playwright run on `main` is green.

Note: the effect (curl retries) only surfaces the next time the smoke workflow runs; there's no deployed-app behavior change to verify on tidecalendar.xyz.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSVKmsxUMYmXVk79e7vQUY)_