### PR TITLE
Automate monthly example-image regeneration (1st of month, UTC)

### DIFF
--- a/.github/workflows/update-example-image.yml
+++ b/.github/workflows/update-example-image.yml
@@ -1,0 +1,102 @@
+name: Update Example Calendar Image
+
+# Regenerates app/static/tide-calendar-example.webp for the CURRENT month and
+# ships it to production, then keeps development in sync.
+#
+# Scheduled workflows only run from the default branch (main), so this file must
+# live on main to fire on its cron.
+
+on:
+  schedule:
+    # 00:00 UTC (GMT) on the 1st of every month.
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Generate + validate only; do NOT commit or push'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+# Never let two runs push concurrently.
+concurrency:
+  group: update-example-image
+  cancel-in-progress: false
+
+jobs:
+  update-image:
+    name: Regenerate example image (current month, UTC)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0  # full history so we can back-merge into development
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # Match the Dockerfile base image (python:3.12-slim-bookworm).
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Install PDF/image toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends pcal ghostscript imagemagick
+          # update_example_image.sh calls `magick` (ImageMagick 7); Ubuntu ships
+          # ImageMagick 6, whose binary is `convert`. Shim it so the script's
+          # dependency check and command work unchanged (same arg syntax).
+          command -v magick >/dev/null 2>&1 || sudo ln -s "$(command -v convert)" /usr/local/bin/magick
+          # Ubuntu's ImageMagick disables PDF reading by default (a Ghostscript
+          # CVE policy), which would break PDF -> WebP. Re-enable it.
+          sudo sed -i 's/rights="none" pattern="PDF"/rights="read|write" pattern="PDF"/' /etc/ImageMagick-*/policy.xml || true
+
+      - name: Regenerate example image for the current month
+        run: ./scripts/update_example_image.sh
+
+      - name: Validate the generated image
+        run: |
+          set -euo pipefail
+          IMG=app/static/tide-calendar-example.webp
+          test -s "$IMG" || { echo "::error::Image missing or empty"; exit 1; }
+          BYTES=$(wc -c < "$IMG")
+          echo "Generated $IMG ($BYTES bytes)"
+          [ "$BYTES" -ge 10000 ] || { echo "::error::Image suspiciously small ($BYTES bytes)"; exit 1; }
+          identify "$IMG" | grep -qi 'WEBP' || { echo "::error::Not a valid WebP"; exit 1; }
+
+      - name: Commit to main (prod) and back-merge into development
+        # Scheduled runs always publish. Manual runs publish only when explicitly
+        # opted in (dry_run=false), so a test dispatch never touches production.
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- app/static/tide-calendar-example.webp; then
+            echo "No change to the example image; nothing to publish."
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          MONTH=$(date -u +'%B %Y')
+
+          # 1) Publish to main -> triggers the production (tidecalendar.xyz) deploy.
+          git add app/static/tide-calendar-example.webp
+          git commit -m "chore: auto-update example calendar image for ${MONTH}"
+          git push origin main
+
+          # 2) Back-merge main into development so it never falls behind main and
+          #    new work always starts from an up-to-date development. The merge is
+          #    clean because development never modifies the webp itself.
+          git fetch origin development
+          git checkout -B development origin/development
+          git merge --no-edit main
+          git push origin development


### PR DESCRIPTION
## Summary
Adds `.github/workflows/update-example-image.yml` — a scheduled GitHub Action that keeps the homepage example calendar current automatically.

**Schedule:** `cron: 0 0 1 * *` → 00:00 UTC (GMT) on the 1st of each month. Also `workflow_dispatch` for manual runs (defaults to **dry-run**, so a manual test never touches production).

## What it does each run
1. Installs the toolchain on the runner (pcal, ghostscript, imagemagick) — incl. a `magick`→`convert` shim and a PDF-policy fix for Ubuntu's ImageMagick.
2. Runs `scripts/update_example_image.sh` → regenerates `app/static/tide-calendar-example.webp` for the **current** month.
3. Validates the output (non-empty, ≥10KB, valid WebP).
4. **Commits to `main`** → triggers the production deploy.
5. **Back-merges `main` → `development`** and pushes → keeps `development` in sync (and updates dev.tidecalendar.xyz), so new work always starts from an up-to-date `development`.

## Activation note
Scheduled workflows only fire from the **default branch (`main`)**, so this must be promoted to `main` to start running. Once there, I'll trigger a `dry_run` dispatch to confirm the runner toolchain works before the first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)