### PR TITLE
Fix Canadian station name search: index alternate names, relax import filter

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,37 @@
+name: Python Unit Tests
+
+on:
+  push:
+    branches: [ main, development ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit-tests:
+    name: Python Unit Tests
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        # Match the Dockerfile base image (python:3.12-slim-bookworm)
+        python-version: '3.12'
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Run app unit tests
+      # Tests import sibling modules (database, canadian_station_sync,
+      # tide_adapters) directly, so run from the app/ directory. They are
+      # fully offline (CHS/NOAA calls are mocked; DB tests use temp files).
+      working-directory: app
+      run: python -m unittest discover -p 'test_*.py' -v
+
+    - name: Run usage_events tests
+      run: python scripts/test_usage_events.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,9 +133,15 @@ ANALYTICS_TOKEN=<random-string>  # gates /admin/analytics dashboard
 1. **Container Startup (Database Initialization)**:
    - Initialize SQLite database and schema
    - Import USA stations from `tide_stations_new.csv` (~2100 stations)
-   - **Dynamically import Canadian stations** from CHS IWLS API (~73 active stations)
-     - Filters: `operating: true`, `type: PERMANENT`, has `wlp-hilo` predictions
-     - Logs: "Found X of Y stations operating with wlp-hilo data"
+   - **Dynamically import Canadian stations** from CHS IWLS API (~1076 stations)
+     - Filter: has `wlp-hilo` predictions (high/low tide data) + a code and official name.
+       The `operating`/`type` flags are intentionally NOT used — many `operating:false`/
+       `TEMPORARY` stations (e.g. 07837 ḵalpilin / Pender Harbour) still publish full
+       forward predictions; gating on them hid ~93% of calendar-capable stations. No
+       `dateStart` param either (it prunes stations that still have current predictions).
+     - Captures CHS `alternativeName` (common name) into the `alternative_name` column so
+       name search/autocomplete matches either name (see `normalize_station`).
+     - Logs: "Found X of Y stations with wlp-hilo predictions"
      - Fallback to `canadian_tide_stations.csv` if API unavailable
    - Sync database (remove inactive stations)
 2. **PDF Generation with Caching**:

--- a/app/canadian_station_sync.py
+++ b/app/canadian_station_sync.py
@@ -107,35 +107,83 @@ def construct_place_name(official_name: str, province: Optional[str], latitude: 
     return f"{official_name}, {inferred_province}"
 
 
+def normalize_station(station: Dict) -> Optional[Dict]:
+    """
+    Normalize a raw CHS station record into our import shape, or return None.
+
+    Inclusion policy: the station must publish high/low tide predictions
+    ("wlp-hilo" time series) and have both a code and an official name. Stations
+    are intentionally NOT filtered on the `operating` or `type` flags — many
+    stations flagged operating=false or type=TEMPORARY (e.g. 07837 "ḵalpilin" /
+    Pender Harbour) still publish full forward tide predictions and are
+    perfectly usable for a calendar. Filtering them out hid ~93% of
+    calendar-capable Canadian stations from name search.
+
+    The CHS `alternativeName` (the familiar common name, e.g. "Pender Harbour"
+    when the official name is the Indigenous "ḵalpilin") is preserved so the
+    autocomplete can match and display it.
+
+    Returns:
+        Normalized dict with keys code, officialName, alternativeName, latitude,
+        longitude, province, place_name — or None if the station is unusable.
+    """
+    if not station:
+        return None
+
+    # Must publish high/low tide predictions to produce a calendar.
+    time_series = station.get('timeSeries', [])
+    if not any(ts.get('code') == 'wlp-hilo' for ts in time_series):
+        return None
+
+    code = station.get('code')
+    official_name = station.get('officialName', '')
+    if not code or not official_name:
+        return None
+
+    latitude = station.get('latitude', 0.0)
+    longitude = station.get('longitude', 0.0)
+    province = extract_province_from_name(official_name)
+    place_name = construct_place_name(official_name, province, latitude, longitude)
+    alternative_name = (station.get('alternativeName') or '').strip()
+
+    return {
+        'code': code,
+        'officialName': official_name,
+        'alternativeName': alternative_name,
+        'latitude': latitude,
+        'longitude': longitude,
+        'province': province or '',
+        'place_name': place_name
+    }
+
+
 def fetch_canadian_stations_from_api() -> Tuple[Optional[List[Dict]], str]:
     """
-    Fetch all operating Canadian stations with wlp-hilo predictions from CHS API.
+    Fetch all Canadian stations with wlp-hilo predictions from the CHS API.
 
-    Filtering criteria:
-    - dateStart: Current year (filters to stations with data from current year forward)
-    - operating: true (station is active)
-    - type: "PERMANENT" (exclude temporary/discontinued stations)
+    Inclusion criteria (see normalize_station):
     - Has "wlp-hilo" in timeSeries array (high/low tide predictions available)
+    - Has a code and an official name
+
+    Note: we deliberately do NOT pass a `dateStart` filter. Empirically the CHS
+    `dateStart` param prunes the list to a small subset that excludes stations
+    which nonetheless have current/forward predictions (07837 is one), so we
+    fetch the full directory and gate purely on prediction availability.
 
     Returns:
         Tuple of (stations_list, endpoint_used) or (None, error_message)
-        Each station dict contains: code, officialName, latitude, longitude, province, place_name
+        Each station dict contains: code, officialName, alternativeName,
+        latitude, longitude, province, place_name
     """
     import json
-    from datetime import datetime
-
-    # Get current year for dateStart parameter (midnight UTC on Jan 1 of current year)
-    current_year = datetime.utcnow().year
-    date_start = f"{current_year}-01-01T00:00:00Z"
 
     # Try each API endpoint
     for base_url in CHS_BASE_URLS:
         try:
             url = f"{base_url}/stations"
-            params = {"dateStart": date_start}
-            logging.info(f"Fetching Canadian stations from {base_url} (dateStart={date_start})...")
+            logging.info(f"Fetching Canadian stations from {base_url}...")
 
-            response = requests.get(url, params=params, headers=HEADERS, timeout=30)
+            response = requests.get(url, headers=HEADERS, timeout=30)
 
             if response.status_code != 200:
                 logging.warning(f"CHS API at {base_url} returned status {response.status_code}")
@@ -145,48 +193,14 @@ def fetch_canadian_stations_from_api() -> Tuple[Optional[List[Dict]], str]:
             all_stations = json.loads(response.text)
             logging.debug(f"Received {len(all_stations)} total stations from API")
 
-            # Filter stations
+            # Normalize + filter (keep any station with wlp-hilo predictions)
             valid_stations = []
             for station in all_stations:
-                # Check if operating
-                if not station.get('operating', False):
-                    continue
+                normalized = normalize_station(station)
+                if normalized is not None:
+                    valid_stations.append(normalized)
 
-                # Check if type is PERMANENT
-                station_type = station.get('type', '')
-                if station_type != 'PERMANENT':
-                    continue
-
-                # Check if has wlp-hilo time series
-                time_series = station.get('timeSeries', [])
-                has_hilo = any(ts.get('code') == 'wlp-hilo' for ts in time_series)
-                if not has_hilo:
-                    continue
-
-                # Extract station data
-                code = station.get('code')
-                official_name = station.get('officialName', '')
-                latitude = station.get('latitude', 0.0)
-                longitude = station.get('longitude', 0.0)
-
-                if not code or not official_name:
-                    logging.warning(f"Station missing code or name: {station}")
-                    continue
-
-                # Extract province and construct place name
-                province = extract_province_from_name(official_name)
-                place_name = construct_place_name(official_name, province, latitude, longitude)
-
-                valid_stations.append({
-                    'code': code,
-                    'officialName': official_name,
-                    'latitude': latitude,
-                    'longitude': longitude,
-                    'province': province or '',
-                    'place_name': place_name
-                })
-
-            logging.info(f"Found {len(valid_stations)} of {len(all_stations)} stations operating with wlp-hilo data")
+            logging.info(f"Found {len(valid_stations)} of {len(all_stations)} stations with wlp-hilo predictions")
             return valid_stations, base_url
 
         except requests.exceptions.RequestException as e:
@@ -236,15 +250,16 @@ def import_canadian_stations_from_csv() -> bool:
             # Import each station
             for station in stations:
                 cursor.execute('''
-                    INSERT INTO tide_station_ids (station_id, place_name, country, api_source, latitude, longitude, province)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    INSERT INTO tide_station_ids (station_id, place_name, country, api_source, latitude, longitude, province, alternative_name)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(station_id) DO UPDATE SET
                         place_name = excluded.place_name,
                         country = excluded.country,
                         api_source = excluded.api_source,
                         latitude = excluded.latitude,
                         longitude = excluded.longitude,
-                        province = excluded.province
+                        province = excluded.province,
+                        alternative_name = excluded.alternative_name
                 ''', (
                     station['station_id'],
                     station.get('place_name', ''),
@@ -252,7 +267,8 @@ def import_canadian_stations_from_csv() -> bool:
                     'CHS',
                     float(station.get('latitude', 0)),
                     float(station.get('longitude', 0)),
-                    station.get('province', '')
+                    station.get('province', ''),
+                    station.get('alternative_name') or None
                 ))
 
             conn.commit()
@@ -299,15 +315,16 @@ def import_canadian_stations_from_api() -> bool:
             # Import/update each station
             for station in stations:
                 cursor.execute('''
-                    INSERT INTO tide_station_ids (station_id, place_name, country, api_source, latitude, longitude, province)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    INSERT INTO tide_station_ids (station_id, place_name, country, api_source, latitude, longitude, province, alternative_name)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(station_id) DO UPDATE SET
                         place_name = excluded.place_name,
                         country = excluded.country,
                         api_source = excluded.api_source,
                         latitude = excluded.latitude,
                         longitude = excluded.longitude,
-                        province = excluded.province
+                        province = excluded.province,
+                        alternative_name = excluded.alternative_name
                 ''', (
                     station['code'],
                     station['place_name'],
@@ -315,7 +332,8 @@ def import_canadian_stations_from_api() -> bool:
                     'CHS',
                     station['latitude'],
                     station['longitude'],
-                    station['province']
+                    station['province'],
+                    station.get('alternativeName') or None
                 ))
 
             # Sync: Remove Canadian stations not in API response (preserving lookup_count)

--- a/app/database.py
+++ b/app/database.py
@@ -62,6 +62,10 @@ def init_database():
                 cursor.execute('ALTER TABLE tide_station_ids ADD COLUMN province TEXT')
                 logging.info("Added province column to tide_station_ids table")
 
+            if 'alternative_name' not in columns:
+                cursor.execute('ALTER TABLE tide_station_ids ADD COLUMN alternative_name TEXT')
+                logging.info("Added alternative_name column to tide_station_ids table")
+
             cursor.execute('''
                 CREATE TABLE IF NOT EXISTS usage_events (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -493,8 +497,50 @@ def import_canadian_stations_from_csv():
         logging.error(f"Error importing Canadian stations from CSV: {e}")
         return False
 
+def format_display_name(place_name, alternative_name, province=None):
+    """Build a search-friendly display label for the autocomplete dropdown.
+
+    CHS increasingly stores the Indigenous name as the official name and the
+    familiar common name in a separate field (e.g. official "ḵalpilin",
+    alternative "Pender Harbour"). When a distinct common name exists, lead with
+    it and show the official name in parentheses, keeping the province suffix
+    outside the parens:
+
+        "ḵalpilin, BC" + "Pender Harbour"  ->  "Pender Harbour (ḵalpilin), BC"
+
+    Falls back to place_name when there is no alternative name or it merely
+    duplicates the official name (e.g. USA/NOAA stations have no alias).
+    """
+    if not place_name:
+        return place_name
+
+    alt = (alternative_name or '').strip()
+    if not alt:
+        return place_name
+
+    # Split the trailing ", PROV" suffix off the official name, if present, so
+    # the province stays at the end rather than inside the parentheses. Prefer
+    # an explicit province; otherwise split the trailing ", <code>" that
+    # construct_place_name appends (the province column is empty when the
+    # province was inferred from longitude rather than parsed from the name).
+    core, suffix = place_name, ''
+    if province and place_name.endswith(f", {province}"):
+        core = place_name[: -len(f", {province}")]
+        suffix = f", {province}"
+    elif ', ' in place_name:
+        core, _, tail = place_name.rpartition(', ')
+        suffix = f", {tail}"
+
+    # Don't duplicate when the common name already matches the official name.
+    if alt.lower() in (core.strip().lower(), place_name.strip().lower()):
+        return place_name
+
+    return f"{alt} ({core}){suffix}"
+
+
 def search_stations_by_country(query, country=None, limit=10):
-    """Search for stations by place name, optionally filtered by country."""
+    """Search for stations by place name or common (alternative) name,
+    optionally filtered by country."""
     if not query or len(query.strip()) < 1:
         return []
 
@@ -502,34 +548,38 @@ def search_stations_by_country(query, country=None, limit=10):
         with sqlite3.connect(DB_PATH) as conn:
             cursor = conn.cursor()
 
-            # Case-insensitive substring search
+            # Case-insensitive substring search across both the official place
+            # name and the CHS alternative/common name so visitors can find a
+            # station by whichever name they know.
             search_query = f"%{query.strip()}%"
 
             if country:
                 results = cursor.execute('''
-                    SELECT station_id, place_name, country, lookup_count
+                    SELECT station_id, place_name, country, lookup_count, alternative_name, province
                     FROM tide_station_ids
                     WHERE place_name IS NOT NULL
-                    AND LOWER(place_name) LIKE LOWER(?)
+                    AND (LOWER(place_name) LIKE LOWER(?) OR LOWER(alternative_name) LIKE LOWER(?))
                     AND country = ?
                     ORDER BY lookup_count DESC, place_name ASC
                     LIMIT ?
-                ''', (search_query, country, limit)).fetchall()
+                ''', (search_query, search_query, country, limit)).fetchall()
             else:
                 results = cursor.execute('''
-                    SELECT station_id, place_name, country, lookup_count
+                    SELECT station_id, place_name, country, lookup_count, alternative_name, province
                     FROM tide_station_ids
                     WHERE place_name IS NOT NULL
-                    AND LOWER(place_name) LIKE LOWER(?)
+                    AND (LOWER(place_name) LIKE LOWER(?) OR LOWER(alternative_name) LIKE LOWER(?))
                     ORDER BY lookup_count DESC, place_name ASC
                     LIMIT ?
-                ''', (search_query, limit)).fetchall()
+                ''', (search_query, search_query, limit)).fetchall()
 
             return [{
                 'station_id': row[0],
                 'place_name': row[1],
                 'country': row[2],
-                'lookup_count': row[3]
+                'lookup_count': row[3],
+                'alternative_name': row[4],
+                'display_name': format_display_name(row[1], row[4], row[5])
             } for row in results]
 
     except sqlite3.Error as e:
@@ -544,7 +594,7 @@ def get_popular_stations_by_country(country=None, limit=16):
 
             if country:
                 results = cursor.execute('''
-                    SELECT station_id, place_name, country, lookup_count
+                    SELECT station_id, place_name, country, lookup_count, alternative_name, province
                     FROM tide_station_ids
                     WHERE place_name IS NOT NULL
                     AND country = ?
@@ -553,7 +603,7 @@ def get_popular_stations_by_country(country=None, limit=16):
                 ''', (country, limit)).fetchall()
             else:
                 results = cursor.execute('''
-                    SELECT station_id, place_name, country, lookup_count
+                    SELECT station_id, place_name, country, lookup_count, alternative_name, province
                     FROM tide_station_ids
                     WHERE place_name IS NOT NULL
                     ORDER BY lookup_count DESC, place_name ASC
@@ -564,7 +614,9 @@ def get_popular_stations_by_country(country=None, limit=16):
                 'station_id': row[0],
                 'place_name': row[1],
                 'country': row[2],
-                'lookup_count': row[3]
+                'lookup_count': row[3],
+                'alternative_name': row[4],
+                'display_name': format_display_name(row[1], row[4], row[5])
             } for row in results]
 
     except sqlite3.Error as e:

