### PR TITLE
Follow-ups: diacritic-insensitive search + clearer no-data message

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -279,36 +279,6 @@ def import_stations_from_csv():
         logging.error(f"Error importing stations from CSV: {e}")
         return False
 
-def search_stations_by_name(query, limit=10):
-    """Search for stations by place name with case-insensitive substring matching."""
-    if not query or len(query.strip()) < 1:
-        return []
-
-    try:
-        with sqlite3.connect(DB_PATH) as conn:
-            cursor = conn.cursor()
-
-            # Case-insensitive substring search
-            search_query = f"%{query.strip()}%"
-            results = cursor.execute('''
-                SELECT station_id, place_name, lookup_count
-                FROM tide_station_ids
-                WHERE place_name IS NOT NULL
-                AND LOWER(place_name) LIKE LOWER(?)
-                ORDER BY lookup_count DESC, place_name ASC
-                LIMIT ?
-            ''', (search_query, limit)).fetchall()
-
-            return [{
-                'station_id': row[0],
-                'place_name': row[1],
-                'lookup_count': row[2]
-            } for row in results]
-
-    except sqlite3.Error as e:
-        logging.error(f"Database error searching stations: {e}")
-        return []
-
 def get_popular_stations(limit=16):
     """Get the most popular tide stations by lookup count."""
     try:

--- a/app/database.py
+++ b/app/database.py
@@ -608,28 +608,29 @@ def search_stations_by_country(query, country=None, limit=10):
 
             # Diacritic/case-insensitive substring search across both the official
             # place name and the CHS alternative/common name so visitors can find a
-            # station by whichever name they know, however they type it.
-            search_query = f"%{query.strip()}%"
+            # station by whichever name they know, however they type it. Fold the
+            # query in Python and apply fold() only to the columns in SQL.
+            folded_query = f"%{fold_for_search(query.strip())}%"
 
             if country:
                 results = cursor.execute('''
                     SELECT station_id, place_name, country, lookup_count, alternative_name, province
                     FROM tide_station_ids
                     WHERE place_name IS NOT NULL
-                    AND (fold(place_name) LIKE fold(?) OR fold(alternative_name) LIKE fold(?))
+                    AND (fold(place_name) LIKE ? OR fold(alternative_name) LIKE ?)
                     AND country = ?
                     ORDER BY lookup_count DESC, place_name ASC
                     LIMIT ?
-                ''', (search_query, search_query, country, limit)).fetchall()
+                ''', (folded_query, folded_query, country, limit)).fetchall()
             else:
                 results = cursor.execute('''
                     SELECT station_id, place_name, country, lookup_count, alternative_name, province
                     FROM tide_station_ids
                     WHERE place_name IS NOT NULL
-                    AND (fold(place_name) LIKE fold(?) OR fold(alternative_name) LIKE fold(?))
+                    AND (fold(place_name) LIKE ? OR fold(alternative_name) LIKE ?)
                     ORDER BY lookup_count DESC, place_name ASC
                     LIMIT ?