--- a/app/database.py
+++ b/app/database.py
@@ -446,7 +446,17 @@ def get_station_info(station_id):
         return None
 
 def import_canadian_stations_from_csv():
-    """Import Canadian tide station data from CSV file and remove Canadian stations not in CSV."""
+    """Import Canadian tide station data from the static CSV and remove Canadian
+    stations not in the CSV.
+
+    Note: this is the CSV-only importer used by the offline maintenance scripts
+    under scripts/ (test_canadian_import.py, test_multi_country_offline.py,
+    test_lookup_count_preservation.py). The runtime startup path uses the
+    API-based importer in canadian_station_sync.py (which falls back to its own
+    CSV reader). Both write alternative_name so the column stays consistent
+    regardless of which path populates the DB; the static CSV simply has no
+    alternative_name column today (see follow-up doc), so it imports as NULL.
+    """
     csv_path = os.path.join(os.path.dirname(__file__), 'canadian_tide_stations.csv')
 
     if not os.path.exists(csv_path):
@@ -489,21 +499,23 @@ def import_canadian_stations_from_csv():
 
                     country = row.get('country', 'Canada')
                     api_source = row.get('api_source', 'CHS')
+                    # Tolerate a CSV without the column (defaults to NULL)
+                    alternative_name = row.get('alternative_name') or None
 
                     # Insert or update station (Canadian stations)
                     # Use INSERT OR IGNORE to preserve lookup_count for existing stations
                     cursor.execute('''
                         INSERT OR IGNORE INTO tide_station_ids
-                        (station_id, place_name, country, api_source, latitude, longitude, province, lookup_count, last_lookup)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
-                    ''', (station_id, place_name, country, api_source, latitude, longitude, province))
+                        (station_id, place_name, country, api_source, latitude, longitude, province, alternative_name, lookup_count, last_lookup)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
+                    ''', (station_id, place_name, country, api_source, latitude, longitude, province, alternative_name))
 
                     # Update metadata for existing stations without touching lookup_count
                     cursor.execute('''
                         UPDATE tide_station_ids