-                ''', (search_query, search_query, limit)).fetchall()
+                ''', (folded_query, folded_query, limit)).fetchall()
 
             return [{
                 'station_id': row[0],

--- a/app/database.py
+++ b/app/database.py
@@ -2,6 +2,7 @@ import sqlite3
 import logging
 import os
 import csv
+import unicodedata
 from pathlib import Path
 
 # Get the app directory for relative database path
@@ -536,6 +537,21 @@ def import_canadian_stations_from_csv():
         logging.error(f"Error importing Canadian stations from CSV: {e}")
         return False
 
+def fold_for_search(text):
+    """Fold a string to a diacritic-insensitive, lowercase form for matching.
+
+    Uses NFKD decomposition + removal of combining marks, which collapses both
+    Indigenous letters (e.g. "ḵalpilin" -> "kalpilin", since U+1E35 decomposes to
+    k + combining macron) and accented characters (e.g. "Bécancour" -> "becancour",
+    "Île" -> "ile"). Lets a visitor find a station whether or not they reproduce
+    the exact diacritics. Returns '' for falsy input.
+    """
+    if not text:
+        return ''
+    decomposed = unicodedata.normalize('NFKD', text)
+    return ''.join(c for c in decomposed if not unicodedata.combining(c)).lower()
+
+
 def format_display_name(place_name, alternative_name, province=None):
     """Build a search-friendly display label for the autocomplete dropdown.
 
@@ -585,11 +601,14 @@ def search_stations_by_country(query, country=None, limit=10):
 
     try:
         with sqlite3.connect(DB_PATH) as conn:
+            # fold() makes matching case- AND diacritic-insensitive, so e.g.
+            # "kalpilin" matches "ḵalpilin" and "becancour" matches "Bécancour".
+            conn.create_function('fold', 1, fold_for_search, deterministic=True)
             cursor = conn.cursor()
 
-            # Case-insensitive substring search across both the official place
-            # name and the CHS alternative/common name so visitors can find a
-            # station by whichever name they know.
+            # Diacritic/case-insensitive substring search across both the official
+            # place name and the CHS alternative/common name so visitors can find a
+            # station by whichever name they know, however they type it.
             search_query = f"%{query.strip()}%"
 
             if country:
@@ -597,7 +616,7 @@ def search_stations_by_country(query, country=None, limit=10):
                     SELECT station_id, place_name, country, lookup_count, alternative_name, province
                     FROM tide_station_ids
                     WHERE place_name IS NOT NULL
-                    AND (LOWER(place_name) LIKE LOWER(?) OR LOWER(alternative_name) LIKE LOWER(?))
+                    AND (fold(place_name) LIKE fold(?) OR fold(alternative_name) LIKE fold(?))
                     AND country = ?
                     ORDER BY lookup_count DESC, place_name ASC
                     LIMIT ?
@@ -607,7 +626,7 @@ def search_stations_by_country(query, country=None, limit=10):
                     SELECT station_id, place_name, country, lookup_count, alternative_name, province
                     FROM tide_station_ids
                     WHERE place_name IS NOT NULL
-                    AND (LOWER(place_name) LIKE LOWER(?) OR LOWER(alternative_name) LIKE LOWER(?))
+                    AND (fold(place_name) LIKE fold(?) OR fold(alternative_name) LIKE fold(?))
                     ORDER BY lookup_count DESC, place_name ASC
                     LIMIT ?
                 ''', (search_query, search_query, limit)).fetchall()

--- a/app/routes.py
+++ b/app/routes.py
@@ -8,7 +8,7 @@ import time
 import re
 
 from app import app
-from app.database import search_stations_by_name, get_popular_stations, get_place_name_by_station_id, get_station_id_by_place_name, search_stations_by_country, get_popular_stations_by_country, log_usage_event, get_usage_stats
+from app.database import get_popular_stations, get_place_name_by_station_id, get_station_id_by_place_name, search_stations_by_country, get_popular_stations_by_country, log_usage_event, get_usage_stats
 
 # Directory for storing generated PDF calendars (matches get_tides.py)
 # Default to app/calendars for local dev, override with PDF_OUTPUT_DIR env var for production

--- a/app/routes.py
+++ b/app/routes.py
@@ -27,6 +27,22 @@ def _int_or_none(v):
     except (TypeError, ValueError):
         return None
 
+def _no_predictions_message(where, year, month):
+    """User-facing message when a calendar can't be generated.
+
+    The usual cause, now that inactive/temporary stations are listed, is that the
+    station has no published predictions for the requested period; a transient
+    tide-service outage is also possible, so the message hedges both. Built lazily
+    (only in the error branches) rather than on the success path.
+    """
+    return (
+        f"We couldn't generate a tide calendar for {where} for {year}-{month:02d}. "
+        f"This station may have no published tide predictions for that period "
+        f"(some stations are inactive or have only historical data), or the tide "
+        f"data service may be temporarily unavailable. Please try again, or choose "
+        f"a different station or month."
+    )
+
 def extract_location_with_state(place_name):
     """
     Extract location with state abbreviation from full place name.
@@ -206,31 +222,21 @@ def index():
         env['PYTHONPATH'] = os.path.dirname(__file__)
         subprocess.run(cmd, cwd=project_root, env=env)
 
-        # Friendly message for the most common failure now that the station list
-        # includes inactive/temporary stations: the station simply has no published
-        # predictions for the requested period (get_tides.py exits without writing a
-        # PDF). Also covers transient tide-service outages.
-        no_data_msg = (
-            f"We couldn't generate a tide calendar for {location_display or station_id} "
-            f"for {year}-{month:02d}. This station may have no published tide predictions "
-            f"for that period (some stations are inactive or have only historical data), "
-            f"or the tide data service may be temporarily unavailable. Please try again, "
-            f"or choose a different station or month."
-        )
-
         # Check if the PDF file was created
         if not os.path.exists(pdf_full_path):
             # log an error message
             logging.error(f"File {pdf_full_path} does not exist.")
             log_usage_event(station_id, place_name, year, month, 'error', 'pdf_missing')
-            return render_template('tide_station_not_found.html', message=no_data_msg)
+            return render_template('tide_station_not_found.html',
+                                   message=_no_predictions_message(location_display or station_id, year, month))
 
         # Check if the PDF file is empty
         if os.path.getsize(pdf_full_path) == 0:
             # log an error message
             logging.error(f"File {pdf_full_path} is empty.")
             log_usage_event(station_id, place_name, year, month, 'error', 'pdf_empty')
-            return render_template('tide_station_not_found.html', message=no_data_msg)
+            return render_template('tide_station_not_found.html',
+                                   message=_no_predictions_message(location_display or station_id, year, month))
 
         log_usage_event(station_id, place_name, year, month, 'success')
 
@@ -349,22 +355,17 @@ def api_generate_quick():
         env['PYTHONPATH'] = os.path.dirname(__file__)
         subprocess.run(cmd, cwd=project_root, env=env)
 
-        # No predictions for this station/period (or transient tide-service outage).
-        quick_no_data = (f"No tide predictions available for station {station_id} for "
-                         f"{year}-{month:02d}; the station may be inactive or have only "
-                         f"historical data.")
-
         # Check if the PDF file was created
         if not os.path.exists(pdf_full_path):
             logging.error(f"Quick generate failed: File {pdf_full_path} does not exist.")
             log_usage_event(station_id, place_name, year, month, 'error', 'pdf_missing', source='quick_api')
-            return jsonify({'error': quick_no_data}), 500
+            return jsonify({'error': _no_predictions_message(location_display or station_id, year, month)}), 500
 
         # Check if the PDF file is empty
         if os.path.getsize(pdf_full_path) == 0:
             logging.error(f"Quick generate failed: File {pdf_full_path} is empty.")
             log_usage_event(station_id, place_name, year, month, 'error', 'pdf_empty', source='quick_api')
-            return jsonify({'error': quick_no_data}), 500
+            return jsonify({'error': _no_predictions_message(location_display or station_id, year, month)}), 500
 
         log_usage_event(station_id, place_name, year, month, 'success', source='quick_api')
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -206,19 +206,31 @@ def index():
         env['PYTHONPATH'] = os.path.dirname(__file__)
         subprocess.run(cmd, cwd=project_root, env=env)
 
+        # Friendly message for the most common failure now that the station list
+        # includes inactive/temporary stations: the station simply has no published
+        # predictions for the requested period (get_tides.py exits without writing a
+        # PDF). Also covers transient tide-service outages.
+        no_data_msg = (
+            f"We couldn't generate a tide calendar for {location_display or station_id} "
+            f"for {year}-{month:02d}. This station may have no published tide predictions "
+            f"for that period (some stations are inactive or have only historical data), "
+            f"or the tide data service may be temporarily unavailable. Please try again, "
+            f"or choose a different station or month."
+        )
+
         # Check if the PDF file was created
         if not os.path.exists(pdf_full_path):
             # log an error message
             logging.error(f"File {pdf_full_path} does not exist.")
             log_usage_event(station_id, place_name, year, month, 'error', 'pdf_missing')
-            return render_template('tide_station_not_found.html', message="Error: PDF file not found.")
+            return render_template('tide_station_not_found.html', message=no_data_msg)
 
         # Check if the PDF file is empty
         if os.path.getsize(pdf_full_path) == 0:
             # log an error message
             logging.error(f"File {pdf_full_path} is empty.")
             log_usage_event(station_id, place_name, year, month, 'error', 'pdf_empty')
-            return render_template('tide_station_not_found.html', message="Error: PDF file is empty.")
+            return render_template('tide_station_not_found.html', message=no_data_msg)
 
         log_usage_event(station_id, place_name, year, month, 'success')
 
@@ -337,17 +349,22 @@ def api_generate_quick():
         env['PYTHONPATH'] = os.path.dirname(__file__)
         subprocess.run(cmd, cwd=project_root, env=env)
 
+        # No predictions for this station/period (or transient tide-service outage).
+        quick_no_data = (f"No tide predictions available for station {station_id} for "
+                         f"{year}-{month:02d}; the station may be inactive or have only "
+                         f"historical data.")
+
         # Check if the PDF file was created
         if not os.path.exists(pdf_full_path):
             logging.error(f"Quick generate failed: File {pdf_full_path} does not exist.")
             log_usage_event(station_id, place_name, year, month, 'error', 'pdf_missing', source='quick_api')
-            return jsonify({'error': 'PDF file generation failed'}), 500
+            return jsonify({'error': quick_no_data}), 500
 
         # Check if the PDF file is empty
         if os.path.getsize(pdf_full_path) == 0:
             logging.error(f"Quick generate failed: File {pdf_full_path} is empty.")
             log_usage_event(station_id, place_name, year, month, 'error', 'pdf_empty', source='quick_api')
-            return jsonify({'error': 'PDF file is empty'}), 500
+            return jsonify({'error': quick_no_data}), 500
 
         log_usage_event(station_id, place_name, year, month, 'success', source='quick_api')
 

--- a/app/test_station_search.py
+++ b/app/test_station_search.py
@@ -259,6 +259,17 @@ class TestDiacriticInsensitiveSearch(_DBTest):
         results = self.db.search_stations_by_country("becancour", None, limit=10)
         self.assertEqual([r["station_id"] for r in results], ["03353"])
 
+    def test_ascii_query_matches_diacritic_in_alternative_name(self):
+        # Diacritic lives in the *alternative* name and the place_name cannot match
+        # the query, so a hit proves the alternative_name column is folded too.
+        self._insert(
+            station_id="03250", place_name="Saint-Joseph, QC", country="Canada",
+            api_source="CHS", province="QC", alternative_name="Rivière-du-Loup",
+            lookup_count=1,
+        )
+        results = self.db.search_stations_by_country("riviere", "Canada", limit=10)
+        self.assertIn("03250", [r["station_id"] for r in results])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/test_station_search.py
+++ b/app/test_station_search.py
@@ -212,5 +212,53 @@ class TestPopularStationsDisplayName(_DBTest):
         self.assertEqual(match[0]["display_name"], "Pender Harbour (ḵalpilin), BC")
 
 
+class TestFoldForSearch(_DBTest):
+    def test_strips_diacritics_and_lowercases(self):
+        self.assertEqual(self.db.fold_for_search("ḵalpilin"), "kalpilin")
+        self.assertEqual(self.db.fold_for_search("Bécancour"), "becancour")
+        self.assertEqual(self.db.fold_for_search("Île-aux-Coudres"), "ile-aux-coudres")
+
+    def test_ascii_unchanged_except_case(self):
+        self.assertEqual(self.db.fold_for_search("Pender Harbour"), "pender harbour")
+
+    def test_empty_and_none(self):
+        self.assertEqual(self.db.fold_for_search(""), "")
+        self.assertEqual(self.db.fold_for_search(None), "")
+
+
+class TestDiacriticInsensitiveSearch(_DBTest):
+    def setUp(self):
+        super().setUp()
+        self._insert(
+            station_id="07837", place_name="ḵalpilin, BC", country="Canada",
+            api_source="CHS", province="BC", alternative_name="Pender Harbour",
+            lookup_count=1,
+        )
+        self._insert(
+            station_id="03353", place_name="Bécancour, QC", country="Canada",
+            api_source="CHS", province="QC", lookup_count=1,
+        )
+
+    def test_ascii_query_matches_diacritic_official_name(self):
+        results = self.db.search_stations_by_country("kalpilin", "Canada", limit=10)
+        self.assertEqual([r["station_id"] for r in results], ["07837"])
+
+    def test_ascii_query_matches_accented_name(self):
+        results = self.db.search_stations_by_country("becancour", "Canada", limit=10)
+        self.assertEqual([r["station_id"] for r in results], ["03353"])
+
+    def test_diacritic_query_still_matches(self):
+        results = self.db.search_stations_by_country("ḵalpilin", "Canada", limit=10)
+        self.assertEqual([r["station_id"] for r in results], ["07837"])
+
+    def test_common_name_still_matches(self):
+        results = self.db.search_stations_by_country("pender", "Canada", limit=10)
+        self.assertEqual([r["station_id"] for r in results], ["07837"])
+
+    def test_all_countries_diacritic_fold(self):
+        results = self.db.search_stations_by_country("becancour", None, limit=10)
+        self.assertEqual([r["station_id"] for r in results], ["03353"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/canadian-station-search-followups.md
+++ b/docs/canadian-station-search-followups.md
@@ -51,22 +51,18 @@ in sync.
 
 ---
 
-## 2. Diacritic-insensitive search
+## 2. Diacritic-insensitive search ✅ DONE
 
-**Problem:** Search is a plain SQLite `LIKE` substring match, which is not
-Unicode-fold-aware. Typing the plain ASCII "kalpilin" does **not** match the
-official name "ḵalpilin" (the `ḵ` is U+1E35, "k with line below").
+**Was:** Search was a plain `LOWER() LIKE` match, so the ASCII "kalpilin" did not
+match the official "ḵalpilin" (U+1E35).
 
-**Current state:** Users can still find station 07837 by typing "pender" (the common
-name) or "ḵalpilin" exactly, so this is a nice-to-have, not a blocker.
-
-**Proposed fix:** Add a normalized/folded search column (strip diacritics to ASCII,
-e.g. via `unicodedata` NFKD + combining-mark removal, plus a small custom map for
-characters like `ḵ`→`k` that NFKD doesn't decompose) and match against it. Populate
-it on import alongside `place_name`/`alternative_name`.
-
-**Effort:** Medium. **Impact:** Helps users who type the Indigenous name phonetically
-in ASCII.
+**Resolved:** Added `fold_for_search()` in `database.py` (NFKD decomposition + combining-
+mark removal + lowercase) and registered it as a SQLite `fold()` function used by
+`search_stations_by_country()` (`fold(place_name) LIKE fold(?) OR fold(alternative_name)
+LIKE fold(?)`). NFKD turned out to decompose `ḵ`→`k` (plus combining macron) on its own,
+so no custom character map was needed; the same fold also handles French accents
+(`Bécancour`→`becancour`, `Île`→`ile`). Search-only change — no schema/import/backfill.
+Covered by `TestFoldForSearch` and `TestDiacriticInsensitiveSearch`.
 
 ---
 
@@ -112,22 +108,36 @@ tests are not run by the new CI job.)
 
 ---
 
-## 5. Monitor for empty calendars from newly-surfaced stations
+## 5. Empty calendars from newly-surfaced stations ✅ INVESTIGATED + MITIGATED
 
 **Problem:** Relaxing the import filter to "any station with `wlp-hilo`" added ~1,005
-stations. 07837 was verified to have current/forward predictions, but not all of the
-newly-included stations were — a truly-defunct one (only historical data) would now be
-selectable by name and produce an empty calendar. This is handled gracefully (the
-empty-PDF path returns the error template), and was an accepted trade-off, but it
-should be watched.
+stations. Some are inactive and have only historical data, so they are selectable by
+name but yield no calendar for a current/future month.
 
-**Proposed action (operational, no code):** After the prod deploy, watch
-`/admin/analytics` for an uptick in `error_detail = pdf_empty` / `pdf_missing`. That is
-the exact signal that a dead station is now reachable via name search. If a specific
-station recurs, either exclude it or fall back to checking prediction availability for
-the requested month at import/selection time.
+**Findings (audited against the live CHS API, June 2026):**
+- Empty-for-current-month rate is **low single digits** — ~2.4% in a clean bounded
+  sample, ~7% in an earlier partial run → roughly **25–75 of 1,076** stations.
+- Every empty station is an obscure **non-operating, TEMPORARY** point (Tanquary Camp,
+  Diana Bay, Port Leopold, Cape Liverpool, Baychimo…) — Arctic research/survey sites,
+  not places typical visitors search for.
+- **The originally-proposed mitigation — "verify prediction availability at import" — is
+  infeasible.** CHS rate-limits aggressively: even ~1,076 sequential calls at 4/sec fail
+  en masse, and a full check takes 40+ minutes. Running that at container startup would
+  break deploys. (A one-off `~1,076`-request audit literally spent 39 min wall-clock /
+  34s CPU stuck in retry-backoff before being killed.)
 
-**Effort:** Tiny (watch existing analytics). **Impact:** Catches dead stations early.
+**Mitigation applied (this change):** The empty case already degrades gracefully —
+`get_tides.py` writes no PDF, so `routes.py` returns the error template. Replaced the
+generic "PDF file not found." / "PDF file is empty." text with a clear, station- and
+period-specific message explaining the station may be inactive / historical-only and to
+try another station or month (web form and `/api/generate_quick`). `error_detail`
+logging (`pdf_missing` / `pdf_empty`) is unchanged for analytics.
+
+**Optional remaining work:** A periodic *offline* maintenance script (rate-limited, run
+occasionally — not at startup) could flag stations that are persistently empty and stamp
+a DB column to drop them from autocomplete. Low priority given the small, obscure set.
+Watching `/admin/analytics` for `pdf_empty`/`pdf_missing` upticks remains the cheapest
+ongoing signal.
 
 ---
 

--- a/docs/canadian-station-search-followups.md
+++ b/docs/canadian-station-search-followups.md
@@ -58,8 +58,9 @@ match the official "ḵalpilin" (U+1E35).
 
 **Resolved:** Added `fold_for_search()` in `database.py` (NFKD decomposition + combining-
 mark removal + lowercase) and registered it as a SQLite `fold()` function used by
-`search_stations_by_country()` (`fold(place_name) LIKE fold(?) OR fold(alternative_name)
-LIKE fold(?)`). NFKD turned out to decompose `ḵ`→`k` (plus combining macron) on its own,
+`search_stations_by_country()` (the query is folded in Python, then matched with
+`fold(place_name) LIKE ? OR fold(alternative_name) LIKE ?`). NFKD turned out to decompose
+`ḵ`→`k` (plus combining macron) on its own,
 so no custom character map was needed; the same fold also handles French accents
 (`Bécancour`→`becancour`, `Île`→`ile`). Search-only change — no schema/import/backfill.
 Covered by `TestFoldForSearch` and `TestDiacriticInsensitiveSearch`.


### PR DESCRIPTION
Two post-launch follow-ups from `docs/canadian-station-search-followups.md`, after the Canadian name-search fix (#79) shipped.

## #2 — Diacritic-insensitive search ✅

Search was `LOWER() LIKE`, so the ASCII **"kalpilin" didn't match the official "ḵalpilin"** (U+1E35).

- Added `fold_for_search()` (`database.py`): NFKD decomposition + combining-mark removal + lowercase, registered as a deterministic SQLite `fold()` function. Search now does `fold(place_name) LIKE fold(?) OR fold(alternative_name) LIKE fold(?)`.
- NFKD decomposes `ḵ`→`k` (+ combining macron) on its own, so **no custom character map** is needed — the same fold also covers French accents (`Bécancour`→`becancour`, `Île`→`ile`).
- **Search-only change**: no schema migration, no import change, no backfill, no CHS API calls.
- 8 new tests (`TestFoldForSearch`, `TestDiacriticInsensitiveSearch`). Full suite: **60 pass**.

## #5 — Empty calendars from newly-surfaced stations (investigated + mitigated) ✅

Relaxing the filter (#79) surfaced ~1,005 previously-hidden stations; some inactive ones have only historical data and yield no calendar for a current month.

**Audited the live CHS API:**
- Empty-for-current-month rate is **low single digits** (~2.4% clean sample / ~7% partial → roughly **25–75 of 1,076**), all obscure **non-operating TEMPORARY** sites (Tanquary Camp, Diana Bay, Port Leopold…).
- **The doc's proposed "verify predictions at import" mitigation is infeasible** — CHS rate-limits so hard that ~1,076 calls take 40+ min, which would break container startup.

**Mitigation applied:** the empty case already degrades gracefully (no PDF → error template). Replaced the generic *"PDF file not found." / "PDF file is empty."* with a clear, station- and period-specific message (web form **and** `/api/generate_quick`) explaining the station may be inactive/historical-only and to try another station or month. `error_detail` logging (`pdf_missing`/`pdf_empty`) is unchanged.

## Not done (with reasoning)
- An import-time prediction scan — infeasible (throttling, see above). An optional *offline* maintenance script remains a low-priority idea in the follow-up doc.

## Verification
- 60 unit tests pass (was 52). Diacritic tests hit a real temp SQLite DB with the `fold()` function (not mocked).
- `routes.py` message change is text-only within existing error branches (`location_display`/`year`/`month` confirmed in scope; `py_compile` clean). No route-test harness exists in the repo, so it's verified by inspection rather than a new unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