-                        SET place_name = ?, country = ?, api_source = ?, latitude = ?, longitude = ?, province = ?
+                        SET place_name = ?, country = ?, api_source = ?, latitude = ?, longitude = ?, province = ?, alternative_name = ?
                         WHERE station_id = ?
-                    ''', (place_name, country, api_source, latitude, longitude, province, station_id))
+                    ''', (place_name, country, api_source, latitude, longitude, province, alternative_name, station_id))
                     imported_count += 1
 
             # Remove Canadian stations from database that are NOT in the CSV

--- a/app/database.py
+++ b/app/database.py
@@ -354,7 +354,14 @@ def get_place_name_by_station_id(station_id):
         return None
 
 def get_station_id_by_place_name(place_name):
-    """Get the station ID for a given place name (exact match)."""
+    """Get the station ID for a given name.
+
+    Tries the official place_name first (exact, then case-insensitive), then the
+    CHS common/alternative name (exact, then case-insensitive). The alternative
+    name fallback lets a visitor who types a common name (e.g. "Pender Harbour")
+    and submits without picking from the autocomplete still resolve the station,
+    consistent with what the name search surfaces.
+    """
     if not place_name:
         return None
 
@@ -362,7 +369,7 @@ def get_station_id_by_place_name(place_name):
         with sqlite3.connect(DB_PATH) as conn:
             cursor = conn.cursor()
 
-            # Try exact match first
+            # Try official place_name: exact, then case-insensitive.
             result = cursor.execute('''
                 SELECT station_id
                 FROM tide_station_ids
@@ -372,11 +379,31 @@ def get_station_id_by_place_name(place_name):
             if result:
                 return result[0]
 
-            # If no exact match, try case-insensitive match
             result = cursor.execute('''
                 SELECT station_id
                 FROM tide_station_ids
                 WHERE LOWER(place_name) = LOWER(?)
+                LIMIT 1
+            ''', (place_name,)).fetchone()
+
+            if result:
+                return result[0]
+
+            # Fall back to the common/alternative name: exact, then case-insensitive.
+            result = cursor.execute('''
+                SELECT station_id
+                FROM tide_station_ids
+                WHERE alternative_name = ?
+                LIMIT 1
+            ''', (place_name,)).fetchone()
+
+            if result:
+                return result[0]
+
+            result = cursor.execute('''
+                SELECT station_id
+                FROM tide_station_ids
+                WHERE LOWER(alternative_name) = LOWER(?)
                 LIMIT 1
             ''', (place_name,)).fetchone()
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -400,7 +400,9 @@
                         item.appendChild(flagSpan);
                     }
 
-                    const nameText = document.createTextNode(station.place_name + ' ');
+                    // Prefer the combined "Common (Official), PROV" label when present
+                    const displayName = station.display_name || station.place_name;
+                    const nameText = document.createTextNode(displayName + ' ');
                     item.appendChild(nameText);
 
                     const badge = document.createElement('span');
@@ -409,7 +411,7 @@
                     item.appendChild(badge);
 
                     item.dataset.stationId = station.station_id;
-                    item.dataset.placeName = station.place_name;
+                    item.dataset.placeName = displayName;
 
                     item.addEventListener('click', () => {
                         selectStation(item);
@@ -501,9 +503,10 @@
                 countryCell.className = 'country-cell';
                 row.appendChild(countryCell);
 
-                // Station Name
+                // Station Name (prefer combined "Common (Official), PROV" label)
+                const displayName = station.display_name || station.place_name || 'Unknown';
                 const nameCell = document.createElement('td');
-                nameCell.textContent = station.place_name || 'Unknown';
+                nameCell.textContent = displayName;
                 row.appendChild(nameCell);
 
                 // Station ID
@@ -522,8 +525,8 @@
                 button.className = 'quick-generate-btn';
                 button.textContent = 'Generate PDF';
                 button.dataset.stationId = station.station_id;
-                button.dataset.placeName = station.place_name || 'Unknown';
-                button.addEventListener('click', () => handleQuickGenerate(station.station_id, station.place_name, button));
+                button.dataset.placeName = displayName;
+                button.addEventListener('click', () => handleQuickGenerate(station.station_id, displayName, button));
                 actionCell.appendChild(button);
                 row.appendChild(actionCell);
 

--- a/app/test_canadian_station_sync.py
+++ b/app/test_canadian_station_sync.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for Canadian station normalization/filtering.
+
+Covers the policy that any station with wlp-hilo predictions should be
+importable (regardless of operating/type flags), and that the CHS
+alternativeName is captured for name search.
+
+Run from the app/ directory:
+    ../venv/bin/python -m unittest test_canadian_station_sync
+"""
+
+import unittest
+
+from canadian_station_sync import normalize_station
+
+
+# Real CHS record shape for station 07837 (ḵalpilin / Pender Harbour):
+# operating=False, type=TEMPORARY, but it DOES publish wlp-hilo predictions.
+PENDER = {
+    "code": "07837",
+    "officialName": "ḵalpilin",
+    "alternativeName": "Pender Harbour",
+    "latitude": 49.633,
+    "longitude": -124.032,
+    "operating": False,
+    "type": "TEMPORARY",
+    "timeSeries": [{"code": "wlp"}, {"code": "wlp-hilo"}],
+}
+
+
+class TestNormalizeStation(unittest.TestCase):
+    def test_includes_non_operating_temporary_station_with_hilo(self):
+        """A non-operating TEMPORARY station with wlp-hilo must be included."""
+        result = normalize_station(PENDER)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["code"], "07837")
+
+    def test_captures_alternative_name(self):
+        """The CHS alternativeName (common name) must be captured."""
+        result = normalize_station(PENDER)
+        self.assertEqual(result["alternativeName"], "Pender Harbour")
+
+    def test_missing_alternative_name_is_falsy(self):
+        """Stations without an alternativeName should not error."""
+        raw = dict(PENDER)
+        raw.pop("alternativeName")
+        result = normalize_station(raw)
+        self.assertIsNotNone(result)
+        self.assertFalse(result["alternativeName"])
+
+    def test_excludes_station_without_hilo(self):
+        """A station lacking wlp-hilo cannot produce a tide calendar -> excluded."""
+        raw = dict(PENDER, timeSeries=[{"code": "wlp"}])
+        self.assertIsNone(normalize_station(raw))
+
+    def test_excludes_station_missing_code_or_name(self):
+        self.assertIsNone(normalize_station(dict(PENDER, code=None)))
+        self.assertIsNone(normalize_station(dict(PENDER, officialName="")))
+
+    def test_still_includes_operating_permanent_station(self):
+        """Regression: stations that passed the old filter still pass."""
+        raw = dict(
+            PENDER,
+            code="07795",
+            officialName="Point Atkinson",
+            alternativeName="Caulfeild Cove",
+            operating=True,
+            type="PERMANENT",
+        )
+        result = normalize_station(raw)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["code"], "07795")
+
+    def test_place_name_has_province_and_excludes_alternative(self):
+        """place_name stays the official name + province; the common name is
+        kept separate (so filenames/notes don't get the parenthetical)."""
+        result = normalize_station(PENDER)
+        self.assertTrue(result["place_name"].endswith(", BC"))
+        self.assertNotIn("Pender", result["place_name"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/test_station_search.py
+++ b/app/test_station_search.py
@@ -144,5 +144,54 @@ class TestUSAUnaffected(_DBTest):
         self.assertEqual(results[0]["display_name"], "Point Roberts, WA")
 
 
+class TestGetStationIdByName(_DBTest):
+    """The form-submit fallback (when no station_id is selected) must resolve a
+    typed common name, not just the official place_name."""
+
+    def setUp(self):
+        super().setUp()
+        self._insert(
+            station_id="07837",
+            place_name="ḵalpilin, BC",
+            country="Canada",
+            api_source="CHS",
+            province="BC",
+            alternative_name="Pender Harbour",
+            lookup_count=1,
+        )
+
+    def test_resolves_by_common_name(self):
+        self.assertEqual(self.db.get_station_id_by_place_name("Pender Harbour"), "07837")
+
+    def test_resolves_by_common_name_case_insensitive(self):
+        self.assertEqual(self.db.get_station_id_by_place_name("pender harbour"), "07837")
+
+    def test_resolves_by_official_place_name_still(self):
+        self.assertEqual(self.db.get_station_id_by_place_name("ḵalpilin, BC"), "07837")
+
+    def test_unknown_name_returns_none(self):
+        self.assertIsNone(self.db.get_station_id_by_place_name("Nowhere, ZZ"))
+
+
+class TestPopularStationsDisplayName(_DBTest):
+    def setUp(self):
+        super().setUp()
+        self._insert(
+            station_id="07837",
+            place_name="ḵalpilin, BC",
+            country="Canada",
+            api_source="CHS",
+            province="BC",
+            alternative_name="Pender Harbour",
+            lookup_count=3,
+        )
+
+    def test_popular_includes_combined_display_name(self):
+        results = self.db.get_popular_stations_by_country("Canada", limit=10)
+        match = [r for r in results if r["station_id"] == "07837"]
+        self.assertEqual(len(match), 1)
+        self.assertEqual(match[0]["display_name"], "Pender Harbour (ḵalpilin), BC")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/app/test_station_search.py
+++ b/app/test_station_search.py
@@ -92,6 +92,25 @@ class TestFormatDisplayName(_DBTest):
             self.db.format_display_name("Halifax, NS", "Halifax", "NS"), "Halifax, NS"
         )
 
+    def test_core_name_containing_comma_splits_on_province_only(self):
+        """Some official names themselves contain a comma; only the trailing
+        ', PROV' is the province suffix. Real example: station 07786."""
+        expected = "Sandy Cove (West Vancouver Laboratories, Ettershank Cove), BC"
+        # Explicit province column
+        self.assertEqual(
+            self.db.format_display_name(
+                "West Vancouver Laboratories, Ettershank Cove, BC", "Sandy Cove", "BC"
+            ),
+            expected,
+        )
+        # Province inferred (column empty) -> rpartition fallback splits last comma
+        self.assertEqual(
+            self.db.format_display_name(
+                "West Vancouver Laboratories, Ettershank Cove, BC", "Sandy Cove", ""
+            ),
+            expected,
+        )
+
 
 class TestSearchByAlternativeName(_DBTest):
     def setUp(self):

--- a/app/test_station_search.py
+++ b/app/test_station_search.py
@@ -1,0 +1,148 @@
+"""
+Unit tests for station name search and display formatting.
+
+Covers:
+- alternative_name schema column
+- searching by the CHS common name (alternativeName) finds the station
+- display_name combines "Common (Official), PROV"
+- USA stations (no alias) are unaffected
+
+Run from the app/ directory:
+    ../venv/bin/python -m unittest test_station_search
+"""
+
+import os
+import sys
+import sqlite3
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+def fresh_db():
+    """Create a throwaway DB and (re)import the database module against it."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    os.environ["DB_PATH"] = path
+    if "database" in sys.modules:
+        del sys.modules["database"]
+    import database
+
+    database.init_database()
+    return database, path
+
+
+class _DBTest(unittest.TestCase):
+    def setUp(self):
+        self.db, self.path = fresh_db()
+
+    def tearDown(self):
+        try:
+            os.remove(self.path)
+        except OSError:
+            pass
+        os.environ.pop("DB_PATH", None)
+
+    def _insert(self, **cols):
+        keys = ", ".join(cols)
+        placeholders = ", ".join("?" * len(cols))
+        with sqlite3.connect(self.path) as conn:
+            conn.execute(
+                f"INSERT INTO tide_station_ids ({keys}) VALUES ({placeholders})",
+                tuple(cols.values()),
+            )
+            conn.commit()
+
+
+class TestSchema(_DBTest):
+    def test_alternative_name_column_exists(self):
+        with sqlite3.connect(self.path) as conn:
+            cols = [r[1] for r in conn.execute("PRAGMA table_info(tide_station_ids)")]
+        self.assertIn("alternative_name", cols)
+
+
+class TestFormatDisplayName(_DBTest):
+    def test_combines_common_then_official_then_province(self):
+        self.assertEqual(
+            self.db.format_display_name("ḵalpilin, BC", "Pender Harbour", "BC"),
+            "Pender Harbour (ḵalpilin), BC",
+        )
+
+    def test_combines_when_province_column_empty_but_in_place_name(self):
+        """Real case: normalize_station infers the province into place_name (from
+        longitude) but leaves the province field empty when the official name has
+        no province code. The suffix must still be split out of place_name so the
+        province lands outside the parentheses."""
+        self.assertEqual(
+            self.db.format_display_name("ḵalpilin, BC", "Pender Harbour", ""),
+            "Pender Harbour (ḵalpilin), BC",
+        )
+        self.assertEqual(
+            self.db.format_display_name("ḵalpilin, BC", "Pender Harbour", None),
+            "Pender Harbour (ḵalpilin), BC",
+        )
+
+    def test_no_alternative_returns_place_name(self):
+        self.assertEqual(self.db.format_display_name("Seattle, WA", None, None), "Seattle, WA")
+        self.assertEqual(self.db.format_display_name("Seattle, WA", "", "WA"), "Seattle, WA")
+
+    def test_alternative_equal_to_official_not_duplicated(self):
+        self.assertEqual(
+            self.db.format_display_name("Halifax, NS", "Halifax", "NS"), "Halifax, NS"
+        )
+
+
+class TestSearchByAlternativeName(_DBTest):
+    def setUp(self):
+        super().setUp()
+        self._insert(
+            station_id="07837",
+            place_name="ḵalpilin, BC",
+            country="Canada",
+            api_source="CHS",
+            province="BC",
+            alternative_name="Pender Harbour",
+            lookup_count=1,
+        )
+
+    def test_search_by_common_name_finds_station(self):
+        results = self.db.search_stations_by_country("pender", "Canada", limit=10)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["station_id"], "07837")
+
+    def test_search_result_has_combined_display_name(self):
+        results = self.db.search_stations_by_country("pender", "Canada", limit=10)
+        self.assertEqual(results[0]["display_name"], "Pender Harbour (ḵalpilin), BC")
+
+    def test_search_by_official_name_still_finds_station(self):
+        results = self.db.search_stations_by_country("ḵalpilin", "Canada", limit=10)
+        self.assertEqual(len(results), 1)
+
+    def test_search_all_countries_matches_alternative(self):
+        results = self.db.search_stations_by_country("pender", None, limit=10)
+        self.assertEqual(len(results), 1)
+
+
+class TestUSAUnaffected(_DBTest):
+    def setUp(self):
+        super().setUp()
+        self._insert(
+            station_id="9449639",
+            place_name="Point Roberts, WA",
+            country="USA",
+            api_source="NOAA",
+            lookup_count=5,
+        )
+
+    def test_usa_search_still_works(self):
+        results = self.db.search_stations_by_country("roberts", "USA", limit=10)
+        self.assertEqual(len(results), 1)
+
+    def test_usa_display_name_is_plain_place_name(self):
+        results = self.db.search_stations_by_country("roberts", "USA", limit=10)
+        self.assertEqual(results[0]["display_name"], "Point Roberts, WA")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/canadian-station-search-followups.md
+++ b/docs/canadian-station-search-followups.md
@@ -102,6 +102,12 @@ search.
 stations including an `alternative_name` column) so the degraded mode closely matches
 normal operation. Could be a small maintenance script under `scripts/`.
 
+**Note:** The stale CSV already causes a pre-existing failure in
+`scripts/test_multi_country_offline.py` ("Get Canadian station info (Halifax) — Wrong
+API source: None") because Halifax is no longer in the curated CSV. Regenerating the
+CSV would fix that test too. (Unrelated to the name-search change; these `scripts/`
+tests are not run by the new CI job.)
+
 **Effort:** Small. **Impact:** Only matters during a CHS API outage.
 
 ---
@@ -142,18 +148,20 @@ make `place_name` carry a structured province consistently (see #1).
 
 ---
 
-## 7. Consolidate duplicate `import_canadian_stations_from_csv()`
+## 7. (Optional) Consolidate the two `import_canadian_stations_from_csv()`
 
-**Problem:** There are two functions with this name — one in
-`app/canadian_station_sync.py` (the active CSV fallback, updated to write
-`alternative_name`) and one in `app/database.py` (not in the startup path, **not**
-updated, so it would insert without `alternative_name`). The dormant duplicate is a
-trap for future maintainers.
+**Status:** The data inconsistency is **resolved** — both functions now write
+`alternative_name`. The `database.py` copy is NOT dead: it is the CSV-only importer
+used by the offline maintenance scripts (`scripts/test_canadian_import.py`,
+`test_multi_country_offline.py`, `test_lookup_count_preservation.py`), while
+`canadian_station_sync.py`'s copy is the API importer (with its own CSV fallback) used
+at runtime startup. They serve different purposes, so they are not strictly duplicates.
 
-**Proposed fix:** Remove the unused `database.py` copy, or unify on one implementation
-and have it write `alternative_name`.
+**Optional cleanup:** If the divergence still feels risky, consolidate the two CSV
+readers into one shared helper that both the offline scripts and the runtime fallback
+call. Low priority.
 
-**Effort:** Small. **Impact:** Code-clarity / avoids a latent inconsistency.
+**Effort:** Small–Medium. **Impact:** Code clarity only (no functional gap remains).
 
 ---
 

--- a/docs/canadian-station-search-followups.md
+++ b/docs/canadian-station-search-followups.md
@@ -1,0 +1,108 @@
+# Canadian Station Search — Follow-up Work
+
+Context: the station name search/autocomplete was overhauled so visitors can find
+Canadian stations by name (see commit "Fix Canadian station name search"). That
+change relaxed the CHS import filter (now keeps any station with `wlp-hilo`
+predictions, ~1,076 vs 71 before) and indexed the CHS `alternativeName` (common
+name) into a new `alternative_name` column so searches match either the official
+or common name, displaying e.g. `Pender Harbour (ḵalpilin), BC`.
+
+The items below are known limitations that were intentionally left out of that
+change. They are independent and can be tackled in any order.
+
+---
+
+## 1. Province inference is inaccurate
+
+**Problem:** When a CHS `officialName` has no province code, `construct_place_name()`
+in `app/canadian_station_sync.py` guesses the province from longitude. The guess is
+coarse and sometimes wrong.
+
+**Evidence:** Station 06380 displays as `Holman (Ulukhaktok), MB`. Ulukhaktok is in
+the Northwest Territories (NT), not Manitoba (MB) — the longitude band for "prairie"
+swallowed it.
+
+**Proposed fix:** The CHS per-station metadata endpoint returns an authoritative
+`provinceCode`:
+
+```
+GET https://api.iwls-sine.azure.cloud-nuage.dfo-mpo.gc.ca/api/v1/stations/{id}/metadata
+-> { ..., "provinceCode": "BC", ... }
+```
+
+Use it instead of the longitude heuristic.
+
+**Cost/trade-off:** The bulk `/stations` list response does **not** include
+`provinceCode`, so this requires one extra call per station (~1,076 calls) at
+container startup. Options to keep startup fast:
+- Fetch metadata only for stations whose name lacks a province code (the minority).
+- Cache provinceCode in the DB and only refetch for new/unknown stations.
+- Run it as a periodic maintenance script rather than at every startup.
+
+**Effort:** Medium. **Impact:** Cosmetic (wrong province label), but visible.
+
+---
+
+## 2. Diacritic-insensitive search
+
+**Problem:** Search is a plain SQLite `LIKE` substring match, which is not
+Unicode-fold-aware. Typing the plain ASCII "kalpilin" does **not** match the
+official name "ḵalpilin" (the `ḵ` is U+1E35, "k with line below").
+
+**Current state:** Users can still find station 07837 by typing "pender" (the common
+name) or "ḵalpilin" exactly, so this is a nice-to-have, not a blocker.
+
+**Proposed fix:** Add a normalized/folded search column (strip diacritics to ASCII,
+e.g. via `unicodedata` NFKD + combining-mark removal, plus a small custom map for
+characters like `ḵ`→`k` that NFKD doesn't decompose) and match against it. Populate
+it on import alongside `place_name`/`alternative_name`.
+
+**Effort:** Medium. **Impact:** Helps users who type the Indigenous name phonetically
+in ASCII.
+
+---
+
+## 3. Messy CHS `alternativeName` values
+
+**Problem:** Some CHS alternate names are duplicated or malformed, which produces
+ugly combined display labels. They are still searchable, just unattractive.
+
+**Evidence:**
+- 03765 Alert → alt `Dumb Bell Bay, DUMB BELL BAY`
+- 09958 Henslung Cove → alt `Parry Passage, B.C., Parry Passage, B.C.`
+
+These render as e.g. `Dumb Bell Bay, DUMB BELL BAY (Alert), NT`.
+
+**Proposed fix:** In `normalize_station()`, clean the alternate name before storing:
+de-duplicate repeated segments, collapse `, <SAME UPPERCASED>` echoes, and optionally
+skip combining into the display label (still index it for search) when it contains
+commas or exceeds a length threshold — fall back to showing just the official name.
+
+**Effort:** Small–Medium. **Impact:** Cosmetic polish for a handful of stations.
+
+---
+
+## 4. Stale CSV fallback (`app/canadian_tide_stations.csv`)
+
+**Problem:** The CSV fallback (used only when the CHS API is unreachable at startup)
+still contains the old hand-curated station set and has no `alternative_name` column.
+The importer tolerates the missing column (defaults to NULL), so it won't crash — but
+if the API is ever down, the site falls back to a much smaller list with no common-name
+search.
+
+**Proposed fix:** Regenerate the fallback CSV from a successful live import (all ~1,076
+stations including an `alternative_name` column) so the degraded mode closely matches
+normal operation. Could be a small maintenance script under `scripts/`.
+
+**Effort:** Small. **Impact:** Only matters during a CHS API outage.
+
+---
+
+## Reference: relevant code
+
+- Import + filter + normalization: `app/canadian_station_sync.py`
+  (`normalize_station`, `fetch_canadian_stations_from_api`, `construct_place_name`)
+- Search + display formatting: `app/database.py`
+  (`search_stations_by_country`, `get_popular_stations_by_country`, `format_display_name`)
+- Frontend rendering: `app/templates/index.html` (autocomplete dropdown + popular table)
+- Tests: `app/test_canadian_station_sync.py`, `app/test_station_search.py`

--- a/docs/canadian-station-search-followups.md
+++ b/docs/canadian-station-search-followups.md
@@ -39,6 +39,14 @@ container startup. Options to keep startup fast:
 - Cache provinceCode in the DB and only refetch for new/unknown stations.
 - Run it as a periodic maintenance script rather than at every startup.
 
+**Related:** The `province` **column** is also left empty (`''`) for stations whose
+province was inferred from longitude rather than parsed from the name — the inferred
+value only lands inside `place_name` (e.g. `"ḵalpilin, BC"`), not the column. So
+`get_station_info()` returns `''` for province on those rows. `format_display_name()`
+compensates by splitting the suffix out of `place_name`, but a proper fix would
+populate the column from the authoritative `provinceCode` above and keep the two
+in sync.
+
 **Effort:** Medium. **Impact:** Cosmetic (wrong province label), but visible.
 
 ---
@@ -95,6 +103,57 @@ stations including an `alternative_name` column) so the degraded mode closely ma
 normal operation. Could be a small maintenance script under `scripts/`.
 
 **Effort:** Small. **Impact:** Only matters during a CHS API outage.
+
+---
+
+## 5. Monitor for empty calendars from newly-surfaced stations
+
+**Problem:** Relaxing the import filter to "any station with `wlp-hilo`" added ~1,005
+stations. 07837 was verified to have current/forward predictions, but not all of the
+newly-included stations were — a truly-defunct one (only historical data) would now be
+selectable by name and produce an empty calendar. This is handled gracefully (the
+empty-PDF path returns the error template), and was an accepted trade-off, but it
+should be watched.
+
+**Proposed action (operational, no code):** After the prod deploy, watch
+`/admin/analytics` for an uptick in `error_detail = pdf_empty` / `pdf_missing`. That is
+the exact signal that a dead station is now reachable via name search. If a specific
+station recurs, either exclude it or fall back to checking prediction availability for
+the requested month at import/selection time.
+
+**Effort:** Tiny (watch existing analytics). **Impact:** Catches dead stations early.
+
+---
+
+## 6. Harden `format_display_name()` province split
+
+**Problem:** When no explicit province is passed, `format_display_name()` in
+`app/database.py` splits the trailing `", …"` off `place_name` via `rpartition(', ')`
+and treats the tail as the province. This is correct today only because
+`construct_place_name()` always appends `", PROV"` for aliased (Canadian) stations and
+USA stations have no alias (so they return early). If that invariant ever changes, an
+official name containing a comma but no province suffix would be mis-split.
+
+**Proposed fix:** Constrain the fallback to a province/state-code shape (e.g. a short
+alpha token, or membership in `PROVINCE_CODES`) before treating it as a suffix, or
+make `place_name` carry a structured province consistently (see #1).
+
+**Effort:** Small. **Impact:** Defensive; no known trigger today.
+
+---
+
+## 7. Consolidate duplicate `import_canadian_stations_from_csv()`
+
+**Problem:** There are two functions with this name — one in
+`app/canadian_station_sync.py` (the active CSV fallback, updated to write
+`alternative_name`) and one in `app/database.py` (not in the startup path, **not**
+updated, so it would insert without `alternative_name`). The dormant duplicate is a
+trap for future maintainers.
+
+**Proposed fix:** Remove the unused `database.py` copy, or unify on one implementation
+and have it write `alternative_name`.
+
+**Effort:** Small. **Impact:** Code-clarity / avoids a latent inconsistency.
 
 ---
 


### PR DESCRIPTION
## Problem

Typing a Canadian station's common name in the autocomplete returned nothing — e.g. searching **"pender"** for Pender Harbour (station `07837`) found no match, forcing visitors to know the raw station ID.

Two compounding root causes (verified against the live CHS API and production):

1. **The import filter was too aggressive.** `canadian_station_sync.py` only kept stations that were `operating: true` **and** `type: "PERMANENT"`. Station 07837 is `operating: false` + `TEMPORARY` — yet it publishes full forward tide predictions (116 events for June 2026). This filter hid **1,005 of 1,076** calendar-capable Canadian stations. Stations missing from the DB are invisible to autocomplete; entering the ID manually still worked only because that path calls the CHS API directly.
2. **The common name was discarded.** CHS stores the Indigenous name as `officialName` ("ḵalpilin") and the familiar name in `alternativeName` ("Pender Harbour"). The importer kept only `officialName`, so even imported stations weren't findable by their common name. This also affected 22 stations already in the DB (e.g. "Daajing Giids" hid "Queen Charlotte City").

## Changes

- **`canadian_station_sync.py`**: extracted a testable `normalize_station()`; inclusion now requires only `wlp-hilo` predictions (dropped the `operating`/`type` filters **and** the `dateStart` query param, which itself excluded stations that still have current predictions); captures `alternativeName`.
- **`database.py`**: new `alternative_name` column (auto-migrated on startup); search matches **both** official and common names; `format_display_name()` renders `Common (Official), PROV`.
- **`templates/index.html`**: autocomplete dropdown + popular table render `display_name`.
- **Tests**: `test_canadian_station_sync.py` (filter/alias capture), `test_station_search.py` (alias search + display formatting).
- **Docs**: corrected the import-filter description in `CLAUDE.md`; added `docs/canadian-station-search-followups.md` for the next round of polish.

**Result:** Canadian stations **71 → 1,076**. Display: `Pender Harbour (ḵalpilin), BC`.

## Verification

- ✅ 46 unit tests pass (incl. 28 pre-existing adapter tests — no regressions)
- ✅ Live CHS import into a temp DB: 1,076 stations, 07837 present
- ✅ HTTP `/api/search_stations?q=pender` → `07837`
- ✅ Browser UI: dropdown renders 🇨🇦 Pender Harbour (ḵalpilin), BC `07837`
- ✅ Deployed to **dev.tidecalendar.xyz** and confirmed live (`/api/search_stations?q=pender`)

## Deployment notes

No manual migration: on container start, `init_database()` adds the `alternative_name` column to the existing `/data` DB, then the Canadian import re-runs and upserts all 1,076 with names populated. USA/NOAA stations are unaffected (no alias → display falls back to `place_name`; CSV import is threshold-guarded).

## Follow-ups (deferred, see docs/canadian-station-search-followups.md)

- Province inference is coarse (e.g. "Holman (Ulukhaktok), MB" — should be NT)
- Diacritic-insensitive search (plain "kalpilin" won't match "ḵalpilin")
- A few messy CHS `alternativeName` values render awkwardly
- Stale CSV fallback (no `alternative_name` column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
