### PR TITLE
Release: sunrise/sunset + local times on the PDF

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,12 @@ See `docs/performance-benchmarks.md` for detailed performance targets, API laten
 
 ### Important Notes
 - **Branching workflow**: Work on `development` branch first, PR into `main`. Dev deploys to https://dev.tidecalendar.xyz, main deploys to https://tidecalendar.xyz
+- **dev→main merge-commit drift**: after a `development → main` PR merge, `development` lags `main` by the merge commit (file trees identical). Resync with `git checkout development && git merge --ff-only origin/main && git push` so new work starts current.
+- **`app/` must NOT import from `scripts/`**: `.dockerignore` excludes `scripts/` from the image, so any runtime `import scripts.*` from `app/` raises ModuleNotFoundError in the container. Cold-DB dev hides it; warm-DB prod surfaces it. Inline shared logic into the shipped `app/` module (e.g. `station_coordinates.py` has its own `fetch_noaa_coordinates`).
+- **Dual-import idiom**: modules imported by the unittest suite use `try: from app.X import … except ImportError: from X import …` (tests run `cd app && python -m unittest` → siblings top-level; gunicorn runs the `app` package). `routes.py` is NOT unittest-importable (`from app import app`) and no test imports it — test pure helpers by putting them in `database.py`, not in routes.
+- **Tests reassign `database.DB_PATH`** at runtime, so reference `database.DB_PATH` dynamically; never `from database import DB_PATH` (the binding goes stale and tests clobber the real DB).
+- **Local manual testing**: seed a temp DB fast with `database.import_stations_from_csv()` + `import_canadian_stations_from_csv()` (CSV, no API), then `DB_PATH=… FLASK_APP=app flask run` to bypass run.py's slow CHS API sync.
+- **Claude Code sandbox can't reach localhost**: curl to a local flask server returns HTTP 000 — verify via the Playwright/Chrome MCP browser (real env) or `dangerouslyDisableSandbox` for localhost-targeting Bash. Run the dev server as a harness background task (`run_in_background`), not `&`/nohup (the sandbox reaps detached processes).
 - **Local development**: Application runs on port 5001
 - **Production (CapRover)**: Application runs on port 80 (CapRover proxies from 443→80)
 - **Database location**: `/data/tide_station_ids.db` (configurable via `DB_PATH` env var)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ ANALYTICS_TOKEN=<random-string>  # gates /admin/analytics dashboard
 │   └── canadian_station_provinces.csv  # Authoritative code→province map (gen: scripts/fetch_canadian_provinces.py)
 ├── scripts/               # Development and maintenance scripts (NOT deployed)
 │   ├── validate_tide_stations.py    # Validate CSV stations against NOAA API
-│   ├── update_example_image.sh      # Monthly update of example calendar image
+│   ├── update_example_image.sh      # Example calendar image (current month); auto-run monthly by .github/workflows/update-example-image.yml
 │   ├── fetch_canadian_provinces.py  # Build authoritative code→province map from CHS /metadata
 │   ├── generate_canadian_fallback_csv.py  # Snapshot full live import to the fallback CSV
 │   └── test_canadian_import.py      # Test Canadian station imports
@@ -248,6 +248,21 @@ hard dependency on a live API. Canadian coordinates already live in
 
 **When to run**: whenever new US stations are added to the CSV (so they get map pins).
 The output CSV must stay listed in the Dockerfile `COPY` lines.
+
+#### Example Calendar Image (automated monthly)
+`scripts/update_example_image.sh` regenerates `app/static/tide-calendar-example.webp`
+with the **current** month's calendar for Point Roberts, WA (station 9449639), using
+pcal → ps2pdf → ImageMagick. You can run it manually, but it normally runs **on its own**:
+
+- **Workflow**: `.github/workflows/update-example-image.yml`, cron `0 0 1 * *`
+  (00:00 UTC on the 1st of each month). Scheduled workflows only fire from the default
+  branch, so the workflow must live on `main`.
+- Each run regenerates + validates the image, **commits to `main`** (→ production deploy),
+  then **back-merges `main` into `development`** so `development` never falls behind.
+- Manual `workflow_dispatch` runs default to **`dry_run=true`** (generate + validate only,
+  no push); set `dry_run=false` to publish.
+- Runner note: Ubuntu ships ImageMagick 6 (`convert`, not `magick`) and disables PDF
+  reading by default — the workflow shims `magick`→`convert` and relaxes the PDF policy.
 
 ### Running Tests
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ ANALYTICS_TOKEN=<random-string>  # gates /admin/analytics dashboard
 ├── scripts/               # Development and maintenance scripts (NOT deployed)
 │   ├── validate_tide_stations.py    # Validate CSV stations against NOAA API
 │   ├── update_example_image.sh      # Example calendar image (current month); auto-run monthly by .github/workflows/update-example-image.yml
+│   ├── fetch_station_timezones.py   # Bake IANA timezone column into station CSVs (from lat/long)
 │   ├── fetch_canadian_provinces.py  # Build authoritative code→province map from CHS /metadata
 │   ├── generate_canadian_fallback_csv.py  # Snapshot full live import to the fallback CSV
 │   └── test_canadian_import.py      # Test Canadian station imports
@@ -249,6 +250,19 @@ hard dependency on a live API. Canadian coordinates already live in
 **When to run**: whenever new US stations are added to the CSV (so they get map pins).
 The output CSV must stay listed in the Dockerfile `COPY` lines.
 
+#### Station Timezones (for local times + sunrise/sunset)
+`scripts/fetch_station_timezones.py` bakes an IANA `timezone` column into
+`app/tide_stations_new.csv` and `app/canadian_tide_stations.csv`, derived from each
+station's lat/long via `timezonefinder`:
+
+```bash
+pip install timezonefinder   # dev-only; heavy (numpy/h3), NOT a runtime dependency
+python scripts/fetch_station_timezones.py
+```
+
+Runtime reads the baked column into the DB `timezone` column (stdlib `zoneinfo` only).
+**When to run**: whenever stations are added. Keep both CSVs in the Dockerfile `COPY` lines.
+
 #### Example Calendar Image (automated monthly)
 `scripts/update_example_image.sh` regenerates `app/static/tide-calendar-example.webp`
 with the **current** month's calendar for Point Roberts, WA (station 9449639), using
@@ -315,5 +329,7 @@ See `docs/performance-benchmarks.md` for detailed performance targets, API laten
 - **Rate-limit testing**: limiter counters are per-gunicorn-worker (in-memory), so effective ceiling ≈ limit × 2 workers; burst tests need 25+ requests to reliably trip 429s
 - **pcal flags reference**: `-s r:g:b` sets day numeral color, `-S` suppresses mini-calendars (on by default), `-K` repositions mini-cals (prev upper-left, next lower-right), `-C text` adds centered footer, `-m` shows month name
 - **Deploy verification**: After pushing, check `/health` endpoint for matching `commit_hash` to confirm CapRover deploy landed (observed 10–60s including container startup). Compare dev vs prod: `curl -s https://dev.tidecalendar.xyz/health | python3 -m json.tool`
+- **Local times on the PDF**: tide times render in the station's local timezone. NOAA is fetched `lst_ldt` (already local); CHS is fetched in UTC and converted via `sun_times.localize_and_filter_csv()` (the CHS fetch is padded ±1 day in UTC, then events are filtered to the target local month so west-of-UTC stations don't lose late-evening tides). The IANA timezone is precomputed per station (see the Station Timezones script) into the DB `timezone` column; `backfill_timezones_from_csv()` populates the warm DB from the shipped CSVs at startup.
+- **Sunrise/sunset**: `app/sun_times.py` (`astral` + stdlib `zoneinfo`) computes per-day local sunrise/sunset, rendered as a 24h `Rise HH:MM  Set HH:MM` line at the top of each pcal day cell. Polar day/night degrades to a `Sun: 24h daylight` / `Sun: polar night` note. Missing tz → sun line omitted (logged). A 12h/24h web toggle is a planned future addition (formatting is centralized in `format_sun_line`).
 - **Station map**: The homepage embeds a Leaflet/OpenStreetMap map of all selectable stations (`app/static/js/station_map.js`). Pins are `L.circleMarker` (vector — no marker-image assets needed), clustered via Leaflet.markercluster. Clicking a pin's "Use this station" popup button fills the existing form (`#station_search` + `#station_id`) and scrolls to it; the country filter radios re-fit the map (all → North America, USA/Canada → that country's bounds, computed from the markers, not hardcoded). Leaflet + markercluster are **vendored** in `app/static/vendor/leaflet/` (no CDN, no CSP changes — there is no CSP). Data comes from `GET /api/stations.geojson` (GeoJSON FeatureCollection, memoized in-process; only stations with coordinates appear, so a pin click can never hit an unknown station). US coordinates ship in `tide_stations_new.csv` (see the NOAA Coordinate Sync script); `app/station_coordinates.py` `backfill_missing_coordinates()` runs at startup (`run.py`) and makes **one** NOAA call to fill any US stations still missing coords (the only path that reaches production's *warm* persistent-volume DB, where the CSV import short-circuits) — non-fatal, and a no-op/no-network-call when nothing is missing.
 - **Analytics**: Server-side `usage_events` table logs every request to `/` and `/api/generate_quick` (station_id, station_name, year, month, status, error_detail, source). No PII. `source='web'` for form submissions, `source='quick_api'` for embed/widget traffic. Dashboard at `/admin/analytics` — accepts `Authorization: Bearer $ANALYTICS_TOKEN` header (preferred, stays out of access logs) or `?token=$ANALYTICS_TOKEN` query param (fallback). Returns 404 on any unauth/unconfigured request (invisible to scanners). Events older than 365 days are pruned on container startup. Complements client-side Plausible (which misses cached serves, validation errors, and ad-blocked users). Tests: `python3 scripts/test_usage_events.py`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ COPY app/database.py /app/
 COPY app/tide_adapters.py /app/
 COPY app/canadian_station_sync.py /app/
 COPY app/station_coordinates.py /app/
+COPY app/sun_times.py /app/
 
 # Templates and static assets
 COPY app/templates/ /app/templates/

--- a/app/canadian_tide_stations.csv
+++ b/app/canadian_tide_stations.csv
@@ -1,1077 +1,1077 @@
-station_id,place_name,province,latitude,longitude,country,api_source,alternative_name
-00001,"Outer Wood Island, NB",NB,44.606836,-66.818208,Canada,CHS,
-00005,"Seal Cove, NB",NB,44.648709,-66.839677,Canada,CHS,
-00007,"Gannet Rock, NB",NB,44.510712,-66.781717,Canada,CHS,
-00010,"North Head, NB",NB,44.763118,-66.749,Canada,CHS,
-00015,"Welshpool, NB",NB,44.888903,-66.957557,Canada,CHS,
-00020,"Wilsons Beach, NB",NB,44.93183,-66.940664,Canada,CHS,
-00021,"East Quoddy Head, NB",NB,44.958056,-66.900556,Canada,CHS,
-00025,"Fairhaven, NB",NB,44.964381,-67.007419,Canada,CHS,
-00028,"McMaster Island, NB",NB,45.054307,-66.930853,Canada,CHS,
-00029,"Matthews Cove, NB",NB,45.052007,-66.894529,Canada,CHS,
-00030,"Letite Harbour, NB",NB,45.055804,-66.864833,Canada,CHS,"Letite, Black Bay, Back Bay"
-00033,"Letang Harbour, NB",NB,45.084553,-66.783714,Canada,CHS,
-00035,"St. Stephen, NB",NB,45.191916,-67.276017,Canada,CHS,
-00040,"St. Andrews, NB",NB,45.0822524,-67.0845247,Canada,CHS,
-00041,"Long Island, NB",NB,45.149561,-66.961084,Canada,CHS,
-00042,"Blacks Harbour, NB",NB,45.047841,-66.807898,Canada,CHS,
-00044,"Beaver Harbour, NB",NB,45.06835,-66.739534,Canada,CHS,
-00046,"West Dipper Harbour, NB",NB,45.09284,-66.418731,Canada,CHS,Dipper Harbour West
-00052,"Five Fathom Hole, NB",NB,45.186598,-66.257278,Canada,CHS,
-00053,"Musquash Harbour, NB",NB,45.148535,-66.257932,Canada,CHS,
-00055,"Lorneville, NB",NB,45.192742,-66.14824,Canada,CHS,
-00060,"Partridge Island, NB",NB,45.241166,-66.052274,Canada,CHS,
-00065,"Saint John, NB",NB,45.254596,-66.06004,Canada,CHS,
-00066,"Reversing Falls, NB",NB,45.259,-66.087,Canada,CHS,Chutes réversibles
-00085,"Kennebecasis Bay, NB",NB,45.393261,-66.000923,Canada,CHS,
-00093,"Public Landing, NB",NB,45.405682,-66.195982,Canada,CHS,
-00097,"Hatfield Point, NB",NB,45.613801,-65.912438,Canada,CHS,
-00098,"Evandale, NB",NB,45.591594,-66.028695,Canada,CHS,
-00102,"Macdonald Point, NB",NB,45.71881,-66.04758,Canada,CHS,
-00103,"Cambridge Narrows, NB",NB,45.829482,-65.95297,Canada,CHS,
-00108,"Upper Gagetown, NB",NB,45.847241,-66.234799,Canada,CHS,
-00120,"Fredericton, NB",NB,45.966423,-66.65197,Canada,CHS,
-00122,"Newcastle Creek, NB",NB,46.056492,-66.002698,Canada,CHS,
-00129,"St Martins, NB",NB,45.35517,-65.531886,Canada,CHS,
-00140,"Herring Cove, NB",NB,45.574668,-64.965629,Canada,CHS,
-00150,"Cape Enrage, NB",NB,45.593584,-64.780225,Canada,CHS,
-00160,"Grindstone Island, NB",NB,45.72187,-64.621207,Canada,CHS,
-00170,"Hopewell Cape, NB",NB,45.860104,-64.57907,Canada,CHS,
-00172,"Belliveau Village, NB",NB,45.937102,-64.619739,Canada,CHS,
-00173,"Dover, NB",NB,45.992446,-64.686416,Canada,CHS,
-00175,"Moncton, NB",NB,46.087883,-64.771888,Canada,CHS,
-00190,"Pecks Point, NB",NB,45.741838,-64.479898,Canada,CHS,
-00210,"Maccan, NB",NB,45.724667,-64.259833,Canada,CHS,
-00211,"River Hebert, NS",NS,45.690167,-64.373833,Canada,CHS,
-00215,"Joggins, NS",NS,45.660547,-64.488192,Canada,CHS,Two Rivers Cove
-00225,"Cape Capstan, NS",NS,45.474004,-64.853811,Canada,CHS,
-00235,"West Advocate, NS",NS,45.345678,-64.816617,Canada,CHS,
-00236,"Advocate, NS",NS,45.331982,-64.775448,Canada,CHS,
-00240,"Cape d'Or, NS",NS,45.290438,-64.774936,Canada,CHS,
-00242,"Spencers Island, NS",NS,45.35476,-64.710035,Canada,CHS,
-00245,"Port Greville, NS",NS,45.404321,-64.541522,Canada,CHS,
-00247,"Diligent River, NS",NS,45.390396,-64.454776,Canada,CHS,
-00250,"Cape Sharp, NS",NS,45.364449,-64.391893,Canada,CHS,
-00255,"Parrsboro, NS",NS,45.3899678,-64.3186504,Canada,CHS,
-00260,"Five Islands, NS",NS,45.379434,-64.12989,Canada,CHS,
-00265,"Truro, NS",NS,45.366667,-63.316667,Canada,CHS,
-00267,"Maitland, NS",NS,45.251167,-63.456,Canada,CHS,
-00270,"Burntcoat Head, NS",NS,45.311475,-63.805688,Canada,CHS,
-00281,"Tidal View Farm, NS",NS,45.01,-64.073,Canada,CHS,
-00282,"Hantsport, NS",NS,45.066886,-64.170122,Canada,CHS,
-00290,"Cape Blomidon, NS",NS,45.30484,-64.349067,Canada,CHS,
-00300,"Scots Bay, NS",NS,45.315444,-64.440747,Canada,CHS,
-00305,"Baxters Harbour, NS",NS,45.230788,-64.514883,Canada,CHS,
-00312,"Ile Haute, NS",NS,45.253894,-64.990928,Canada,CHS,
-00315,"Margaretsville, NS",NS,45.048773,-65.062969,Canada,CHS,
-00320,"Parkers Cove, NS",NS,44.813683,-65.538394,Canada,CHS,
-00324,"Digby Ferry Wharf, NS",NS,44.65984,-65.75677,Canada,CHS,
-00325,"Digby, NS",NS,44.626561,-65.753687,Canada,CHS,
-00330,"Culloden, NS",NS,44.665805,-65.831633,Canada,CHS,
-00333,"Grand Eddy, NS",NS,44.39592,-66.204866,Canada,CHS,
-00334,"Trout Cove, NS",NS,44.551317,-66.032085,Canada,CHS,
-00335,"Sandy Cove, NS",NS,44.498851,-66.098584,Canada,CHS,
-00336,"East Sandy Cove, NS",NS,44.487013,-66.084873,Canada,CHS,
-00337,"Tiverton, NS",NS,44.380189,-66.213845,Canada,CHS,
-00338,"Tiverton (Boars Head), NS",NS,44.404224,-66.214794,Canada,CHS,
-00340,"Westport, NS",NS,44.263641,-66.350064,Canada,CHS,
-00345,"Lighthouse Cove, NS",NS,44.24963,-66.392209,Canada,CHS,
-00353,"Church Point, NS",NS,44.345634,-66.118497,Canada,CHS,
-00355,"Meteghan, NS",NS,44.193113,-66.166268,Canada,CHS,
-00360,"Port Maitland, NS",NS,43.985999,-66.159098,Canada,CHS,
-00365,"Yarmouth, NS",NS,43.832311,-66.124968,Canada,CHS,
-00366,"Bunker Island Wharf, NS",NS,43.818936,-66.136363,Canada,CHS,
-00367,"Bunker Island Light, NS",NS,43.812291,-66.143235,Canada,CHS,
-00368,"Kellys Cove, NS",NS,43.783271,-66.131679,Canada,CHS,
-00370,"Pinkney Point, NS",NS,43.704021,-66.055683,Canada,CHS,
-00374,"Wedgeport, NS",NS,43.71704,-65.983089,Canada,CHS,
-00375,"Lower Wedgeport, NS",NS,43.712299,-65.984139,Canada,CHS,
-00378,"Tusket, NS",NS,43.852062,-65.975042,Canada,CHS,
-00380,"Abrams River, NS",NS,43.824506,-65.935217,Canada,CHS,
-00382,"Abbotts Harbour, NS",NS,43.663818,-65.824022,Canada,CHS,
-00385,"Lower East Pubnico, NS",NS,43.630445,-65.771242,Canada,CHS,
-00390,"Woods Harbour, NS",NS,43.529406,-65.739946,Canada,CHS,
-00395,"Flat Island, NS",NS,43.509749,-66.002756,Canada,CHS,
-00400,"Seal Island, NS",NS,43.409734,-66.020097,Canada,CHS,
-00405,"Clarks Harbour, NS",NS,43.444829,-65.634434,Canada,CHS,
-00408,"West Head, NS",NS,43.459567,-65.653437,Canada,CHS,
-00410,"Swims Point, NS",NS,43.433419,-65.631869,Canada,CHS,
-00415,"Barrington Passage, NS",NS,43.525632,-65.607207,Canada,CHS,
-00420,"Upper Port la Tour, NS",NS,43.505894,-65.469347,Canada,CHS,
-00423,"Ingomar, NS",NS,43.563155,-65.363373,Canada,CHS,
-00425,"Shelburne, NS",NS,43.753636,-65.320292,Canada,CHS,
-00426,"Sandy Point, NS",NS,43.695318,-65.324184,Canada,CHS,
-00430,"Lockeport, NS",NS,43.701539,-65.107167,Canada,CHS,
-00435,"Port Mouton, NS",NS,43.921621,-64.841138,Canada,CHS,
-00440,"Liverpool, NS",NS,44.048996,-64.69442,Canada,CHS,
-00450,"Bridgewater, NS",NS,44.371741,-64.505517,Canada,CHS,
-00452,"Riverport, NS",NS,44.289312,-64.345007,Canada,CHS,
-00455,"Lunenburg, NS",NS,44.375468,-64.307098,Canada,CHS,
-00460,"Mahone Harbour, NS",NS,44.447429,-64.373975,Canada,CHS,
-00465,"Chester, NS",NS,44.536383,-64.242787,Canada,CHS,
-00473,"Owls Head, NS",NS,44.521816,-64.00538,Canada,CHS,
-00475,"Mill Cove, NS",NS,44.580148,-64.052082,Canada,CHS,
-00479,"Blandford, NS",NS,44.494691,-64.11229,Canada,CHS,
-00480,"Hubbards, NS",NS,44.637327,-64.059586,Canada,CHS,
-00482,"Boutiliers Point, NS",NS,44.656852,-63.94656,Canada,CHS,
-00484,"Indian Harbour, NS",NS,44.514837,-63.937238,Canada,CHS,
-00485,"Cliff Cove, NS",NS,44.511767,-63.937469,Canada,CHS,"St. Margarets Bay, St. MargaretsBay"
-00486,"Prospect, NS",NS,44.468951,-63.783677,Canada,CHS,
-00488,"Sambro Harbour, NS",NS,44.478153,-63.599156,Canada,CHS,
-00490,"Halifax, NS",NS,44.65914,-63.583386,Canada,CHS,
-00491,"Bedford Institute, NS",NS,44.682262,-63.613239,Canada,CHS,
-00493,"Chezzetcook Inlet, NS",NS,44.71092,-63.236669,Canada,CHS,
-00495,"Salmon River Bridge, NS",NS,44.778633,-63.042147,Canada,CHS,
-00497,"Little Harbour, NS",NS,44.708858,-62.841551,Canada,CHS,
-00500,"Murphys Cove, NS",NS,44.785651,-62.761954,Canada,CHS,
-00505,"Tomlee Bay, NS",NS,44.836431,-62.587022,Canada,CHS,
-00509,"Spry Harbour, NS",NS,44.837741,-62.614059,Canada,CHS,
-00510,"Sheet Harbour, NS",NS,44.903,-62.5036,Canada,CHS,
-00511,"Port Dufferin, NS",NS,44.89582,-62.375197,Canada,CHS,
-00512,"West Newdy Quoddy, NS",NS,44.904092,-62.349648,Canada,CHS,
-00514,"Ecum Secum, NS",NS,44.966012,-62.137565,Canada,CHS,
-00515,"Liscomb Harbour, NS",NS,45.023824,-61.996742,Canada,CHS,
-00516,"Marie Joseph, NS",NS,44.965562,-62.079311,Canada,CHS,
-00520,"Sonora, NS",NS,45.057346,-61.904549,Canada,CHS,
-00525,"Sherbrooke, NS",NS,45.133931,-61.983345,Canada,CHS,
-00530,"Port Bickerton, NS",NS,45.105369,-61.723156,Canada,CHS,
-00535,"Isaacs Harbour, NS",NS,45.179911,-61.659633,Canada,CHS,
-00536,"Goldboro, NS",NS,45.180778,-61.652261,Canada,CHS,
-00540,"Larrys River, NS",NS,45.217684,-61.373621,Canada,CHS,
-00545,"Whitehead, NS",NS,45.240412,-61.188736,Canada,CHS,
-00550,"Sable Island/Sable, ÃŽle de, NS",NS,43.959157,-59.794781,Canada,CHS,
-00555,"Canso Harbour, NS",NS,45.338236,-60.995406,Canada,CHS,
-00563,"Sand Point, NS",NS,45.521378,-61.263584,Canada,CHS,
-00570,"Port Hastings, NS",NS,45.64615,-61.405665,Canada,CHS,
-00575,"Port Hawkesbury, NS",NS,45.614417,-61.365637,Canada,CHS,
-00576,"Point Tupper, NS",NS,45.595606,-61.363328,Canada,CHS,
-00580,"Arichat, NS",NS,45.5104757,-61.01769383,Canada,CHS,
-00582,"Petit De Grat, NS",NS,45.506907,-60.961596,Canada,CHS,
-00585,"Cannes, NS",NS,45.636331,-60.959515,Canada,CHS,
-00587,"St Peters Bay, NS",NS,45.652431,-60.869506,Canada,CHS,
-00588,"St Peters Inlet, NS",NS,45.661123,-60.874447,Canada,CHS,
-00595,"Fourchu, NS",NS,45.71712,-60.245189,Canada,CHS,
-00600,"Louisbourg, NS",NS,45.916903,-59.971018,Canada,CHS,
-00610,"Sydney, NS",NS,46.141358,-60.199803,Canada,CHS,
-00612,"North Sydney, NS",NS,46.20897,-60.245314,Canada,CHS,
-00621,"Table Head, NS",NS,46.323534,-60.360073,Canada,CHS,
-00622,"Duffus Point, NS",NS,46.281566,-60.424734,Canada,CHS,
-00623,"Black Rock Point, NS",NS,46.305169,-60.392998,Canada,CHS,
-00624,"Penny Lane, NS",NS,46.29864,-60.399749,Canada,CHS,Penny Lane (Blackrock)
-00626,"Seal Islands Bridge, NS",NS,46.2366,-60.5002,Canada,CHS,
-00630,"Ingonish Beach, NS",NS,46.629842,-60.389685,Canada,CHS,
-00635,"Neils Harbour, NS",NS,46.806867,-60.320471,Canada,CHS,
-00638,"Dingwall, NS",NS,46.902499,-60.457949,Canada,CHS,
-00640,"Baddeck, NS",NS,46.100254,-60.747687,Canada,CHS,
-00653,"Johnstown, NS",NS,45.79297,-60.739103,Canada,CHS,
-00654,"Eskasoni, NS",NS,45.955825,-60.586051,Canada,CHS,
-00655,"Iona, NS",NS,45.956781,-60.793964,Canada,CHS,
-00656,"Dundee, NS",NS,45.699744,-61.090416,Canada,CHS,
-00663,"Grand Bay, NL",NL,47.59022,-59.181979,Canada,CHS,
-00665,"Port aux Basques, NL",NL,47.580155,-59.139055,Canada,CHS,
-00666,"Isle Aux Morts, NL",NL,47.582132,-58.979109,Canada,CHS,
-00668,"Rose Blanche, NL",NL,47.615609,-58.700195,Canada,CHS,
-00670,"La Poile (Little Bay), NL",NL,47.684234,-58.39571,Canada,CHS,
-00671,"Grand Bruit, NL",NL,47.671685,-58.224724,Canada,CHS,
-00672,"Couteau Bay, NL",NL,47.712801,-58.049808,Canada,CHS,
-00677,"Short Reach, NL",NL,47.616818,-57.620916,Canada,CHS,Burgeo
-00679,"Ramea Island, NL",NL,47.521818,-57.38464,Canada,CHS,
-00683,"Francois, NL",NL,47.577351,-56.743771,Canada,CHS,
-00688,"Mccallum, NL",NL,47.631183,-56.22705,Canada,CHS,
-00690,"Pushthrough, NL",NL,47.635589,-56.16505,Canada,CHS,"Great Gervis Hbr, Great Gervis Hbr"
-00705,"St Albans, NL",NL,47.863101,-55.835199,Canada,CHS,
-00708,"Gaultois, NL",NL,47.608433,-55.904371,Canada,CHS,
-00710,"Hermitage, NL",NL,47.556463,-55.925395,Canada,CHS,
-00720,"Harbour Breton, NL",NL,47.477957,-55.81267,Canada,CHS,
-00724,"Belleoram, NL",NL,47.526829,-55.409341,Canada,CHS,
-00745,"Saint-Pierre Et Miquelon, NL",NL,46.777365,-56.169216,Canada,CHS,
-00755,"St. Lawrence, NL",NL,46.916789,-55.39005,Canada,CHS,Great St. Lawrence
-00760,"Burin, NL",NL,47.03573,-55.164358,Canada,CHS,
-00765,"Marystown, NL",NL,47.165605,-55.148173,Canada,CHS,
-00776,"Petite Forte, NL",NL,47.396298,-54.667979,Canada,CHS,
-00795,"Tacks Beach, NL",NL,47.581357,-54.212081,Canada,CHS,
-00796,"Davis Cove, NL",NL,47.636177,-54.3406365,Canada,CHS,
-00805,"Woody Island, NL",NL,47.783668,-54.178688,Canada,CHS,
-00810,"North Harbour, NL",NL,47.846313,-54.096719,Canada,CHS,
-00815,"Come By Chance, NL",NL,47.81042,-54.007651,Canada,CHS,
-00818,"Arnolds Cove, NL",NL,47.7579625,-53.990144,Canada,CHS,
-00830,"Long Harbour, NL",NL,47.428591,-53.822808,Canada,CHS,
-00835,"Argentia, NL",NL,47.289998,-53.991899,Canada,CHS,
-00845,"St Brides, NL",NL,46.9175758,-54.177762,Canada,CHS,
-00860,"St Marys, NL",NL,46.9194628,-53.580154,Canada,CHS,
-00880,"Trepassey, NL",NL,46.735517,-53.371543,Canada,CHS,
-00890,"Fermeuse, NL",NL,46.964724,-52.938131,Canada,CHS,
-00893,"Lance Cove, NL",NL,46.80064,-54.097654,Canada,CHS,
-00898,"Gull Island, NL",NL,47.262122,-52.777936,Canada,CHS,
-00900,"Bay Bulls, NL",NL,47.313812,-52.806124,Canada,CHS,
-00905,"St. Johns, NL",NL,47.567045,-52.702311,Canada,CHS,St. John's
-00907,"Middle Cove, NL",NL,47.650895,-52.695878,Canada,CHS,
-00912,"Portugal Cove, NL",NL,47.625667,-52.856716,Canada,CHS,
-00915,"Bell Island, NL",NL,47.629755,-52.923473,Canada,CHS,
-00920,"Long Pond, NL",NL,47.517431,-52.978591,Canada,CHS,
-00925,"Holyrood Bay, NL",NL,47.389127,-53.135356,Canada,CHS,
-00932,"Bay Roberts, NL",NL,47.588812,-53.263168,Canada,CHS,
-00935,"Harbour Grace, NL",NL,47.691119,-53.2168035,Canada,CHS,
-00955,"Hearts Content, NL",NL,47.8708505,-53.367706,Canada,CHS,
-00962,"Long Cove, NL",NL,47.566755,-53.6675267,Canada,CHS,
-00970,"Long Beach, NL",NL,47.996447,-53.810697,Canada,CHS,
-00973,"Hickmans Harbour, NL",NL,48.103238,-53.743636,Canada,CHS,
-00975,"Clarenville, NL",NL,48.169807,-53.960495,Canada,CHS,
-00977,"Clifton, NL",NL,48.175581,-53.724624,Canada,CHS,
-00981,"Trinity, NL",NL,48.372154,-53.357848,Canada,CHS,
-00985,"Port Union, NL",NL,48.498876,-53.0811086,Canada,CHS,
-00990,"Bonavista, NL",NL,48.650605,-53.115757,Canada,CHS,
-01003,"Jamestown, NL",NL,48.444292,-53.799962,Canada,CHS,
-01008,"Charlottetown, NL",NL,48.434052,-54.004372,Canada,CHS,
-01009,"Saltons Brook, NL",NL,48.57899,-53.946939,Canada,CHS,
-01010,"Newman Sound, NL",NL,48.561952,-53.962352,Canada,CHS,
-01015,"Salvage, NL",NL,48.686698,-53.642866,Canada,CHS,
-01018,"Glovertown South, NL",NL,48.682227,-53.993161,Canada,CHS,
-01025,"Dover - Wellington, NL",NL,48.8642416,-53.9721258,Canada,CHS,
-01030,"Valleyfield, NL",NL,49.122244,-53.607874,Canada,CHS,
-01035,"Musgrave Harbour, NL",NL,49.453792,-53.958367,Canada,CHS,
-01040,"Carmanville, NL",NL,49.403201,-54.281334,Canada,CHS,
-01047,"Joe Batts Arm, NL",NL,49.730817,-54.157698,Canada,CHS,
-01048,"Seldom, NL",NL,49.609583,-54.182199,Canada,CHS,"Seldom Come By, Seldom Come By"
-01049,"Tilting Harbour, NL",NL,49.705267,-54.061983,Canada,CHS,
-01050,"Fogo, NL",NL,49.7136486,-54.2884966,Canada,CHS,"Seal Cove, Seal Cove"
-01052,"Change Islands, NL",NL,49.67474,-54.400271,Canada,CHS,
-01053,"Farewell, NL",NL,49.555593,-54.477702,Canada,CHS,
-01054,"Dark Cove, NL",NL,49.52496,-54.755303,Canada,CHS,
-01056,"Dildo Run (Causeway), NL",NL,49.4811,-54.734404,Canada,CHS,
-01058,"Summerford, NL",NL,49.4896307,-54.796798,Canada,CHS,
-01060,"Twillingate, NL",NL,49.6597532,-54.77322577,Canada,CHS,
-01065,"Bridgeport, NL",NL,49.549643,-54.873393,Canada,CHS,
-01070,"Lewisporte, NL",NL,49.246536,-55.052948,Canada,CHS,
-01080,"Botwood, NL",NL,49.146832,-55.337226,Canada,CHS,
-01085,"Exploits Island, NL",NL,49.517688,-55.063684,Canada,CHS,
-01087,"Leading Tickle, NL",NL,49.5020504,-55.4470603,Canada,CHS,
-01095,"Little Bay Arm, NL",NL,49.600766,-55.923296,Canada,CHS,
-01097,"Beachside, NL",NL,49.643134,-55.89575,Canada,CHS,
-01098,"Springdale, NL",NL,49.5000599,-56.064947,Canada,CHS,
-01101,"Nippers Harbour, NL",NL,49.793454,-55.8598663,Canada,CHS,
-01102,"Tilt Cove, NL",NL,49.880514,-55.623771,Canada,CHS,
-01105,"La Scie, NL",NL,49.9631805,-55.6029476,Canada,CHS,
-01110,"Baie Verte, NL",NL,49.937268,-56.191381,Canada,CHS,
-01115,"Seal Cove, NL",NL,49.936176,-56.38880325,Canada,CHS,
-01125,"Hampden, NL",NL,49.5452688,-56.85334086,Canada,CHS,
-01135,"Sops Island, NL",NL,49.797178,-56.794615,Canada,CHS,
-01150,"Englee, NS",NS,50.732249638,-56.10674919,Canada,CHS,
-01165,"Locks Cove, NL",NL,51.337356,-55.954712,Canada,CHS,
-01170,"St Anthony, NL",NL,51.3639566,-55.58490847,Canada,CHS,
-01180,"Ship Cove, NL",NL,51.6027255,-55.62597008,Canada,CHS,
-01181,"Cooks Harbour, NL",NL,51.607009,-55.862446,Canada,CHS,
-01182,"Black Joke Cove, NL",NL,51.999257,-55.279315,Canada,CHS,
-01185,"Chateau Bay, NL",NL,51.975223,-55.855186,Canada,CHS,
-01186,"Henley Harbour, NL",NL,51.9925867,-55.8553451,Canada,CHS,
-01190,"Battle Harbour, NL",NL,52.2736235,-55.58394272,Canada,CHS,
-01195,"Port Marnham, NL",NL,52.383568,-55.733203,Canada,CHS,
-01199,"Williams Harbour, South Labrador, NL",NL,52.5596724,-55.7698364,Canada,CHS,
-01200,"Denbigh Island, Labrador, NL",NL,52.531128,-55.82491,Canada,CHS,
-01202,"White Bear Arm, NL",NL,52.734901,-55.829688,Canada,CHS,"Square Island Harbour, Square Island Harbour"
-01205,"Nevile Island, NL",NL,52.55116,-56.111893,Canada,CHS,Cooper's Island
-01210,"Port Hope Simpson, NL",NL,52.54908,-56.296152,Canada,CHS,
-01214,"Norman Bay, NL",NL,52.93597986,-55.90235541,Canada,CHS,
-01217,"Punchbowl, NL",NL,53.250676,-55.751618,Canada,CHS,
-01245,"Cartwright, NL",NL,53.70421458,-57.020407,Canada,CHS,
-01247,"Sandwich Bay (East Arm), NL",NL,53.566561,-57.161563,Canada,CHS,
-01248,"Paradise River, NL",NL,53.440361,-57.285765,Canada,CHS,
-01263,"Snooks Rocks, NL",NL,54.2627,-58.1955,Canada,CHS,
-01267,"Jordans Point, NL",NL,54.218294,-58.241539,Canada,CHS,
-01280,"Rigolet, NL",NL,54.180469,-58.427962,Canada,CHS,
-01285,"Caravalla Cove, NL",NL,54.054143,-58.593691,Canada,CHS,
-01287,"Long Point Island, NL",NL,54.015302,-58.566696,Canada,CHS,
-01320,"Cabot Point, NL",NL,53.719117,-59.0644,Canada,CHS,
-01331,"Mulligan Bay, NL",NL,53.8356,-59.871383,Canada,CHS,
-01335,"North West River, NL",NL,53.523929,-60.1457805,Canada,CHS,
-01345,"Rabbit Island, NL",NL,53.401117,-60.137636,Canada,CHS,
-01350,"Terrington Basin, NL",NL,53.344237,-60.401007,Canada,CHS,
-01365,"Broomfield, NL",NL,54.47233,-57.182573,Canada,CHS,Icy Tickle
-01370,"Emily Harbour, NL",NL,54.541068,-57.191598,Canada,CHS,
-01374,"Byron Bay (Copper Island), NL",NL,54.728082,-57.688218,Canada,CHS,
-01376,"Jeanette Bay, Lab, NL",NL,54.749478,-57.891383,Canada,CHS,
-01377,"Mostyn Cove, NL",NL,54.7401315,-57.982024,Canada,CHS,
-01390,"Makkovik, NL",NL,55.082942,-59.1701008,Canada,CHS,
-01397,"Postville, NL",NL,54.907125,-59.766688,Canada,CHS,
-01398,"Jackos Point, NL",NL,55.121487,-59.443562,Canada,CHS,
-01400,"Turnavik Island, NL",NL,55.285606,-59.34282,Canada,CHS,
-01405,"Hopedale, NL",NL,55.4541256,-60.2228018,Canada,CHS,
-01410,"Shoal Tickle, NL",NL,55.771765,-60.352145,Canada,CHS,
-01416,"Davis Inlet, NL",NL,55.892393,-60.901578,Canada,CHS,
-01420,"House Harbour, NL",NL,56.235527,-61.049647,Canada,CHS,
-01421,"Nukasusutok Island, NL",NL,56.370108,-61.241776,Canada,CHS,North Harbour
-01422,"John Hayes Harbour, NL",NL,56.399527,-61.614195,Canada,CHS,
-01425,"Ford Harbour, NL",NL,56.4663686,-61.19228058,Canada,CHS,
-01430,"Nain, NL",NL,56.543452,-61.686473,Canada,CHS,"Nain, Nunainguk, Unity Bay"
-01435,"Young's Harbour, NL",NL,56.633,-61.061,Canada,CHS,
-01450,"Port Manvers, NL",NL,56.954676,-61.506858,Canada,CHS,
-01452,"Kiglapait Harbour, NL",NL,57.158904,-61.56302,Canada,CHS,
-01458,"Igloksoatalik Island, NL",NL,57.67846,-61.816734,Canada,CHS,
-01465,"Hebron, NL",NL,58.199632,-62.624991,Canada,CHS,
-01470,"Saglek Bay, NL",NL,58.486817,-62.668467,Canada,CHS,
-01485,"Brownell Point, NL",NL,59.392177,-63.877661,Canada,CHS,
-01487,"Eclipse Channel, NL",NL,59.694339,-64.132595,Canada,CHS,
-01490,"Williams Harbour, North Labrador, NL",NL,60.009951,-64.316726,Canada,CHS,
-01495,"Cape Chidley, NL",NL,60.33468,-64.451803,Canada,CHS,
-01520,"Bay St. Lawrence, NS",NS,47.002654,-60.467522,Canada,CHS,
-01530,"St Paul Island, NS",NS,47.199,-60.146544,Canada,CHS,
-01539,"Cheticamp, NS",NS,46.625175,-61.016557,Canada,CHS,"La Digue, LA DIGUE"
-01540,"La Pointe, NS",NS,46.603101,-61.0526,Canada,CHS,
-01545,"Margaree Trailer, NS",NS,46.440193,-61.11288,Canada,CHS,
-01546,"Margaree Harbour, NS",NS,46.4424,-61.112103,Canada,CHS,Belle Cote Breakwater
-01547,"East Margaree River, NS",NS,46.42772,-61.088565,Canada,CHS,Margaree Fish Pond
-01548,"East Margaree Bridge, NS",NS,46.39729,-61.078761,Canada,CHS,
-01550,"Broad Cove Marsh, NS",NS,46.300635,-61.257343,Canada,CHS,
-01560,"Port Hood, NS",NS,46.027909,-61.545014,Canada,CHS,
-01570,"Aulds Cove, NS",NS,45.648343,-61.435526,Canada,CHS,
-01576,"Havre Boucher, NS",NS,45.68962,-61.527238,Canada,CHS,
-01580,"Cape Jack, NS",NS,45.683753,-61.574802,Canada,CHS,
-01590,"Antigonish Harbour, NS",NS,45.672456,-61.907064,Canada,CHS,
-01597,"Cribbeans Point, NS",NS,45.755204,-61.896344,Canada,CHS,Cribbons Point
-01600,"Ballantynes Cove, NS",NS,45.858721,-61.918052,Canada,CHS,
-01610,"Arisaig, NS",NS,45.7619714,-62.1716137,Canada,CHS,
-01620,"Merigomish, NS",NS,45.648764,-62.448885,Canada,CHS,
-01630,"Pictou, NS",NS,45.6740806,-62.7033375,Canada,CHS,
-01635,"Pictou Island, NS",NS,45.802557,-62.585592,Canada,CHS,
-01640,"Caribou, NS",NS,45.73928,-62.688116,Canada,CHS,Caribou Ferry Terminal
-01650,"Souris, PE",PE,46.349625,-62.251762,Canada,CHS,
-01660,"Georgetown, PE",PE,46.17951,-62.531618,Canada,CHS,
-01662,"Montague, PE",PE,46.164725,-62.646332,Canada,CHS,
-01665,"Graham Pond, PE",PE,46.095961,-62.453698,Canada,CHS,
-01670,"Murray Harbour, PE",PE,46.005478,-62.523515,Canada,CHS,
-01680,"Wood Islands, PE",PE,45.952878,-62.749395,Canada,CHS,
-01690,"Point Prim, PE",PE,46.056251,-63.030217,Canada,CHS,
-01700,"Charlottetown, PE",PE,46.23012108,-63.1221766,Canada,CHS,
-01710,"Canoe Cove, PE",PE,46.149224,-63.303736,Canada,CHS,
-01715,"Victoria, PEI, PE",PE,46.212623,-63.489466,Canada,CHS,
-01725,"Port Borden, PE",PE,46.246127,-63.700721,Canada,CHS,
-01735,"Summerside, PE",PE,46.386486,-63.789649,Canada,CHS,
-01745,"Skinners Cove, NS",NS,45.79447,-63.04467,Canada,CHS,
-01760,"Malagash, NS",NS,45.77520205,-63.2961563,Canada,CHS,
-01770,"Cape Cliff, NS",NS,45.876731,-63.480512,Canada,CHS,
-01775,"Pugwash, NS",NS,45.8483972,-63.663297,Canada,CHS,
-01780,"Tidnish, NS",NS,45.997582,-64.007441,Canada,CHS,
-01785,"Port Elgin, NB",NB,46.051875,-64.082768,Canada,CHS,
-01790,"Cape Tormentine, NB",NB,46.134676,-63.776757,Canada,CHS,
-01800,"Cap Pelé, NB",NB,46.235841,-64.26127,Canada,CHS,"Cape Bald, CAPE BALD"
-01804,"Pointe-du-Chêne, NB",NB,46.24061389,-64.53000556,Canada,CHS,
-01805,"Shediac Bay, NB",NB,46.22689722,-64.54510278,Canada,CHS,
-01810,"Cap de Caissie, NB",NB,46.312812,-64.509737,Canada,CHS,
-01812,"Cocagne, NB",NB,46.3380696,-64.61814202,Canada,CHS,
-01815,"Saint Thomas De Kent, NB",NB,46.447615,-64.636837,Canada,CHS,
-01820,"Richibucto Cape, NB",NB,46.67454025,-64.7125534,Canada,CHS,
-01825,"Richibucto Bar, NB",NB,46.710852,-64.791113,Canada,CHS,
-01827,"Richibucto, NB",NB,46.68032,-64.86042,Canada,CHS,
-01830,"Pointe Sapin, NB",NB,46.9628154,-64.8300883,Canada,CHS,
-01835,"Cape Egmont, PE",PE,46.408225,-64.133638,Canada,CHS,
-01845,"West Point, PE",PE,46.620079,-64.371788,Canada,CHS,
-01855,"Miminegash, PE",PE,46.88011,-64.234435,Canada,CHS,
-01860,"Skinners Pond, PE",PE,46.964224,-64.122878,Canada,CHS,
-01865,"North Point, PE",PE,47.0581997,-63.9960403,Canada,CHS,
-01875,"Tignish, PE",PE,46.950947,-63.9938431,Canada,CHS,
-01885,"Alberton, PE",PE,46.7951034,-64.0582548,Canada,CHS,
-01896,"Goodwood River, PE",PE,46.616799,-63.916607,Canada,CHS,
-01905,"Malpeque, PE",PE,46.523993,-63.696637,Canada,CHS,
-01915,"Rustico, PE",PE,46.4560018,-63.2940585,Canada,CHS,
-01918,"Covehead, PE",PE,46.429035,-63.146052,Canada,CHS,
-01925,"Crowbush Cove, PE",PE,46.4269503,-62.8399476,Canada,CHS,
-01935,"St Peters Bay, PE",PE,46.43862,-62.73313,Canada,CHS,
-01945,"Naufrage, PE",PE,46.468428,-62.417173,Canada,CHS,
-01955,"North Lake Harbour, PE",PE,46.4669804,-62.06881902,Canada,CHS,
-01960,"Anse à la Cabane, QC",QC,47.21766667,-61.98541667,Canada,CHS,Millerand
-01964,"Havre-Aubert, QC",QC,47.235189,-61.828083,Canada,CHS,Havre Aubert
-01966,"Île d'Entrée, QC",QC,47.277444,-61.718639,Canada,CHS,
-01970,"Cap-aux-Meules, QC",QC,47.378861,-61.857283,Canada,CHS,Grindstone Wharf
-01976,"Havre-aux-Maisons, QC",QC,47.405333,-61.836,Canada,CHS,House Harbour
-01981,"Pointe-Basse, QC",QC,47.389806,-61.789035,Canada,CHS,Pointe Basse
-01985,"Grande-Entrée, QC",QC,47.555842,-61.558949,Canada,CHS,Grande Entrée
-01986,"Old-Harry, QC",QC,47.570755,-61.467094,Canada,CHS,Old Harry Head
-01987,"Leslie, QC",QC,47.627778,-61.515667,Canada,CHS,Leslie Grosse Île
-01988,"Grosse Île - Mine Seleine, QC",QC,47.610739,-61.560078,Canada,CHS,Mine Seleine
-01990,"L'Étang-du-Nord, QC",QC,47.37,-61.958922,Canada,CHS,Étang du Nord
-02000,"Escuminac, NB",NB,47.082241,-64.885565,Canada,CHS,Lower Escuminac
-02010,"Portage Island, NB",NB,47.177032,-65.037294,Canada,CHS,
-02012,"Fox Island Range Light, NB",NB,47.11348,-65.043085,Canada,CHS,
-02014,"Cormorant (underwater), NB",NB,47.124708,-65.148642,Canada,CHS,
-02020,"Bas Neguac, NB",NB,47.256519,-65.053075,Canada,CHS,
-02022,"Neguac, NB",NB,47.240992,-65.072306,Canada,CHS,
-02025,"Burnt Church, NB",NB,47.190671,-65.134805,Canada,CHS,
-02028,"Baie du Vin Island, NB",NB,47.039056,-65.146615,Canada,CHS,
-02029,"Robichaud Spit, NB",NB,47.129705,-65.251003,Canada,CHS,
-02030,"Oak Point, NB",NB,47.116441,-65.267016,Canada,CHS,
-02033,"Loggieville, NB",NB,47.074387,-65.384277,Canada,CHS,
-02034,"Gordon Point, NB",NB,47.079161,-65.393159,Canada,CHS,
-02035,"Chatham, NB",NB,47.029867,-65.47223,Canada,CHS,
-02040,"Newcastle, NB",NB,46.998039,-65.561618,Canada,CHS,
-02060,"Tracadie, NB",NB,47.52295,-64.90893,Canada,CHS,
-02070,"Shippagan Gully, NB",NB,47.7187001,-64.669771,Canada,CHS,
-02071,"Shippagan, NB",NB,47.747852,-64.702431,Canada,CHS,
-02090,"Miscou, NB",NB,47.896209,-64.578601,Canada,CHS,
-02110,"Caraquet, NB",NB,47.79601475,-64.927602,Canada,CHS,
-02120,"Stonehaven, NB",NB,47.7542608,-65.3618448,Canada,CHS,
-02130,"Bathurst Harbour, NB",NB,47.614601,-65.639602,Canada,CHS,
-02145,"Belledune, NB",NB,47.908954,-65.845892,Canada,CHS,Chaleur
-02165,"Dalhousie, NB",NB,48.0720178,-66.3776873,Canada,CHS,
-02175,"Campbellton, NB",NB,48.0115566,-66.6693986,Canada,CHS,
-02196,"Miguasha, QC",QC,48.09878599,-66.34707575,Canada,CHS,
-02200,"Carleton, QC",QC,48.100181,-66.130929,Canada,CHS,Carleton Center
-02215,"Pointe Howatson, QC",QC,48.137764,-65.836794,Canada,CHS,"Les Caps Noirs, Black Cape"
-02230,"Bonaventure, QC",QC,48.037623,-65.481124,Canada,CHS,
-02235,"Paspébiac, QC",QC,48.018652,-65.257383,Canada,CHS,Paspebiac
-02240,"Saint-Godefroi, QC",QC,48.073804,-65.113371,Canada,CHS,St-Godefroi
-02250,"Port-Daniel-Gascons, QC",QC,48.182612,-64.96142,Canada,CHS,
-02253,"Gascons, QC",QC,48.19073,-64.861547,Canada,CHS,
-02260,"Newport, QC",QC,48.284376,-64.71932,Canada,CHS,Newport Point
-02269,"Chandler, QC",QC,48.34205,-64.657065,Canada,CHS,
-02279,"Grande-Rivière, QC",QC,48.392651,-64.492455,Canada,CHS,
-02285,"Sainte-Thérèse-de-Gaspé, QC",QC,48.415011,-64.39517,Canada,CHS,Petite Rivière Est
-02290,"Cap-d'Espoir, QC",QC,48.414713,-64.327389,Canada,CHS,Cap-D'Espoir
-02295,"L'Anse-à-Beaufils, QC",QC,48.472174,-64.30779,Canada,CHS,Anse-à-Beaufils
-02309,"Mal-Bay, QC",QC,48.620111,-64.199972,Canada,CHS,Malbay
-02310,"Pointe Saint-Pierre, QC",QC,48.633389,-64.166,Canada,CHS,
-02314,"L'Anse-à-Brillant, QC",QC,48.72065004,-64.29060876,Canada,CHS,Anse-à-Brillant
-02319,"Sandy Beach, QC",QC,48.825917,-64.440722,Canada,CHS,Sandy Beach Wharf
-02330,"Rivière-au-Renard, QC",QC,48.997,-64.3805,Canada,CHS,
-02335,"L'Anse-à-Valleau, QC",QC,49.081,-64.544667,Canada,CHS,Anse à Valleau
-02340,"Cloridorme, QC",QC,49.185833,-64.847833,Canada,CHS,
-02350,"Grande-Vallée, QC",QC,49.229833,-65.1345,Canada,CHS,Grande-Vallee
-02360,"Port-Menier, QC",QC,49.811667,-64.366667,Canada,CHS,Port Menier
-02375,"Pointe du Sud-Ouest, QC",QC,49.395,-63.59,Canada,CHS,Southwest Point
-02415,"Baie du Renard, QC",QC,49.281667,-61.834,Canada,CHS,Baie-du-Renard
-02470,"Mingan, QC",QC,50.289167,-64.020167,Canada,CHS,
-02480,"Havre-Saint-Pierre, QC",QC,50.237056,-63.609194,Canada,CHS,
-02490,"Baie-Johan-Beetz, QC",QC,50.283667,-62.810167,Canada,CHS,Baie Johan Beetz
-02510,"Natashquan, QC",QC,50.189167,-61.8415,Canada,CHS,Natashquan Harbour
-02518,"Kegaska, QC",QC,50.184286,-61.263938,Canada,CHS,Kégashka
-02530,"Gethsémani, QC",QC,50.212108,-60.689319,Canada,CHS,Gethsemani
-02550,"Harrington Harbour, QC",QC,50.496333,-59.476,Canada,CHS,Harrington-Harbour
-02554,"Tête-à-la-Baleine, QC",QC,50.68,-59.24,Canada,CHS,Tête-a-la-Baleine
-02556,"Baie des Moutons, QC",QC,50.769304,-59.03234,Canada,CHS,Baie-des-Moutons
-02558,"La Tabatière, QC",QC,50.838294,-58.972951,Canada,CHS,Baie de la Tabatière
-02564,"Saint-Augustin, QC",QC,51.176333,-58.534667,Canada,CHS,St Augustin
-02577,"Vieux-Fort, QC",QC,51.421833,-57.8145,Canada,CHS,Baie du Vieux Fort
-02579,"Rivière-Saint-Paul, QC",QC,51.4711,-57.7075,Canada,CHS,Rivière-St-Paul
-02580,"Île des Esquimaux, QC",QC,51.424,-57.7025,Canada,CHS,Rivière Saint-Paul
-02581,"Baie Chevalier, QC",QC,51.432483,-57.638472,Canada,CHS,
-02583,"Middle Bay, QC",QC,51.463,-57.485,Canada,CHS,Middle-Bay
-02588,"Blanc-Sablon, QC",QC,51.415333,-57.150667,Canada,CHS,Blanc Sablon
-02590,"Forteau Bay, NL",NL,51.46944,-56.953481,Canada,CHS,
-02595,"West St. Modeste, NL",NL,51.594882,-56.704036,Canada,CHS,
-02600,"Red Bay, NL",NL,51.732061,-56.43062,Canada,CHS,
-02633,"Savage Cove, NL",NL,51.3327256,-56.70043202,Canada,CHS,
-02635,"Flowers Cove, NL",NL,51.29992,-56.735151,Canada,CHS,
-02637,"Anchor Point, NL",NL,51.233626,-56.797733,Canada,CHS,
-02638,"St. Barbe, NL",NL,51.204308,-56.77283,Canada,CHS,
-02642,"Shoal Cove West, NL",NL,51.024546,-57.022789,Canada,CHS,
-02650,"Port Saunders, NL",NL,50.644007,-57.296997,Canada,CHS,
-02655,"Port Aux Choix, NL",NL,50.70732869,-57.35684758,Canada,CHS,
-02660,"Cow Head, NL",NL,49.9221072,-57.8039272,Canada,CHS,
-02670,"Norris Cove, NL",NL,49.5173444,-57.87582752,Canada,CHS,
-02680,"Corner Brook, NL",NL,48.95829816,-57.9431008,Canada,CHS,
-02685,"Lark Harbour, NL",NL,49.0959298,-58.37913541,Canada,CHS,
-02695,"Fox Island, NL",NL,48.695636,-58.683013,Canada,CHS,
-02710,"Port Harmon, NL",NL,48.53051075,-58.52627363,Canada,CHS,Stephenville Pond
-02720,"St Georges, NL",NL,48.430237,-58.484809,Canada,CHS,
-02725,"Crabbes River, NL",NL,48.2184586,-58.8634113,Canada,CHS,St. Davids
-02750,"Rivière-au-Tonnerre, QC",QC,50.273333,-64.761001,Canada,CHS,
-02780,"Sept-Îles, QC",QC,50.200369,-66.385102,Canada,CHS,Seven Islands
-02790,"Port-Cartier, QC",QC,50.0325,-66.7875,Canada,CHS,
-02815,"Baie-Trinité, QC",QC,49.42165872,-67.28240575,Canada,CHS,
-02826,"Godbout, QC",QC,49.322167,-67.592667,Canada,CHS,
-02840,"Baie-Comeau, QC",QC,49.231333,-68.131001,Canada,CHS,
-02880,"Forestville, QC",QC,48.738333,-69.052167,Canada,CHS,
-02883,"Portneuf-sur-Mer, QC",QC,48.640833,-69.093333,Canada,CHS,Sainte-Anne-de-Portneuf
-02900,"Les Escoumins, QC",QC,48.346167,-69.388833,Canada,CHS,
-02920,"Mont-Louis, QC",QC,49.235167,-65.7375,Canada,CHS,
-02933,"Petite-Tourelle, QC",QC,49.167833,-66.372833,Canada,CHS,Saint-Joachim-de-Tourelle
-02935,"Sainte-Anne-des-Monts, QC",QC,49.134,-66.485833,Canada,CHS,
-02940,"Cap-Chat, QC",QC,49.098333,-66.6815,Canada,CHS,
-02945,"Le Gros Méchins, QC",QC,49.005833,-66.9775,Canada,CHS,
-02955,"Matane, QC",QC,48.853333,-67.533167,Canada,CHS,
-02975,"Pointe aux Cenelles, QC",QC,48.642833,-68.166667,Canada,CHS,Pointe-aux-Cenelles
-02980,"Pointe-au-Père, QC",QC,48.519167,-68.473167,Canada,CHS,
-02985,"Rimouski, QC",QC,48.478333,-68.513667,Canada,CHS,
-02995,"Le Bic, QC",QC,48.377167,-68.7265,Canada,CHS,Bic
-03000,"Île Bicquette, QC",QC,48.4155,-68.893333,Canada,CHS,
-03005,"Trois-Pistoles, QC",QC,48.134667,-69.186833,Canada,CHS,
-03030,"Saint-Siméon, QC",QC,47.840667,-69.873167,Canada,CHS,
-03045,"Pointe-au-Pic, QC",QC,47.621667,-70.140833,Canada,CHS,
-03052,"Cap-aux-Oies, QC",QC,47.487167,-70.232667,Canada,CHS,
-03057,"Saint-Joseph-de-la-Rive, QC",QC,47.448833,-70.3655,Canada,CHS,
-03058,"Saint-Bernard-sur-Mer, QC",QC,47.4205,-70.392167,Canada,CHS,"Saint-Bernard, Île aux Coudres"
-03060,"Cap-aux-Corbeaux, QC",QC,47.4255,-70.455667,Canada,CHS,
-03070,"Sault-au-Cochon, QC",QC,47.199667,-70.635833,Canada,CHS,
-03071,"Rocher de Neptune, QC",QC,47.161667,-70.6075,Canada,CHS,Rocher-Neptune
-03072,"Bouée K92, QC",QC,47.158517,-70.658167,Canada,CHS,
-03087,"Sainte-Anne-de-Beaupré, QC",QC,47.0185,-70.9255,Canada,CHS,
-03095,"Montmorency, QC",QC,46.881167,-71.144667,Canada,CHS,
-03100,"Saint-François I.O., QC",QC,46.9965,-70.808167,Canada,CHS,Saint-Francois I.O.
-03104,"Bouée K136, QC",QC,46.924833,-70.869,Canada,CHS,
-03105,"Saint-Jean I.O., QC",QC,46.915667,-70.8965,Canada,CHS,
-03110,"Saint-Laurent I.O., QC",QC,46.85816667,-71.00333333,Canada,CHS,
-03120,"Île Verte, QC",QC,48.051167,-69.424667,Canada,CHS,
-03122,"L'Isle-Verte, QC",QC,48.024667,-69.408,Canada,CHS,Chenal de l'Île Verte
-03125,"Gros-Cacouna, QC",QC,47.9275,-69.513667,Canada,CHS,
-03130,"Rivière-du-Loup, QC",QC,47.846833,-69.571833,Canada,CHS,
-03140,"Île aux Lièvres, QC",QC,47.801167,-69.770667,Canada,CHS,Îles-aux-Lièvres
-03145,"Le Petit Pèlerin, QC",QC,47.701,-69.758333,Canada,CHS,Le Petit Pelerin
-03150,"La Grande Île, QC",QC,47.624167,-69.860833,Canada,CHS,Grande-ile
-03160,"Pointe-aux-Orignaux, QC",QC,47.487,-70.025833,Canada,CHS,
-03170,"Saint-Jean-Port-Joli, QC",QC,47.216167,-70.274667,Canada,CHS,
-03180,"L'Isle-aux-Grues, QC",QC,47.055333,-70.5315,Canada,CHS,L'ile-aux-Grues
-03190,"La Grosse Île, QC",QC,47.0195,-70.670833,Canada,CHS,
-03200,"Berthier-sur-Mer, QC",QC,46.936167,-70.737333,Canada,CHS,
-03248,"Vieux-Québec, QC",QC,46.811111,-71.20175,Canada,CHS,
-03250,"Lauzon, QC",QC,46.8325,-71.157833,Canada,CHS,Québec (Lauzon)
-03251,"Immigration Wharf, QC",QC,46.7923,-71.2265,Canada,CHS,
-03260,"Saint-Romuald, QC",QC,46.761333,-71.240333,Canada,CHS,St-Romuald
-03264,"Quai des Cageux, QC",QC,46.755,-71.2715,Canada,CHS,Quai Irving
-03265,"Pont de Québec, QC",QC,46.745581,-71.287938,Canada,CHS,
-03270,"Saint-Nicolas, QC",QC,46.712,-71.378833,Canada,CHS,
-03280,"Neuville, QC",QC,46.6965,-71.572833,Canada,CHS,
-03295,"Pointe Platon, QC",QC,46.670833,-71.846,Canada,CHS,Pointe-au-Platon
-03300,"Portneuf, QC",QC,46.681167,-71.877167,Canada,CHS,
-03304,"Lotbinière (moulin à blé), QC",QC,46.650667,-71.889833,Canada,CHS,Moulin a Ble
-03325,"Grondines, QC",QC,46.585333,-72.038833,Canada,CHS,
-03335,"Deschaillons-sur-Saint-Laurent, QC",QC,46.561033,-72.106222,Canada,CHS,Deschaillons
-03337,"Les Bricailles, QC",QC,46.549833,-72.134333,Canada,CHS,Brickyard
-03345,"Batiscan, QC",QC,46.500333,-72.245833,Canada,CHS,
-03350,"Champlain, QC",QC,46.440167,-72.339667,Canada,CHS,
-03353,"Bécancour, QC",QC,46.400333,-72.3795,Canada,CHS,Becancour
-03360,"Trois-Rivières, QC",QC,46.3405,-72.539167,Canada,CHS,
-03424,"Baie-Sainte-Catherine, QC",QC,48.126333,-69.72975,Canada,CHS,Anse du Portage
-03425,"Tadoussac, QC",QC,48.138333,-69.714,Canada,CHS,
-03440,"L'Anse-Saint-Jean, QC",QC,48.245,-70.179667,Canada,CHS,Anse Saint-Jean
-03460,"Port-Alfred, QC",QC,48.3339,-70.869267,Canada,CHS,Port Alfred
-03466,"Grande-Anse, QC",QC,48.401667,-70.832833,Canada,CHS,
-03480,"Chicoutimi, QC",QC,48.43083333,-71.05483333,Canada,CHS,
-03510,"Qarqortoq, Greenland",Greenland,60.716667,-46.033333,Canada,CHS,"Julianehaab, JULIANEHAAB"
-03575,"Nuuk, Greenland",Greenland,64.183333,-51.75,Canada,CHS,"Godthaab, GODTHAAB"
-03670,"North Star Bay, Greenland",Greenland,76.545,-68.875,Canada,CHS,Pituffik
-03671,"Thule, Greenland",Greenland,76.533333,-68.900002,Canada,CHS,Pituffik
-03690,"Foulke Harbour, Greenland",Greenland,78.3,-72.633333,Canada,CHS,"Foulke Fiord, FOULKE FIORD, Foulke Havn"
-03710,"Rensselaer Bay, Greenland",Greenland,78.6258,-70.9658,Canada,CHS,
-03735,"Thank God Harbour, Greenland",Greenland,81.6,-61.633333,Canada,CHS,Thank God Havn
-03755,"Cape Bryant, Greenland",Greenland,82.338,-55.2044,Canada,CHS,
-03765,"Alert, NU",NU,82.494152,-62.3096,Canada,CHS,"Dumb Bell Bay, DUMB BELL BAY"
-03780,"Cape Sheridan , NU",NU,82.455349,-61.448051,Canada,CHS,
-03785,"Wrangel Bay, NU",NU,82.0,-62.5,Canada,CHS,
-03790,"Discovery Harbour, NU",NU,81.733333,-64.733333,Canada,CHS,DISCOVERY HBR.
-03838,"Alexandra Fiord, NU",NU,78.9118,-75.479496,Canada,CHS,
-03840,"Pim Island, NU",NU,78.671667,-74.171667,Canada,CHS,
-03902,"Cape Liverpool, NU",NU,73.65,-78.05,Canada,CHS,
-03916,"Nova Zembla Island, NU",NU,72.169083,-74.920444,Canada,CHS,
-03940,"Clyde River, NU",NU,70.464361,-68.587167,Canada,CHS,
-03960,"Cape Hooper, NU",NU,68.46276,-66.817,Canada,CHS,
-03970,"Kivitoo, NU",NU,67.93,-64.93,Canada,CHS,
-03980,"Qikiqtarjuaq, NU",NU,67.56052,-64.031752,Canada,CHS,"Broughton Island, BROUGHTON ISLAND"
-03995,"Cape Dyer, NU",NU,66.558333,-61.659444,Canada,CHS,
-04029,"Pangnirtung, NU",NU,66.140883,-65.8284,Canada,CHS,
-04031,"Aulatsivik Point, NU",NU,66.181086,-65.636452,Canada,CHS,
-04040,"Clearwater Fiord, NU",NU,66.6,-67.316667,Canada,CHS,
-04045,"Imigen Island, NU",NU,66.027274,-67.07126,Canada,CHS,
-04070,"Brevoort Harbour, NU",NU,63.316667,-64.15,Canada,CHS,
-04100,"Resor Island, NU",NU,63.214933,-67.9904,Canada,CHS,
-04120,"Frobisher's Farthest, NU",NU,63.47985,-68.027527,Canada,CHS,
-04135,"Lewis Bay, NU",NU,63.6,-68.075,Canada,CHS,
-04140,"Iqaluit, NU",NU,63.712667,-68.5025,Canada,CHS,"Koojesse Inlet, Frobisher Bay, FROBISHER BAY, KOOJESSE INLET"
-04160,"Sorry Harbour, NU",NU,61.616667,-64.733333,Canada,CHS,
-04170,"Acadia Cove, NU",NU,61.343078,-64.898161,Canada,CHS,
-04205,"Kimmirut, NU",NU,62.796,-69.775,Canada,CHS,"Lake Harbour, LAKE HARBOUR"
-04215,"Ashe Inlet, NU",NU,62.54086,-70.54564,Canada,CHS,"Big Island, Big Island"
-04245,"Kinngait, NU",NU,64.22967,-76.49499,Canada,CHS,Cape Dorset
-04255,"Schooner Harbour, NU",NU,64.4035,-77.875,Canada,CHS,
-04265,"Port Burwell, NU",NU,60.4175,-64.842,Canada,CHS,"Killiniq, Killiniq"
-04275,"Beacon Island, QC",QC,58.900168,-66.334805,Canada,CHS,
-04279,"Kangiqsualujjuaq, QC",QC,58.668433,-65.948088,Canada,CHS,
-04294,"Rivière Koksoak est, QC",QC,58.524967,-68.149917,Canada,CHS,Koksoak #1
-04295,"Rivière Koksoak, QC",QC,58.527251,-68.193244,Canada,CHS,Koksoak River Entrance
-04296,"The Narrows, QC",QC,58.39675,-68.212194,Canada,CHS,Koksoak #2
-04297,"Île Mackays, QC",QC,58.26045,-68.266283,Canada,CHS,"Ile Mackays, Koksoak #3, MacKay's Island"
-04298,"Kuujjuaq, QC",QC,58.1,-68.316667,Canada,CHS,"Fort Chimo, Koksoak #4, Little Elbow Island"
-04315,"Tasiujaq, QC",QC,58.733333,-69.833333,Canada,CHS,"Leaf Basin, LEAF BASIN, Lac Aux Feuilles"
-04325,"Hopes Advance Bay, QC",QC,59.332569,-69.692256,Canada,CHS,
-04335,"Agvik Island, NU",NU,60.016667,-69.7,Canada,CHS,"Payne Bay, Payne Bay"
-04340,"Île Pikiyulik, QC",QC,59.996728,-69.913881,Canada,CHS,"Ile Pikiulik, Ile Pikiulik, Pikiyulik Island"
-04345,"Île Basking, QC",QC,59.98833,-70.07917,Canada,CHS,"Ile Basking, Basking Island, Ile Basking"
-04379,"Quaqtaq, QC",QC,61.047083,-69.669944,Canada,CHS,"Koartac, Koartac"
-04380,"Diana Bay, QC",QC,60.866667,-70.066667,Canada,CHS,"Quaqtaq, Quaqtaq"
-04400,"Stupart Bay, QC",QC,61.583333,-71.533333,Canada,CHS,
-04415,"Doctor Island, QC",QC,61.680556,-71.568333,Canada,CHS,
-04425,"Kangiqsujuaq, QC",QC,61.6061,-71.961358,Canada,CHS,"Baie Wakeham, Baie Wakeham, Wakeham Bay"
-04435,"Douglas Harbour, QC",QC,61.878667,-72.6802,Canada,CHS,"Havre Douglas, Havre Douglas"
-04460,"Deception Bay, QC",QC,62.147762,-74.694494,Canada,CHS,"Baie Deception, Baie Deception"
-04470,"Salluit, QC",QC,62.216667,-75.65,Canada,CHS,"Sugluk, Salluit, Sugluk, Saglouc"
-04480,"Digges Harbour, NU",NU,62.561361,-77.869833,Canada,CHS,
-04490,"Port De Laperriere, NU",NU,62.566667,-78.066667,Canada,CHS,
-04500,"Port De Boucherville, NU",NU,63.166667,-77.583333,Canada,CHS,
-04538,"Akulivik, QC",QC,60.801507,-78.219061,Canada,CHS,
-04548,"North Kopak Island, NU",NU,60.003637,-77.733327,Canada,CHS,"North Kopac Island , North Kopac Island"
-04550,"Povungnituk, QC",QC,60.0325,-77.279167,Canada,CHS,
-04575,"Inukjuak, QC",QC,58.445883,-78.101725,Canada,CHS,"Port Harrison, Inoucdjouac, Port Harrison, Inoucdjouac"
-04597,"Gillies Island, NU",NU,56.549195,-76.640285,Canada,CHS,
-04600,"Tukarak Island, NU",NU,56.316667,-78.833333,Canada,CHS,
-04604,"Belanger Island, NU",NU,56.132021,-76.707148,Canada,CHS,
-04610,"Innetalling Island, NU",NU,55.9,-79.066667,Canada,CHS,
-04620,"Flaherty Island, NU",NU,55.9,-79.616667,Canada,CHS,
-04628,"Sanikiluaq, NU",NU,56.624722,-79.224555,Canada,CHS,"Eskimo Harbour, Eskimo Harbour, Renouf Island"
-04645,"Kuujjuarapik, QC",QC,55.266667,-77.766667,Canada,CHS,"Great Whale, Poste-de-la-Baleine, POSTE-DE-LA-BALEINE, GREAT WHALE"
-04648,"Bear Island, NU",NU,55.1,-78.35,Canada,CHS,
-04655,"Long Island, NU",NU,54.766667,-79.733333,Canada,CHS,"Pointe Louis-XIV, POINTE LOUIS-XIV"
-04662,"Roggan River, QC",QC,54.390764,-79.492806,Canada,CHS,
-04680,"La Grande Riviere , QC",QC,53.85,-79.15,Canada,CHS,"Fort George River, Loon Point, Fort George River, Loon Point"
-04681,"Loon Island, NU",NU,53.814656,-79.170782,Canada,CHS,
-04688,"Hook Island, NU",NU,53.435327,-79.122359,Canada,CHS,
-04710,"Eastmain River, QC",QC,52.231944,-78.559777,Canada,CHS,
-04720,"Strutton Islands, NU",NU,52.083333,-78.95,Canada,CHS,
-04730,"Charlton Island, NU",NU,51.966667,-79.3,Canada,CHS,
-04740,"Stag Island, QC",QC,51.633333,-79.033333,Canada,CHS,
-04780,"Sand Head, ON",ON,51.416667,-80.35,Canada,CHS,
-04790,"Ship Sands Island, ON",ON,51.333333,-80.433333,Canada,CHS,
-04800,"Nicholson Creek, ON",ON,51.3,-80.566667,Canada,CHS,
-04810,"Moosonee, ON",ON,51.283333,-80.633333,Canada,CHS,Moosonee Gov't Wharf
-04840,"Fort Albany, ON",ON,52.218889,-81.635556,Canada,CHS,
-04880,"Bear Island, NU",NU,54.353333,-81.083333,Canada,CHS,
-04920,"Winisk, ON",ON,55.283333,-85.1,Canada,CHS,
-04980,"Port Nelson, MB",MB,57.0,-92.5,Canada,CHS,"Nelson, Nelson"
-05010,"Churchill, MB",MB,58.773429,-94.1919,Canada,CHS,
-05040,"Arviat, NU",NU,61.110005,-94.063663,Canada,CHS,"Eskimo Point, ESKIMO POINT"
-05055,"Whale Cove, NU",NU,62.166667,-92.566667,Canada,CHS,
-05070,"Marble Island, NU",NU,62.683333,-91.2,Canada,CHS,
-05090,"Panorama Island, NU",NU,62.79141,-92.094102,Canada,CHS,
-05100,"Rankin Inlet, NU",NU,62.816667,-92.066667,Canada,CHS,
-05140,"Chesterfield Inlet, NU",NU,63.329917,-90.684583,Canada,CHS,
-05141,"Akreavenek Island, NU",NU,63.417306,-90.6665,Canada,CHS,Sandpiper Island
-05159,"Norton Island, NU",NU,64.0,-94.216667,Canada,CHS,
-05160,"Chesterfield Narrows, NU",NU,63.991528,-94.302611,Canada,CHS,Ice Cutter Point
-05161,"Schooner Cove, NU",NU,63.989217,-94.2686,Canada,CHS,
-05180,"Coral Harbour, NU",NU,64.130451,-83.261479,Canada,CHS,
-05190,"Cape Dobbs, NU",NU,65.10061,-86.963472,Canada,CHS,
-05193,"Paliak Islands, NU",NU,65.386722,-89.045389,Canada,CHS,
-05195,"Bennett Bay, NU",NU,65.875333,-89.528639,Canada,CHS,
-05200,"Naujaat, NU",NU,66.519333,-86.307472,Canada,CHS,Repulse Bay
-05275,"Sanirajak, NU",NU,68.75,-81.216667,Canada,CHS,Hall Beach
-05295,"Igloolik, NU",NU,69.346283,-81.729617,Canada,CHS,
-05310,"Sevigny Point, NU",NU,69.783333,-82.116667,Canada,CHS,
-05330,"Purfur Cove, NU",NU,69.836361,-84.254,Canada,CHS,
-05350,"Entrance Island, NU",NU,69.9,-85.6,Canada,CHS,
-05358,"Needle Cove, NU",NU,69.090317,-79.112332,Canada,CHS,
-05430,"Dundas Harbour, NU",NU,74.52,-82.43,Canada,CHS,
-05490,"Rigby Bay, NU",NU,74.556667,-90.165667,Canada,CHS,
-05500,"Radstock Bay, NU",NU,74.706667,-91.03,Canada,CHS,
-05510,"Beechey Island, NU",NU,74.716667,-91.9,Canada,CHS,
-05560,"Resolute, NU",NU,74.655667,-94.875833,Canada,CHS,
-05600,"Cape Capel, NU",NU,75.031944,-98.083333,Canada,CHS,
-05615,"Hamilton Island, NU",NU,74.191667,-99.16,Canada,CHS,
-05643,"Natkusiak Peninsula, NT",NT,73.016667,-110.466667,Canada,CHS,
-05645,"Winter Harbour, NU",NU,74.783333,-110.8,Canada,CHS,"WINTER HARBOUR, N.W.T."
-05650,"Peel Point, NT",NT,73.266667,-115.183333,Canada,CHS,
-05790,"Koluktoo Bay, NU",NU,72.106564,-80.74431,Canada,CHS,"Navy Board Inlet, NAVY BOARD INLET"
-05795,"Pisiktarfik Island, NU",NU,72.576306,-80.35275,Canada,CHS,
-05800,"Pond Inlet, NU",NU,72.7,-77.966667,Canada,CHS,POND INLET (SITE)
-05860,"Strathcona Sound, NU",NU,73.069722,-84.548333,Canada,CHS,
-05865,"Arctic Bay, NU",NU,72.99271,-85.0619,Canada,CHS,
-05905,"Port Leopold, NU",NU,73.833333,-90.333333,Canada,CHS,
-05906,"Whaler Point, NU",NU,73.816666,-90.283333,Canada,CHS,
-05912,"Port Bowen, NU",NU,73.28,-89.041667,Canada,CHS,
-05917,"Bellot Strait East, NU",NU,72.016666,-94.333333,Canada,CHS,
-05918,"Fury Point, NU",NU,72.900002,-91.783333,Canada,CHS,
-05930,"Fort Ross, NU",NU,72.00802,-94.2165,Canada,CHS,
-05935,"Cape Kater, NU",NU,71.966666,-90.066666,Canada,CHS,
-05940,"Cape Augherston, NU",NU,71.3735,-93.01,Canada,CHS,
-05948,"Lavoie Islands, NU",NU,71.02,-87.6085,Canada,CHS,
-05960,"Martin Islands, NU",NU,70.316666,-91.666666,Canada,CHS,
-05970,"Crown Prince Frederik Island, NU",NU,69.99725,-87.1,Canada,CHS,
-05975,"Cape Chapman, NU",NU,69.27475,-89.24025,Canada,CHS,
-05976,"Cape Berens, NU",NU,69.066666,-90.633333,Canada,CHS,
-05978,"Cape Miles, NU",NU,69.333,-85.43175,Canada,CHS,
-05985,"Kugaaruk, NU",NU,68.52706,-89.848803,Canada,CHS,"Pelly Bay, Pelly Bay"
-05990,"Cape Sibbald, NU",NU,69.333333,-85.7667,Canada,CHS,
-05992,"Cape Barclay, NU",NU,68.233333,-88.133333,Canada,CHS,
-05998,"Dease Peninsula, NU",NU,67.266667,-87.15,Canada,CHS,
-06100,"False Strait, NU",NU,71.983333,-95.166667,Canada,CHS,
-06110,"Tasmania Island, NU",NU,71.2,-96.416667,Canada,CHS,
-06140,"Cape Felix, NU",NU,69.9465,-97.909639,Canada,CHS,
-06144,"Oscar Bay, NU",NU,69.7798,-95.833867,Canada,CHS,
-06150,"Taloyoak, NU",NU,69.529633,-93.536933,Canada,CHS,"Spence Bay, SPENCE BAY"
-06160,"Shepherd Bay, NU",NU,68.76667,-93.566666,Canada,CHS,
-06170,"Gjoa Haven, NU",NU,68.617208,-95.888139,Canada,CHS,
-06210,"Gladman Point, NU",NU,68.648444,-97.737444,Canada,CHS,
-06213,"Island NE of M'Clintock Point, NU",NU,69.348617,-99.963433,Canada,CHS,Racon Island
-06225,"Jenny Lind Island, NU",NU,68.653333,-101.756667,Canada,CHS,
-06230,"Kean Point, NU",NU,68.955,-102.361667,Canada,CHS,"Kean Point, Victoria Island"
-06240,"Cambridge Bay, NU",NU,69.116667,-105.066667,Canada,CHS,
-06250,"Baychimo, NU",NU,67.698,-107.9325,Canada,CHS,
-06255,"Quadyuk Island, NU",NU,66.91575,-107.8125,Canada,CHS,
-06284,"Austin Bay, NU",NU,68.5335,-113.300528,Canada,CHS,
-06285,"Black Berry Island, NU",NU,68.240483,-113.335983,Canada,CHS,
-06290,"Kugluktuk, NU",NU,67.879417,-115.217944,Canada,CHS,"Coppermine, COPPERMINE"
-06310,"Bernard Harbour, NU",NU,68.784,-114.7585,Canada,CHS,
-06338,"Tysoe Point, NU",NU,69.616667,-120.783333,Canada,CHS,
-06340,"Pearce Point, NT",NT,69.816389,-122.666667,Canada,CHS,
-06350,"Paulatuk, NT",NT,69.35,-124.066667,Canada,CHS,
-06360,"Cape Parry, NT",NT,70.15,-124.666667,Canada,CHS,
-06367,"Franklin Bay, NT",NT,69.95,-126.916667,Canada,CHS,
-06380,"Ulukhaktok, NT",NT,70.736528,-117.756278,Canada,CHS,Holman
-06424,"Sachs Harbour, NT",NT,71.966667,-125.25,Canada,CHS,
-06443,"Baillie Is. (South Spit), NT",NT,70.516667,-128.35,Canada,CHS,
-06457,"Krubluyak Point, NT",NT,69.533333,-130.95,Canada,CHS,"Eskimo Lakes (Entrance), ESKIMO LAKES, Eskimo Lakes (Entrance)"
-06472,"Cape Dalhousie, NT",NT,70.266667,-129.65,Canada,CHS,
-06476,"Atkinson Point, NT",NT,69.95,-131.416667,Canada,CHS,
-06485,"Tuktoyaktuk, NT",NT,69.438226,-132.994402,Canada,CHS,
-06495,"Hooper Island, YT",YT,69.683333,-134.833333,Canada,CHS,
-06497,"Pelly Island, NT",NT,69.616667,-135.366667,Canada,CHS,
-06505,"Shingle Point, YT",YT,68.933333,-137.2,Canada,CHS,
-06515,"Kay Point, YT",YT,69.283333,-138.433333,Canada,CHS,
-06525,"Herschel Island, YT",YT,69.570328,-138.924608,Canada,CHS,
-06560,"Cape Skogn, NU",NU,75.763889,-84.216111,Canada,CHS,
-06570,"Grise Fiord, NU",NU,76.41966,-83.133067,Canada,CHS,
-06580,"Bay of Woe, NU",NU,76.416667,-89.016667,Canada,CHS,"BAY OF WOE, JONES SD."
-06640,"Eureka, NU",NU,79.985067,-85.908967,Canada,CHS,
-06660,"Iceberg Point, NU",NU,80.416667,-86.166667,Canada,CHS,
-06670,"Greely Fiord, NU",NU,80.6,-79.583333,Canada,CHS,
-06680,"Tanquary Camp, NU",NU,81.4,-76.916667,Canada,CHS,
-06704,"Kleybolte Peninsula, NU",NU,81.55,-91.55,Canada,CHS,
-06730,"Disreali Fiord, NU",NU,82.883333,-73.5,Canada,CHS,
-06735,"Cape Aldrich, NU",NU,83.116667,-69.666667,Canada,CHS,
-06758,"Little Cornwallis Island, NU",NU,75.383333,-96.95,Canada,CHS,"Polaris Mine, POLARIS MINE"
-06765,"Airstrip Point, NU",NU,76.070241,-97.590035,Canada,CHS,"Penny Strait, PENNY STRAIT"
-06780,"Northumberland Sound, NU",NU,76.866667,-96.7,Canada,CHS,
-06787,"Cameron Island, NU",NU,76.316666,-104.033333,Canada,CHS,
-06910,"Isachsen, NU",NU,78.780055,-103.507806,Canada,CHS,
-06955,"Mould Bay, NU",NU,76.283333,-119.466667,Canada,CHS,
-07010,"Point No Point, BC",BC,48.3951,-123.9709,Canada,CHS,
-07013,"Sheringham Point, BC",BC,48.377066,-123.921166,Canada,CHS,
-07020,"Sooke, BC",BC,48.3695,-123.726,Canada,CHS,
-07024,"Sooke Basin, BC",BC,48.3742,-123.6818,Canada,CHS,
-07030,"Becher Bay, BC",BC,48.3349,-123.6038,Canada,CHS,
-07080,"Pedder Bay, BC",BC,48.3317,-123.5501,Canada,CHS,
-07082,"William Head, BC",BC,48.341,-123.5369,Canada,CHS,
-07109,"Esquimalt Harbour, BC",BC,48.440433,-123.449833,Canada,CHS,
-07110,"Esquimalt Government  Hbr., BC",BC,48.432166,-123.438533,Canada,CHS,
-07115,"Clover Point, BC",BC,48.403816,-123.3486,Canada,CHS,
-07120,"Victoria Harbour, BC",BC,48.424363,-123.370828,Canada,CHS,
-07121,"Selkirk Water, BC",BC,48.439277,-123.379472,Canada,CHS,
-07122,"Gorge at Aaron Point, BC",BC,48.4444,-123.3952,Canada,CHS,
-07123,"Gorge at Tillicum, BC",BC,48.44775,-123.403583,Canada,CHS,
-07124,"Gorge at Craigflower, BC",BC,48.4509,-123.4215,Canada,CHS,
-07125,"Portage Inlet, BC",BC,48.4571,-123.4166,Canada,CHS,
-07130,"Oak Bay, BC",BC,48.4237,-123.3027,Canada,CHS,
-07140,"Finnerty Cove, BC",BC,48.473583,-123.296083,Canada,CHS,
-07255,"Saanichton Bay, BC",BC,48.5989,-123.3885,Canada,CHS,
-07260,"Sidney, BC",BC,48.649216,-123.3929,Canada,CHS,
-07270,"Swartz Bay, BC",BC,48.6892,-123.4108,Canada,CHS,
-07277,"Patricia Bay, BC",BC,48.6536,-123.4515,Canada,CHS,
-07280,"Brentwood Bay, BC",BC,48.578,-123.467,Canada,CHS,
-07284,"Finlayson Arm, BC",BC,48.4966,-123.5529,Canada,CHS,
-07310,"Cowichan Bay, BC",BC,48.7404,-123.6184,Canada,CHS,
-07315,"Maple Bay, BC",BC,48.8157,-123.60961,Canada,CHS,
-07330,"Fulford Harbour, BC",BC,48.769,-123.451,Canada,CHS,
-07345,"Narvaez Bay, BC",BC,48.7743,-123.0981,Canada,CHS,
-07350,"Bedwell Harbour, BC",BC,48.7478,-123.2273,Canada,CHS,
-07360,"Hope Bay, BC",BC,48.8034,-123.2759,Canada,CHS,
-07370,"Samuel Island, BC",BC,48.8217,-123.2084,Canada,CHS,
-07407,"Ganges, BC",BC,48.8534,-123.4973,Canada,CHS,
-07414,"Village Bay, BC",BC,48.8445,-123.3241,Canada,CHS,
-07420,"Montague Harbour, BC",BC,48.8927,-123.3922,Canada,CHS,
-07435,"North Galiano, BC",BC,48.9947,-123.5839,Canada,CHS,
-07437,"Porlier Pass, BC",BC,49.0113,-123.5859,Canada,CHS,
-07439,"Cardale Point, BC",BC,49.016667,-123.616667,Canada,CHS,
-07445,"Degnen Bay, BC",BC,49.133333,-123.716667,Canada,CHS,
-07450,"Crofton, BC",BC,48.874583,-123.643516,Canada,CHS,
-07455,"Chemainus, BC",BC,48.9256,-123.7144,Canada,CHS,
-07460,"Ladysmith, BC",BC,48.99895,-123.815316,Canada,CHS,
-07471,"Preedy Harbour, BC",BC,48.9802,-123.6777,Canada,CHS,
-07480,"Boat Harbour, BC",BC,49.09,-123.7982,Canada,CHS,
-07510,"Tumbo Channel, BC",BC,48.7932,-123.1088,Canada,CHS,
-07515,"Samuel Island, BC",BC,48.816667,-123.2,Canada,CHS,
-07525,"Georgina Point, BC",BC,48.8725,-123.2923,Canada,CHS,
-07528,"Miners Bay, BC",BC,48.85,-123.3,Canada,CHS,
-07532,"Whaler Bay, BC",BC,48.883333,-123.316667,Canada,CHS,
-07535,"Dionisio Point, BC",BC,49.0139,-123.5739,Canada,CHS,
-07542,"Valdes Island, BC",BC,49.058,-123.62,Canada,CHS,
-07550,"Silva Bay, BC",BC,49.15,-123.7,Canada,CHS,
-07577,"White Rock, BC",BC,49.016667,-122.8,Canada,CHS,
-07579,"Crescent Beach, BC",BC,49.033333,-122.883333,Canada,CHS,
-07590,"Tsawwassen, BC",BC,49.00677,-123.12933,Canada,CHS,
-07592,"Roberts Bank, BC",BC,49.015,-123.156,Canada,CHS,
-07594,"Sand Heads, BC",BC,49.1052,-123.3042,Canada,CHS,
-07607,"Steveston, BC",BC,49.1245,-123.1922,Canada,CHS,
-07609,"Deas Basin, BC",BC,49.1239,-123.083419,Canada,CHS,
-07610,"Woodward's Landing, BC",BC,49.1251,-123.0754,Canada,CHS,
-07654,"New Westminster, BC",BC,49.2,-122.91,Canada,CHS,
-07707,"Kitsilano, BC",BC,49.276583,-123.13936,Canada,CHS,
-07710,"False Creek, BC",BC,49.271,-123.12,Canada,CHS,
-07724,"Calamity Point, BC",BC,49.31257,-123.127678,Canada,CHS,
-07735,"Vancouver, BC",BC,49.2863,-123.0997,Canada,CHS,
-07755,"Port Moody, BC",BC,49.2877,-122.86583,Canada,CHS,
-07765,"Deep Cove, BC",BC,49.32683,-122.9485,Canada,CHS,
-07774,"Indian Arm Head, BC",BC,49.4618,-122.8861,Canada,CHS,
-07780,"Ambleside, BC",BC,49.32577,-123.15458,Canada,CHS,
-07786,"Sandy Cove, BC",BC,49.3405,-123.2319,Canada,CHS,"West Vancouver Laboratories, Ettershank Cove"
-07795,"Point Atkinson, BC",BC,49.3375,-123.253583,Canada,CHS,Caulfeild Cove
-07803,"Port Mellon, BC",BC,49.519233,-123.485311,Canada,CHS,
-07808,"Darrell Bay, BC",BC,49.669,-123.169,Canada,CHS,
-07811,"Squamish Inner, BC",BC,49.695,-123.155,Canada,CHS,
-07820,"Gibsons, BC",BC,49.402,-123.505,Canada,CHS,
-07824,"Roberts Creek, BC",BC,49.419,-123.642,Canada,CHS,
-07830,"Halfmoon Bay, BC",BC,49.511,-123.912,Canada,CHS,
-07836,"Irvines Landing, BC",BC,49.633,-124.058,Canada,CHS,
-07837,"ḵalpilin, BC",BC,49.633,-124.032,Canada,CHS,Pender Harbour
-07842,"Egmont, BC",BC,49.749,-123.93,Canada,CHS,
-07843,"Boom Islet, BC",BC,49.745223,-123.903803,Canada,CHS,
-07847,"Storm Bay, BC",BC,49.662,-123.826,Canada,CHS,
-07852,"Porpoise Bay, BC",BC,49.482,-123.759,Canada,CHS,
-07860,"Malibu Islet, BC",BC,50.163,-123.85,Canada,CHS,
-07865,"Blind Bay, BC",BC,49.716,-124.179,Canada,CHS,"Ballet Bay, Ballet Bay"
-07868,"Saltery Bay, BC",BC,49.783333,-124.183333,Canada,CHS,
-07875,"Blubber Bay, BC",BC,49.8,-124.616667,Canada,CHS,
-07880,"Powell River, BC",BC,49.866667,-124.55,Canada,CHS,
-07885,"Lund, BC",BC,49.983333,-124.766667,Canada,CHS,
-07892,"Twin Islands, BC",BC,50.03,-124.93,Canada,CHS,
-07895,"Mitlenatch, BC",BC,49.95,-124.998,Canada,CHS,
-07913,"Harmac, BC",BC,49.14,-123.846,Canada,CHS,
-07917,"Nanaimo Harbour, BC",BC,49.1628,-123.9235,Canada,CHS,Port of Nanaimo
-07930,"Nanoose Bay, BC",BC,49.25,-124.17,Canada,CHS,"Nanoose Harbour, B.C., Nanoose Harbour, B.C."
-07935,"Winchelsea Island, BC",BC,49.3,-124.086,Canada,CHS,
-07938,"Northwest Bay, BC",BC,49.303,-124.202,Canada,CHS,
-07940,"French Creek, BC",BC,49.349604,-124.358817,Canada,CHS,
-07953,"Hornby Island, BC",BC,49.49623,-124.676,Canada,CHS,"Ford Cove, B.C."
-07955,"Denman Island, BC",BC,49.53448,-124.8209,Canada,CHS,
-07965,"Comox, BC",BC,49.67,-124.928,Canada,CHS,
-07982,"False Bay, BC",BC,49.483,-124.35,Canada,CHS,
-07985,"Skerry Bay, BC",BC,49.5,-124.237,Canada,CHS,
-07990,"Welcome Bay, BC",BC,49.7,-124.55,Canada,CHS,
-07993,"Little River, BC",BC,49.741,-124.923,Canada,CHS,
-08006,"Okeover Inlet, BC",BC,49.98,-124.7,Canada,CHS,
-08008,"Prideaux Haven, BC",BC,50.15,-124.67,Canada,CHS,
-08015,"Channel Island, BC",BC,50.316667,-124.75,Canada,CHS,
-08025,"Redonda Bay, BC",BC,50.2604833,-124.95532,Canada,CHS,
-08035,"Heriot Bay, BC",BC,50.1,-125.2,Canada,CHS,
-08037,"Gorge Harbour, BC",BC,50.092,-124.989,Canada,CHS,
-08038,"Whaletown, BC",BC,50.108,-125.052,Canada,CHS,
-08045,"Surge Narrows, BC",BC,50.22719,-125.112,Canada,CHS,
-08050,"Octopus Islands, BC",BC,50.282,-125.224,Canada,CHS,
-08055,"Florence Cove, BC",BC,50.313,-125.165,Canada,CHS,
-08060,"Big Bay, Stuart Island, BC",BC,50.393,-125.13525,Canada,CHS,
-08065,"Orford Bay, BC",BC,50.597969,-124.864385,Canada,CHS,
-08069,"Waddington Harbour, BC",BC,50.873,-124.873,Canada,CHS,
-08074,"Campbell River, BC",BC,50.042,-125.247,Canada,CHS,
-08079,"Quathiaski Cove, BC",BC,50.047,-125.218,Canada,CHS,
-08082,"Gowlland Hbr., BC",BC,50.065,-125.217,Canada,CHS,
-08087,"Duncan Bay, BC",BC,50.076,-125.301,Canada,CHS,
-08095,"Bloedel - Menzies Bay, BC",BC,50.118,-125.381,Canada,CHS,
-08105,"Seymour Narrows, BC",BC,50.135,-125.346,Canada,CHS,
-08110,"Brown Bay, BC",BC,50.162,-125.375,Canada,CHS,
-08120,"Owen Bay, BC",BC,50.31045,-125.22343,Canada,CHS,
-08135,"Mermaid Bay, BC",BC,50.404,-125.1854,Canada,CHS,
-08142,"Thurlow Point, BC",BC,50.42016,-125.32823,Canada,CHS,
-08145,"Shoal Bay, BC",BC,50.46,-125.361,Canada,CHS,
-08150,"Cordero Islands, BC",BC,50.442,-125.492,Canada,CHS,
-08155,"Blind Channel, BC",BC,50.414,-125.502,Canada,CHS,
-08162,"Sidney Bay, BC",BC,50.516667,-125.583333,Canada,CHS,
-08180,"Chatham Pt., BC",BC,50.331,-125.442,Canada,CHS,
-08195,"Knox Bay, BC",BC,50.387,-125.619,Canada,CHS,
-08210,"Billy Goat Bay, BC",BC,50.398,-125.865,Canada,CHS,
-08215,"Kelsey Bay, BC",BC,50.398,-125.961,Canada,CHS,
-08233,"Yorke Island, BC",BC,50.444,-125.978,Canada,CHS,
-08245,"Port Neville, BC",BC,50.496,-126.087,Canada,CHS,
-08250,"Port Harvey, BC",BC,50.568,-126.268,Canada,CHS,
-08258,"Lagoon Cove, BC",BC,50.597716,-126.31895,Canada,CHS,
-08270,"Growler Cove, BC",BC,50.53,-126.62,Canada,CHS,
-08280,"Alert Bay, BC",BC,50.587,-126.931,Canada,CHS,
-08290,"Port McNeill, BC",BC,50.593,-127.094,Canada,CHS,
-08310,"Glendale Cove, BC",BC,50.674293,-125.736856,Canada,CHS,
-08311,"Siwash Bay, BC",BC,50.687166,-125.76065,Canada,CHS,
-08313,"Montagu Point, BC",BC,50.63908,-126.21283,Canada,CHS,
-08318,"Shewell Island, BC",BC,50.65833,-126.239167,Canada,CHS,
-08325,"Cedar Island, BC",BC,50.656667,-126.675,Canada,CHS,
-08340,"Sunday Harbour, BC",BC,50.72,-126.7,Canada,CHS,
-08347,"Kwatsi Bay, BC",BC,50.8643,-126.2486,Canada,CHS,
-08348,"Kingcome Inlet, BC",BC,50.908717,-126.19945,Canada,CHS,
-08364,"Sullivan Bay, BC",BC,50.886,-126.826,Canada,CHS,
-08371,"Jessie Point, BC",BC,50.951,-126.812,Canada,CHS,
-08379,"Stuart Narrows, BC",BC,50.897,-126.896,Canada,CHS,
-08384,"Jennis Bay, BC",BC,50.913,-127.026,Canada,CHS,
-08394,"Raynor Group, BC",BC,50.886,-127.243,Canada,CHS,
-08408,"Port Hardy, BC",BC,50.722,-127.489,Canada,CHS,
-08416,"Shushartie Bay, BC",BC,50.856,-127.859,Canada,CHS,
-08426,"Walker Group, BC",BC,50.899,-127.526,Canada,CHS,
-08438,"Fox Islands, BC",BC,51.081,-127.604,Canada,CHS,
-08440,"Treadwell Bay, BC",BC,51.103,-127.541,Canada,CHS,
-08458,"Frederick Sound, BC",BC,51.04,-126.734,Canada,CHS,
-08464,"Nugent Sound, BC",BC,51.083333,-127.25,Canada,CHS,
-08470,"Johnson Point, BC",BC,51.11,-127.537,Canada,CHS,
-08476,"Mereworth Sound, BC",BC,51.176,-127.409,Canada,CHS,"Village Cove, B.C., Village Cove, B.C."
-08482,"Belize Inlet, BC",BC,51.122,-127.274,Canada,CHS,
-08488,"Alison Sound, BC",BC,51.161,-126.982,Canada,CHS,
-08525,"Port Renfrew, BC",BC,48.555,-124.421,Canada,CHS,
-08545,"Bamfield, BC",BC,48.836,-125.136,Canada,CHS,
-08556,"Mutine Point, BC",BC,48.942,-125.019,Canada,CHS,
-08558,"Brooksby Point, BC",BC,48.982,-124.985,Canada,CHS,
-08559,"Head of Uchucklesit, BC",BC,49.016667,-125.05,Canada,CHS,
-08565,"Franklin River, BC",BC,49.108,-124.812,Canada,CHS,
-08575,"Port Alberni, BC",BC,49.225621,-124.813613,Canada,CHS,
-08585,"Effingham Bay, BC",BC,48.878,-125.313,Canada,CHS,
-08588,"Stopper Islands, BC",BC,48.993,-125.346,Canada,CHS,
-08595,"Ucluelet, BC",BC,48.947,-125.552,Canada,CHS,
-08615,"Tofino, BC",BC,49.154,-125.913,Canada,CHS,"Clayoquot , CLAYOQUOT"
-08623,"Kennedy Cove, BC",BC,49.14,-125.671,Canada,CHS,
-08626,"Warn Bay, BC",BC,49.238868,-125.745536,Canada,CHS,
-08630,"Cypress Bay, BC",BC,49.261,-125.871,Canada,CHS,
-08632,"Herbert Inlet, BC",BC,49.346,-125.984,Canada,CHS,
-08634,"Sulphur Passage, BC",BC,49.404,-126.068,Canada,CHS,
-08637,"Riley Cove, BC",BC,49.391,-126.225,Canada,CHS,
-08645,"Saavedra Islands, BC",BC,49.622,-126.617,Canada,CHS,
-08650,"Gold River, BC",BC,49.679,-126.126,Canada,CHS,
-08664,"Ceepeecee, BC",BC,49.874,-126.716,Canada,CHS,
-08665,"Esperanza, BC",BC,49.872,-126.744,Canada,CHS,
-08670,"Zeballos, BC",BC,49.979,-126.846,Canada,CHS,
-08710,"Kyuquot, BC",BC,50.026,-127.376,Canada,CHS,
-08714,"Copp Island, BC",BC,50.045938,-127.190348,Canada,CHS,
-08715,"Fair Harbour, BC",BC,50.068867,-127.138867,Canada,CHS,
-08720,"Bunsby Islands, BC",BC,50.11756,-127.5096,Canada,CHS,
-08735,"Winter Harbour, BC",BC,50.513,-128.029,Canada,CHS,
-08736,"Hunt Islet, BC",BC,50.474,-128.03,Canada,CHS,
-08750,"Port Alice, BC",BC,50.384,-127.455,Canada,CHS,
-08751,"Port Alice South, BC",BC,50.41101,-127.48592,Canada,CHS,
-08754,"Bergh Cove, BC",BC,50.537,-127.624,Canada,CHS,
-08755,"Kwokwesta Creek, BC",BC,50.527,-127.569,Canada,CHS,
-08756,"Makwazniht Island, BC",BC,50.556,-127.554,Canada,CHS,
-08765,"Coal Harbour, BC",BC,50.599,-127.581,Canada,CHS,
-08790,"Cape Scott, BC",BC,50.78,-128.43,Canada,CHS,
-08805,"Egg Island, BC",BC,51.249,-127.836,Canada,CHS,
-08810,"Leroy Bay, BC",BC,51.273,-127.664,Canada,CHS,
-08812,"Boswell Inlet, BC",BC,51.372,-127.469,Canada,CHS,Security Bay
-08814,"Smith Inlet, BC",BC,51.336,-127.188,Canada,CHS,
-08830,"Draney Inlet, BC",BC,51.476,-127.551,Canada,CHS,
-08840,"Wadhams, BC",BC,51.51,-127.524,Canada,CHS,
-08860,"Addenbroke Island, BC",BC,51.605,-127.826,Canada,CHS,
-08863,"Pruth Bay, BC",BC,51.654504,-128.129455,Canada,CHS,
-08865,"Adams Harbour, BC",BC,51.683333,-128.1,Canada,CHS,
-08866,"Starfish Island, BC",BC,51.686,-128.123,Canada,CHS,
-08870,"Namu, BC",BC,51.86153,-127.8657,Canada,CHS,
-08906,"Gosling Island, BC",BC,51.899,-128.442,Canada,CHS,
-08909,"Goose Island, BC",BC,51.992,-128.413,Canada,CHS,
-08912,"Spider Island, BC",BC,51.845,-128.231,Canada,CHS,
-08917,"Stryker Island, BC",BC,52.093,-128.348,Canada,CHS,
-08922,"Joassa Channel, BC",BC,52.192,-128.309,Canada,CHS,
-08932,"Larso Bay, BC",BC,52.179,-126.862,Canada,CHS,
-08937,"Bella Coola, BC",BC,52.374,-126.796,Canada,CHS,
-08941,"Labouchere Channel East, BC",BC,52.3829,-127.20847,Canada,CHS,
-08952,"Luke Passage, BC",BC,52.095,-127.853,Canada,CHS,
-08958,"Forit Bay, BC",BC,52.174,-127.91,Canada,CHS,
-08962,"Ocean Falls, BC",BC,52.352,-127.693,Canada,CHS,
-08970,"Kimsquit Channel, BC",BC,52.814,-127.001,Canada,CHS,
-08976,"Bella Bella, BC",BC,52.163,-128.143,Canada,CHS,
-08978,"Kynumpt Harbour, BC",BC,52.208,-128.162,Canada,CHS,
-08981,"Troup Passage, BC",BC,52.242,-128.039,Canada,CHS,
-08996,"Gerald Point, BC",BC,52.438,-128.084,Canada,CHS,
-08998,"Thompson Bay, BC",BC,52.16,-128.358,Canada,CHS,
-09005,"Port Blackney, BC",BC,52.312,-128.351,Canada,CHS,
-09010,"Tom Bay, BC",BC,52.402,-128.264,Canada,CHS,
-09020,"Griffin Passage, BC",BC,52.77,-128.346,Canada,CHS,
-09035,"Klemtu, BC",BC,52.594,-128.521,Canada,CHS,
-09051,"Cann Inlet, BC",BC,52.547181,-128.695281,Canada,CHS,
-09052,"Marvin Island, BC",BC,52.529639,-128.73885,Canada,CHS,
-09053,"Butedale, BC",BC,53.16,-128.694,Canada,CHS,
-09056,"Higgins Passage, BC",BC,52.483,-128.762,Canada,CHS,
-09058,"Price Island, BC",BC,52.278,-128.675,Canada,CHS,
-09060,"Meyers Narrows, BC",BC,52.604,-128.617,Canada,CHS,
-09063,"Milne Island, BC",BC,52.609,-128.769,Canada,CHS,
-09067,"Smithers Island, BC",BC,52.758,-129.073,Canada,CHS,
-09077,"McKenney Isl., BC",BC,52.65,-129.472,Canada,CHS,
-09078,"Moore Islands, BC",BC,52.673,-129.408,Canada,CHS,
-09080,"Borrowman Bay, BC",BC,52.737,-129.281,Canada,CHS,
-09082,"Beauchemin Channel, BC",BC,52.77758,-129.303048,Canada,CHS,
-09105,"Gillen Harbour, BC",BC,52.964,-129.606,Canada,CHS,
-09115,"Barnard Harbour, BC",BC,53.074,-129.117,Canada,CHS,
-09130,"Hartley Bay, BC",BC,53.424213,-129.251877,Canada,CHS,
-09140,"Kitimat, BC",BC,53.989,-128.696,Canada,CHS,
-09150,"Kemano Bay, BC",BC,53.478,-128.124,Canada,CHS,
-09163,"Oswald Bay, BC",BC,53.012917,-129.664639,Canada,CHS,
-09165,"Block Islands, BC",BC,53.157,-129.741,Canada,CHS,
-09180,"Patterson Inlet, BC",BC,53.4383,-129.8442,Canada,CHS,
-09195,"Lowe Inlet, BC",BC,53.55,-129.583333,Canada,CHS,
-09220,"Clear Passage, BC",BC,53.551,-129.964,Canada,CHS,
-09227,"Bonilla Island, BC",BC,53.493806,-130.636972,Canada,CHS,
-09230,"Griffith Harbour, BC",BC,53.599,-130.543,Canada,CHS,
-09232,"Larsen Island, BC",BC,53.619,-130.574,Canada,CHS,
-09242,"Kitkatla, BC",BC,53.803,-130.357,Canada,CHS,
-09250,"Seabreeze Point, BC",BC,53.987,-130.182,Canada,CHS,
-09260,"Claxton, BC",BC,54.079,-130.089,Canada,CHS,
-09266,"Haysport, BC",BC,54.178,-130.009,Canada,CHS,
-09275,"Khyex River, BC",BC,54.223,-129.8,Canada,CHS,
-09285,"Kwinitsa River, BC",BC,54.216667,-129.583333,Canada,CHS,
-09305,"Welcome Harbour, BC",BC,54.016667,-130.616667,Canada,CHS,
-09306,"Refuge Bay, BC",BC,54.053,-130.541,Canada,CHS,
-09309,"Humpback Bay, BC",BC,54.087,-130.395,Canada,CHS,
-09310,"Hunt Inlet, BC",BC,54.068,-130.446,Canada,CHS,
-09312,"Lawyer Islands, BC",BC,54.105,-130.334,Canada,CHS,
-09315,"Qlawdzeet Anchorage, BC",BC,54.208,-130.768,Canada,CHS,
-09325,"Moffatt Islands, BC",BC,54.446,-130.726,Canada,CHS,
-09329,"Hudson Bay Passage, BC",BC,54.457,-130.848,Canada,CHS,
-09333,"Brundige Inlet, BC",BC,54.613,-130.854,Canada,CHS,
-09338,"Aero Trading, BC",BC,54.212997,-130.288383,Canada,CHS,Aero Trading
-09339,"Pembina Terminal, BC",BC,54.236287,-130.303479,Canada,CHS,
-09340,"Inverness, BC",BC,54.194,-130.2249,Canada,CHS,
-09341,"Porpoise Channel East, BC",BC,54.21515,-130.28906,Canada,CHS,
-09342,"Port Edward, BC",BC,54.229,-130.296,Canada,CHS,
-09343,"Wainwright Basin, BC",BC,54.256216,-130.265239,Canada,CHS,
-09344,"Morse Basin, BC",BC,54.258319,-130.237624,Canada,CHS,
-09345,"Prince Rupert Grain, BC",BC,54.232778,-130.335875,Canada,CHS,
-09346,"Prince Rupert RoRo, BC",BC,54.234885,-130.335097,Canada,CHS,
-09348,"Fairview Terminal, BC",BC,54.290263,-130.359937,Canada,CHS,
-09350,"Casey Cove, BC",BC,54.279,-130.376,Canada,CHS,
-09354,"Prince Rupert, BC",BC,54.317,-130.324,Canada,CHS,
-09360,"Seal Cove, BC",BC,54.3311,-130.2796,Canada,CHS,
-09390,"Lax Kw'alaams, BC",BC,54.56,-130.431,Canada,CHS,Port Simpson
-09406,"Trail Bay, BC",BC,54.583,-130.357,Canada,CHS,
-09414,"Kumeon Bay, BC",BC,54.713,-130.24,Canada,CHS,
-09418,"Ranger Islet, BC",BC,54.837,-130.175,Canada,CHS,
-09422,"Gingolx, BC",BC,54.999,-129.978,Canada,CHS,Kincolith
-09425,"Mill Bay, BC",BC,54.994,-129.891,Canada,CHS,
-09435,"Salmon Cove, BC",BC,55.264,-129.846,Canada,CHS,
-09443,"Granby Bay, BC",BC,55.416,-129.818,Canada,CHS,
-09448,"Alice Arm, BC",BC,55.47,-129.496,Canada,CHS,
-09475,"Stewart, BC",BC,55.9166,-130.01,Canada,CHS,
-09502,"Cape St. James, BC",BC,51.938,-131.015,Canada,CHS,
-09511,"Houston Stewart Channel West, BC",BC,52.083333,-131.116667,Canada,CHS,Houston Stewart
-09512,"Gordon Islands, BC",BC,52.095,-131.141,Canada,CHS,
-09570,"Hunger Harbour, BC",BC,52.766,-132.047,Canada,CHS,
-09581,"Mudge Inlet, BC",BC,52.9619,-132.1218,Canada,CHS,
-09582,"Peel Inlet, BC",BC,52.98039,-132.10108,Canada,CHS,
-09583,"Leopold Island, BC",BC,52.98692,-132.17061,Canada,CHS,
-09585,"Security Cove, BC",BC,53.05647,-132.29061,Canada,CHS,
-09605,"Armentieres Channel, BC",BC,53.115,-132.389,Canada,CHS,
-09625,"Trounce Inlet, BC",BC,53.148,-132.322,Canada,CHS,
-09627,"Trounce Inlet North, BC",BC,53.15835,-132.32274,Canada,CHS,
-09635,"Dawson Harbour, BC",BC,53.166667,-132.466667,Canada,CHS,
-09650,"Shields Bay, BC",BC,53.313,-132.417,Canada,CHS,
-09667,"Nesto Inlet, BC",BC,53.55,-132.916667,Canada,CHS,
-09671,"Port Louis, BC",BC,53.685,-132.961,Canada,CHS,
-09708,"Heater Harbour, BC",BC,52.116667,-131.033333,Canada,CHS,
-09710,"High Island, BC",BC,52.124,-131.011,Canada,CHS,
-09713,"Rose Harbour, BC",BC,52.1552,-131.0909,Canada,CHS,
-09717,"Carpenter Bay, BC",BC,52.24,-131.156,Canada,CHS,
-09724,"Copper Islands, BC",BC,52.36,-131.181,Canada,CHS,
-09746,"Ramsay Island, BC",BC,52.583762,-131.378091,Canada,CHS,
-09753,"Sedgwick Bay, BC",BC,52.636,-131.583,Canada,CHS,
-09765,"Atli Inlet, BC",BC,52.714,-131.577,Canada,CHS,
-09775,"Pacofi Bay, BC",BC,52.832,-131.883,Canada,CHS,
-09781,"Louise Island, BC",BC,52.94128,-131.89934,Canada,CHS,
-09790,"McCoy Cove, BC",BC,53.041,-131.664,Canada,CHS,
-09795,"Sandspit Marina, BC",BC,53.237626,-131.863064,Canada,CHS,
-09808,"Shingle Bay, BC",BC,53.254,-131.822,Canada,CHS,
-09850,"Daajing Giids, BC",BC,53.252,-132.072,Canada,CHS,Queen Charlotte City
-09860,"Tlell, BC",BC,53.5517,-131.9078,Canada,CHS,
-09881,"Cape Ball, BC",BC,53.718333,-131.735,Canada,CHS,
-09910,"Masset, BC",BC,54.01,-132.149,Canada,CHS,
-09920,"Port Clements, BC",BC,53.6893,-132.184,Canada,CHS,
-09927,"Juskatla Inlet, BC",BC,53.628,-132.319,Canada,CHS,
-09930,"Dinan Bay, BC",BC,53.694094,-132.606175,Canada,CHS,
-09940,"Wiah Point, BC",BC,54.112,-132.31,Canada,CHS,
-09958,"Henslung Cove, BC",BC,54.191,-133.002,Canada,CHS,"Parry Passage, B.C., Parry Passage, B.C."
-09961,"Egeria Bay, BC",BC,54.216667,-132.966667,Canada,CHS,"Cohoe Pt., Egeria Bay"
-09963,"McPherson Point, BC",BC,54.247,-132.98,Canada,CHS,
-09964,"Langara Point, BC",BC,54.256,-133.045,Canada,CHS,
+station_id,place_name,province,latitude,longitude,country,api_source,alternative_name,timezone
+00001,"Outer Wood Island, NB",NB,44.606836,-66.818208,Canada,CHS,,America/Moncton
+00005,"Seal Cove, NB",NB,44.648709,-66.839677,Canada,CHS,,America/Moncton
+00007,"Gannet Rock, NB",NB,44.510712,-66.781717,Canada,CHS,,America/Moncton
+00010,"North Head, NB",NB,44.763118,-66.749,Canada,CHS,,America/Moncton
+00015,"Welshpool, NB",NB,44.888903,-66.957557,Canada,CHS,,America/Moncton
+00020,"Wilsons Beach, NB",NB,44.93183,-66.940664,Canada,CHS,,America/Moncton
+00021,"East Quoddy Head, NB",NB,44.958056,-66.900556,Canada,CHS,,America/Moncton
+00025,"Fairhaven, NB",NB,44.964381,-67.007419,Canada,CHS,,America/Moncton
+00028,"McMaster Island, NB",NB,45.054307,-66.930853,Canada,CHS,,America/Moncton
+00029,"Matthews Cove, NB",NB,45.052007,-66.894529,Canada,CHS,,America/Moncton
+00030,"Letite Harbour, NB",NB,45.055804,-66.864833,Canada,CHS,"Letite, Black Bay, Back Bay",America/Moncton
+00033,"Letang Harbour, NB",NB,45.084553,-66.783714,Canada,CHS,,America/Moncton
+00035,"St. Stephen, NB",NB,45.191916,-67.276017,Canada,CHS,,America/Moncton
+00040,"St. Andrews, NB",NB,45.0822524,-67.0845247,Canada,CHS,,America/Moncton
+00041,"Long Island, NB",NB,45.149561,-66.961084,Canada,CHS,,America/Moncton
+00042,"Blacks Harbour, NB",NB,45.047841,-66.807898,Canada,CHS,,America/Moncton
+00044,"Beaver Harbour, NB",NB,45.06835,-66.739534,Canada,CHS,,America/Moncton
+00046,"West Dipper Harbour, NB",NB,45.09284,-66.418731,Canada,CHS,Dipper Harbour West,America/Moncton
+00052,"Five Fathom Hole, NB",NB,45.186598,-66.257278,Canada,CHS,,America/Moncton
+00053,"Musquash Harbour, NB",NB,45.148535,-66.257932,Canada,CHS,,America/Moncton
+00055,"Lorneville, NB",NB,45.192742,-66.14824,Canada,CHS,,America/Moncton
+00060,"Partridge Island, NB",NB,45.241166,-66.052274,Canada,CHS,,America/Moncton
+00065,"Saint John, NB",NB,45.254596,-66.06004,Canada,CHS,,America/Moncton
+00066,"Reversing Falls, NB",NB,45.259,-66.087,Canada,CHS,Chutes réversibles,America/Moncton
+00085,"Kennebecasis Bay, NB",NB,45.393261,-66.000923,Canada,CHS,,America/Moncton
+00093,"Public Landing, NB",NB,45.405682,-66.195982,Canada,CHS,,America/Moncton
+00097,"Hatfield Point, NB",NB,45.613801,-65.912438,Canada,CHS,,America/Moncton
+00098,"Evandale, NB",NB,45.591594,-66.028695,Canada,CHS,,America/Moncton
+00102,"Macdonald Point, NB",NB,45.71881,-66.04758,Canada,CHS,,America/Moncton
+00103,"Cambridge Narrows, NB",NB,45.829482,-65.95297,Canada,CHS,,America/Moncton
+00108,"Upper Gagetown, NB",NB,45.847241,-66.234799,Canada,CHS,,America/Moncton
+00120,"Fredericton, NB",NB,45.966423,-66.65197,Canada,CHS,,America/Moncton
+00122,"Newcastle Creek, NB",NB,46.056492,-66.002698,Canada,CHS,,America/Moncton
+00129,"St Martins, NB",NB,45.35517,-65.531886,Canada,CHS,,America/Moncton
+00140,"Herring Cove, NB",NB,45.574668,-64.965629,Canada,CHS,,America/Moncton
+00150,"Cape Enrage, NB",NB,45.593584,-64.780225,Canada,CHS,,America/Moncton
+00160,"Grindstone Island, NB",NB,45.72187,-64.621207,Canada,CHS,,America/Moncton
+00170,"Hopewell Cape, NB",NB,45.860104,-64.57907,Canada,CHS,,America/Moncton
+00172,"Belliveau Village, NB",NB,45.937102,-64.619739,Canada,CHS,,America/Moncton
+00173,"Dover, NB",NB,45.992446,-64.686416,Canada,CHS,,America/Moncton
+00175,"Moncton, NB",NB,46.087883,-64.771888,Canada,CHS,,America/Moncton
+00190,"Pecks Point, NB",NB,45.741838,-64.479898,Canada,CHS,,America/Moncton
+00210,"Maccan, NB",NB,45.724667,-64.259833,Canada,CHS,,America/Halifax
+00211,"River Hebert, NS",NS,45.690167,-64.373833,Canada,CHS,,America/Halifax
+00215,"Joggins, NS",NS,45.660547,-64.488192,Canada,CHS,Two Rivers Cove,America/Halifax
+00225,"Cape Capstan, NS",NS,45.474004,-64.853811,Canada,CHS,,America/Halifax
+00235,"West Advocate, NS",NS,45.345678,-64.816617,Canada,CHS,,America/Halifax
+00236,"Advocate, NS",NS,45.331982,-64.775448,Canada,CHS,,America/Halifax
+00240,"Cape d'Or, NS",NS,45.290438,-64.774936,Canada,CHS,,America/Halifax
+00242,"Spencers Island, NS",NS,45.35476,-64.710035,Canada,CHS,,America/Halifax
+00245,"Port Greville, NS",NS,45.404321,-64.541522,Canada,CHS,,America/Halifax
+00247,"Diligent River, NS",NS,45.390396,-64.454776,Canada,CHS,,America/Halifax
+00250,"Cape Sharp, NS",NS,45.364449,-64.391893,Canada,CHS,,America/Halifax
+00255,"Parrsboro, NS",NS,45.3899678,-64.3186504,Canada,CHS,,America/Halifax
+00260,"Five Islands, NS",NS,45.379434,-64.12989,Canada,CHS,,America/Halifax
+00265,"Truro, NS",NS,45.366667,-63.316667,Canada,CHS,,America/Halifax
+00267,"Maitland, NS",NS,45.251167,-63.456,Canada,CHS,,America/Halifax
+00270,"Burntcoat Head, NS",NS,45.311475,-63.805688,Canada,CHS,,America/Halifax
+00281,"Tidal View Farm, NS",NS,45.01,-64.073,Canada,CHS,,America/Halifax
+00282,"Hantsport, NS",NS,45.066886,-64.170122,Canada,CHS,,America/Halifax
+00290,"Cape Blomidon, NS",NS,45.30484,-64.349067,Canada,CHS,,America/Halifax
+00300,"Scots Bay, NS",NS,45.315444,-64.440747,Canada,CHS,,America/Halifax
+00305,"Baxters Harbour, NS",NS,45.230788,-64.514883,Canada,CHS,,America/Halifax
+00312,"Ile Haute, NS",NS,45.253894,-64.990928,Canada,CHS,,America/Halifax
+00315,"Margaretsville, NS",NS,45.048773,-65.062969,Canada,CHS,,America/Halifax
+00320,"Parkers Cove, NS",NS,44.813683,-65.538394,Canada,CHS,,America/Halifax
+00324,"Digby Ferry Wharf, NS",NS,44.65984,-65.75677,Canada,CHS,,America/Halifax
+00325,"Digby, NS",NS,44.626561,-65.753687,Canada,CHS,,America/Halifax
+00330,"Culloden, NS",NS,44.665805,-65.831633,Canada,CHS,,America/Halifax
+00333,"Grand Eddy, NS",NS,44.39592,-66.204866,Canada,CHS,,America/Halifax
+00334,"Trout Cove, NS",NS,44.551317,-66.032085,Canada,CHS,,America/Halifax
+00335,"Sandy Cove, NS",NS,44.498851,-66.098584,Canada,CHS,,America/Halifax
+00336,"East Sandy Cove, NS",NS,44.487013,-66.084873,Canada,CHS,,America/Halifax
+00337,"Tiverton, NS",NS,44.380189,-66.213845,Canada,CHS,,America/Halifax
+00338,"Tiverton (Boars Head), NS",NS,44.404224,-66.214794,Canada,CHS,,America/Halifax
+00340,"Westport, NS",NS,44.263641,-66.350064,Canada,CHS,,America/Halifax
+00345,"Lighthouse Cove, NS",NS,44.24963,-66.392209,Canada,CHS,,America/Halifax
+00353,"Church Point, NS",NS,44.345634,-66.118497,Canada,CHS,,America/Halifax
+00355,"Meteghan, NS",NS,44.193113,-66.166268,Canada,CHS,,America/Halifax
+00360,"Port Maitland, NS",NS,43.985999,-66.159098,Canada,CHS,,America/Halifax
+00365,"Yarmouth, NS",NS,43.832311,-66.124968,Canada,CHS,,America/Halifax
+00366,"Bunker Island Wharf, NS",NS,43.818936,-66.136363,Canada,CHS,,America/Halifax
+00367,"Bunker Island Light, NS",NS,43.812291,-66.143235,Canada,CHS,,America/Halifax
+00368,"Kellys Cove, NS",NS,43.783271,-66.131679,Canada,CHS,,America/Halifax
+00370,"Pinkney Point, NS",NS,43.704021,-66.055683,Canada,CHS,,America/Halifax
+00374,"Wedgeport, NS",NS,43.71704,-65.983089,Canada,CHS,,America/Halifax
+00375,"Lower Wedgeport, NS",NS,43.712299,-65.984139,Canada,CHS,,America/Halifax
+00378,"Tusket, NS",NS,43.852062,-65.975042,Canada,CHS,,America/Halifax
+00380,"Abrams River, NS",NS,43.824506,-65.935217,Canada,CHS,,America/Halifax
+00382,"Abbotts Harbour, NS",NS,43.663818,-65.824022,Canada,CHS,,America/Halifax
+00385,"Lower East Pubnico, NS",NS,43.630445,-65.771242,Canada,CHS,,America/Halifax
+00390,"Woods Harbour, NS",NS,43.529406,-65.739946,Canada,CHS,,America/Halifax
+00395,"Flat Island, NS",NS,43.509749,-66.002756,Canada,CHS,,America/Halifax
+00400,"Seal Island, NS",NS,43.409734,-66.020097,Canada,CHS,,America/Halifax
+00405,"Clarks Harbour, NS",NS,43.444829,-65.634434,Canada,CHS,,America/Halifax
+00408,"West Head, NS",NS,43.459567,-65.653437,Canada,CHS,,America/Halifax
+00410,"Swims Point, NS",NS,43.433419,-65.631869,Canada,CHS,,America/Halifax
+00415,"Barrington Passage, NS",NS,43.525632,-65.607207,Canada,CHS,,America/Halifax
+00420,"Upper Port la Tour, NS",NS,43.505894,-65.469347,Canada,CHS,,America/Halifax
+00423,"Ingomar, NS",NS,43.563155,-65.363373,Canada,CHS,,America/Halifax
+00425,"Shelburne, NS",NS,43.753636,-65.320292,Canada,CHS,,America/Halifax
+00426,"Sandy Point, NS",NS,43.695318,-65.324184,Canada,CHS,,America/Halifax
+00430,"Lockeport, NS",NS,43.701539,-65.107167,Canada,CHS,,America/Halifax
+00435,"Port Mouton, NS",NS,43.921621,-64.841138,Canada,CHS,,America/Halifax
+00440,"Liverpool, NS",NS,44.048996,-64.69442,Canada,CHS,,America/Halifax
+00450,"Bridgewater, NS",NS,44.371741,-64.505517,Canada,CHS,,America/Halifax
+00452,"Riverport, NS",NS,44.289312,-64.345007,Canada,CHS,,America/Halifax
+00455,"Lunenburg, NS",NS,44.375468,-64.307098,Canada,CHS,,America/Halifax
+00460,"Mahone Harbour, NS",NS,44.447429,-64.373975,Canada,CHS,,America/Halifax
+00465,"Chester, NS",NS,44.536383,-64.242787,Canada,CHS,,America/Halifax
+00473,"Owls Head, NS",NS,44.521816,-64.00538,Canada,CHS,,America/Halifax
+00475,"Mill Cove, NS",NS,44.580148,-64.052082,Canada,CHS,,America/Halifax
+00479,"Blandford, NS",NS,44.494691,-64.11229,Canada,CHS,,America/Halifax
+00480,"Hubbards, NS",NS,44.637327,-64.059586,Canada,CHS,,America/Halifax
+00482,"Boutiliers Point, NS",NS,44.656852,-63.94656,Canada,CHS,,America/Halifax
+00484,"Indian Harbour, NS",NS,44.514837,-63.937238,Canada,CHS,,America/Halifax
+00485,"Cliff Cove, NS",NS,44.511767,-63.937469,Canada,CHS,"St. Margarets Bay, St. MargaretsBay",America/Halifax
+00486,"Prospect, NS",NS,44.468951,-63.783677,Canada,CHS,,America/Halifax
+00488,"Sambro Harbour, NS",NS,44.478153,-63.599156,Canada,CHS,,America/Halifax
+00490,"Halifax, NS",NS,44.65914,-63.583386,Canada,CHS,,America/Halifax
+00491,"Bedford Institute, NS",NS,44.682262,-63.613239,Canada,CHS,,America/Halifax
+00493,"Chezzetcook Inlet, NS",NS,44.71092,-63.236669,Canada,CHS,,America/Halifax
+00495,"Salmon River Bridge, NS",NS,44.778633,-63.042147,Canada,CHS,,America/Halifax
+00497,"Little Harbour, NS",NS,44.708858,-62.841551,Canada,CHS,,America/Halifax
+00500,"Murphys Cove, NS",NS,44.785651,-62.761954,Canada,CHS,,America/Halifax
+00505,"Tomlee Bay, NS",NS,44.836431,-62.587022,Canada,CHS,,America/Halifax
+00509,"Spry Harbour, NS",NS,44.837741,-62.614059,Canada,CHS,,America/Halifax
+00510,"Sheet Harbour, NS",NS,44.903,-62.5036,Canada,CHS,,America/Halifax
+00511,"Port Dufferin, NS",NS,44.89582,-62.375197,Canada,CHS,,America/Halifax
+00512,"West Newdy Quoddy, NS",NS,44.904092,-62.349648,Canada,CHS,,America/Halifax
+00514,"Ecum Secum, NS",NS,44.966012,-62.137565,Canada,CHS,,America/Glace_Bay
+00515,"Liscomb Harbour, NS",NS,45.023824,-61.996742,Canada,CHS,,America/Glace_Bay
+00516,"Marie Joseph, NS",NS,44.965562,-62.079311,Canada,CHS,,America/Glace_Bay
+00520,"Sonora, NS",NS,45.057346,-61.904549,Canada,CHS,,America/Glace_Bay
+00525,"Sherbrooke, NS",NS,45.133931,-61.983345,Canada,CHS,,America/Glace_Bay
+00530,"Port Bickerton, NS",NS,45.105369,-61.723156,Canada,CHS,,America/Glace_Bay
+00535,"Isaacs Harbour, NS",NS,45.179911,-61.659633,Canada,CHS,,America/Glace_Bay
+00536,"Goldboro, NS",NS,45.180778,-61.652261,Canada,CHS,,America/Glace_Bay
+00540,"Larrys River, NS",NS,45.217684,-61.373621,Canada,CHS,,America/Glace_Bay
+00545,"Whitehead, NS",NS,45.240412,-61.188736,Canada,CHS,,America/Glace_Bay
+00550,"Sable Island/Sable, ÃŽle de, NS",NS,43.959157,-59.794781,Canada,CHS,,America/Halifax
+00555,"Canso Harbour, NS",NS,45.338236,-60.995406,Canada,CHS,,America/Glace_Bay
+00563,"Sand Point, NS",NS,45.521378,-61.263584,Canada,CHS,,America/Glace_Bay
+00570,"Port Hastings, NS",NS,45.64615,-61.405665,Canada,CHS,,America/Glace_Bay
+00575,"Port Hawkesbury, NS",NS,45.614417,-61.365637,Canada,CHS,,America/Glace_Bay
+00576,"Point Tupper, NS",NS,45.595606,-61.363328,Canada,CHS,,America/Glace_Bay
+00580,"Arichat, NS",NS,45.5104757,-61.01769383,Canada,CHS,,America/Glace_Bay
+00582,"Petit De Grat, NS",NS,45.506907,-60.961596,Canada,CHS,,America/Glace_Bay
+00585,"Cannes, NS",NS,45.636331,-60.959515,Canada,CHS,,America/Glace_Bay
+00587,"St Peters Bay, NS",NS,45.652431,-60.869506,Canada,CHS,,America/Glace_Bay
+00588,"St Peters Inlet, NS",NS,45.661123,-60.874447,Canada,CHS,,America/Glace_Bay
+00595,"Fourchu, NS",NS,45.71712,-60.245189,Canada,CHS,,America/Glace_Bay
+00600,"Louisbourg, NS",NS,45.916903,-59.971018,Canada,CHS,,America/Glace_Bay
+00610,"Sydney, NS",NS,46.141358,-60.199803,Canada,CHS,,America/Glace_Bay
+00612,"North Sydney, NS",NS,46.20897,-60.245314,Canada,CHS,,America/Glace_Bay
+00621,"Table Head, NS",NS,46.323534,-60.360073,Canada,CHS,,America/Glace_Bay
+00622,"Duffus Point, NS",NS,46.281566,-60.424734,Canada,CHS,,America/Glace_Bay
+00623,"Black Rock Point, NS",NS,46.305169,-60.392998,Canada,CHS,,America/Glace_Bay
+00624,"Penny Lane, NS",NS,46.29864,-60.399749,Canada,CHS,Penny Lane (Blackrock),America/Glace_Bay
+00626,"Seal Islands Bridge, NS",NS,46.2366,-60.5002,Canada,CHS,,America/Glace_Bay
+00630,"Ingonish Beach, NS",NS,46.629842,-60.389685,Canada,CHS,,America/Glace_Bay
+00635,"Neils Harbour, NS",NS,46.806867,-60.320471,Canada,CHS,,America/Glace_Bay
+00638,"Dingwall, NS",NS,46.902499,-60.457949,Canada,CHS,,America/Glace_Bay
+00640,"Baddeck, NS",NS,46.100254,-60.747687,Canada,CHS,,America/Glace_Bay
+00653,"Johnstown, NS",NS,45.79297,-60.739103,Canada,CHS,,America/Glace_Bay
+00654,"Eskasoni, NS",NS,45.955825,-60.586051,Canada,CHS,,America/Glace_Bay
+00655,"Iona, NS",NS,45.956781,-60.793964,Canada,CHS,,America/Glace_Bay
+00656,"Dundee, NS",NS,45.699744,-61.090416,Canada,CHS,,America/Glace_Bay
+00663,"Grand Bay, NL",NL,47.59022,-59.181979,Canada,CHS,,America/St_Johns
+00665,"Port aux Basques, NL",NL,47.580155,-59.139055,Canada,CHS,,America/St_Johns
+00666,"Isle Aux Morts, NL",NL,47.582132,-58.979109,Canada,CHS,,America/St_Johns
+00668,"Rose Blanche, NL",NL,47.615609,-58.700195,Canada,CHS,,America/St_Johns
+00670,"La Poile (Little Bay), NL",NL,47.684234,-58.39571,Canada,CHS,,America/St_Johns
+00671,"Grand Bruit, NL",NL,47.671685,-58.224724,Canada,CHS,,America/St_Johns
+00672,"Couteau Bay, NL",NL,47.712801,-58.049808,Canada,CHS,,America/St_Johns
+00677,"Short Reach, NL",NL,47.616818,-57.620916,Canada,CHS,Burgeo,America/St_Johns
+00679,"Ramea Island, NL",NL,47.521818,-57.38464,Canada,CHS,,America/St_Johns
+00683,"Francois, NL",NL,47.577351,-56.743771,Canada,CHS,,America/St_Johns
+00688,"Mccallum, NL",NL,47.631183,-56.22705,Canada,CHS,,America/St_Johns
+00690,"Pushthrough, NL",NL,47.635589,-56.16505,Canada,CHS,"Great Gervis Hbr, Great Gervis Hbr",America/St_Johns
+00705,"St Albans, NL",NL,47.863101,-55.835199,Canada,CHS,,America/St_Johns
+00708,"Gaultois, NL",NL,47.608433,-55.904371,Canada,CHS,,America/St_Johns
+00710,"Hermitage, NL",NL,47.556463,-55.925395,Canada,CHS,,America/St_Johns
+00720,"Harbour Breton, NL",NL,47.477957,-55.81267,Canada,CHS,,America/St_Johns
+00724,"Belleoram, NL",NL,47.526829,-55.409341,Canada,CHS,,America/St_Johns
+00745,"Saint-Pierre Et Miquelon, NL",NL,46.777365,-56.169216,Canada,CHS,,America/Miquelon
+00755,"St. Lawrence, NL",NL,46.916789,-55.39005,Canada,CHS,Great St. Lawrence,America/St_Johns
+00760,"Burin, NL",NL,47.03573,-55.164358,Canada,CHS,,America/St_Johns
+00765,"Marystown, NL",NL,47.165605,-55.148173,Canada,CHS,,America/St_Johns
+00776,"Petite Forte, NL",NL,47.396298,-54.667979,Canada,CHS,,America/St_Johns
+00795,"Tacks Beach, NL",NL,47.581357,-54.212081,Canada,CHS,,America/St_Johns
+00796,"Davis Cove, NL",NL,47.636177,-54.3406365,Canada,CHS,,America/St_Johns
+00805,"Woody Island, NL",NL,47.783668,-54.178688,Canada,CHS,,America/St_Johns
+00810,"North Harbour, NL",NL,47.846313,-54.096719,Canada,CHS,,America/St_Johns
+00815,"Come By Chance, NL",NL,47.81042,-54.007651,Canada,CHS,,America/St_Johns
+00818,"Arnolds Cove, NL",NL,47.7579625,-53.990144,Canada,CHS,,America/St_Johns
+00830,"Long Harbour, NL",NL,47.428591,-53.822808,Canada,CHS,,America/St_Johns
+00835,"Argentia, NL",NL,47.289998,-53.991899,Canada,CHS,,America/St_Johns
+00845,"St Brides, NL",NL,46.9175758,-54.177762,Canada,CHS,,America/St_Johns
+00860,"St Marys, NL",NL,46.9194628,-53.580154,Canada,CHS,,America/St_Johns
+00880,"Trepassey, NL",NL,46.735517,-53.371543,Canada,CHS,,America/St_Johns
+00890,"Fermeuse, NL",NL,46.964724,-52.938131,Canada,CHS,,America/St_Johns
+00893,"Lance Cove, NL",NL,46.80064,-54.097654,Canada,CHS,,America/St_Johns
+00898,"Gull Island, NL",NL,47.262122,-52.777936,Canada,CHS,,America/St_Johns
+00900,"Bay Bulls, NL",NL,47.313812,-52.806124,Canada,CHS,,America/St_Johns
+00905,"St. Johns, NL",NL,47.567045,-52.702311,Canada,CHS,St. John's,America/St_Johns
+00907,"Middle Cove, NL",NL,47.650895,-52.695878,Canada,CHS,,America/St_Johns
+00912,"Portugal Cove, NL",NL,47.625667,-52.856716,Canada,CHS,,America/St_Johns
+00915,"Bell Island, NL",NL,47.629755,-52.923473,Canada,CHS,,America/St_Johns
+00920,"Long Pond, NL",NL,47.517431,-52.978591,Canada,CHS,,America/St_Johns
+00925,"Holyrood Bay, NL",NL,47.389127,-53.135356,Canada,CHS,,America/St_Johns
+00932,"Bay Roberts, NL",NL,47.588812,-53.263168,Canada,CHS,,America/St_Johns
+00935,"Harbour Grace, NL",NL,47.691119,-53.2168035,Canada,CHS,,America/St_Johns
+00955,"Hearts Content, NL",NL,47.8708505,-53.367706,Canada,CHS,,America/St_Johns
+00962,"Long Cove, NL",NL,47.566755,-53.6675267,Canada,CHS,,America/St_Johns
+00970,"Long Beach, NL",NL,47.996447,-53.810697,Canada,CHS,,America/St_Johns
+00973,"Hickmans Harbour, NL",NL,48.103238,-53.743636,Canada,CHS,,America/St_Johns
+00975,"Clarenville, NL",NL,48.169807,-53.960495,Canada,CHS,,America/St_Johns
+00977,"Clifton, NL",NL,48.175581,-53.724624,Canada,CHS,,America/St_Johns
+00981,"Trinity, NL",NL,48.372154,-53.357848,Canada,CHS,,America/St_Johns
+00985,"Port Union, NL",NL,48.498876,-53.0811086,Canada,CHS,,America/St_Johns
+00990,"Bonavista, NL",NL,48.650605,-53.115757,Canada,CHS,,America/St_Johns
+01003,"Jamestown, NL",NL,48.444292,-53.799962,Canada,CHS,,America/St_Johns
+01008,"Charlottetown, NL",NL,48.434052,-54.004372,Canada,CHS,,America/St_Johns
+01009,"Saltons Brook, NL",NL,48.57899,-53.946939,Canada,CHS,,America/St_Johns
+01010,"Newman Sound, NL",NL,48.561952,-53.962352,Canada,CHS,,America/St_Johns
+01015,"Salvage, NL",NL,48.686698,-53.642866,Canada,CHS,,America/St_Johns
+01018,"Glovertown South, NL",NL,48.682227,-53.993161,Canada,CHS,,America/St_Johns
+01025,"Dover - Wellington, NL",NL,48.8642416,-53.9721258,Canada,CHS,,America/St_Johns
+01030,"Valleyfield, NL",NL,49.122244,-53.607874,Canada,CHS,,America/St_Johns
+01035,"Musgrave Harbour, NL",NL,49.453792,-53.958367,Canada,CHS,,America/St_Johns
+01040,"Carmanville, NL",NL,49.403201,-54.281334,Canada,CHS,,America/St_Johns
+01047,"Joe Batts Arm, NL",NL,49.730817,-54.157698,Canada,CHS,,America/St_Johns
+01048,"Seldom, NL",NL,49.609583,-54.182199,Canada,CHS,"Seldom Come By, Seldom Come By",America/St_Johns
+01049,"Tilting Harbour, NL",NL,49.705267,-54.061983,Canada,CHS,,America/St_Johns
+01050,"Fogo, NL",NL,49.7136486,-54.2884966,Canada,CHS,"Seal Cove, Seal Cove",America/St_Johns
+01052,"Change Islands, NL",NL,49.67474,-54.400271,Canada,CHS,,America/St_Johns
+01053,"Farewell, NL",NL,49.555593,-54.477702,Canada,CHS,,America/St_Johns
+01054,"Dark Cove, NL",NL,49.52496,-54.755303,Canada,CHS,,America/St_Johns
+01056,"Dildo Run (Causeway), NL",NL,49.4811,-54.734404,Canada,CHS,,America/St_Johns
+01058,"Summerford, NL",NL,49.4896307,-54.796798,Canada,CHS,,America/St_Johns
+01060,"Twillingate, NL",NL,49.6597532,-54.77322577,Canada,CHS,,America/St_Johns
+01065,"Bridgeport, NL",NL,49.549643,-54.873393,Canada,CHS,,America/St_Johns
+01070,"Lewisporte, NL",NL,49.246536,-55.052948,Canada,CHS,,America/St_Johns
+01080,"Botwood, NL",NL,49.146832,-55.337226,Canada,CHS,,America/St_Johns
+01085,"Exploits Island, NL",NL,49.517688,-55.063684,Canada,CHS,,America/St_Johns
+01087,"Leading Tickle, NL",NL,49.5020504,-55.4470603,Canada,CHS,,America/St_Johns
+01095,"Little Bay Arm, NL",NL,49.600766,-55.923296,Canada,CHS,,America/St_Johns
+01097,"Beachside, NL",NL,49.643134,-55.89575,Canada,CHS,,America/St_Johns
+01098,"Springdale, NL",NL,49.5000599,-56.064947,Canada,CHS,,America/St_Johns
+01101,"Nippers Harbour, NL",NL,49.793454,-55.8598663,Canada,CHS,,America/St_Johns
+01102,"Tilt Cove, NL",NL,49.880514,-55.623771,Canada,CHS,,America/St_Johns
+01105,"La Scie, NL",NL,49.9631805,-55.6029476,Canada,CHS,,America/St_Johns
+01110,"Baie Verte, NL",NL,49.937268,-56.191381,Canada,CHS,,America/St_Johns
+01115,"Seal Cove, NL",NL,49.936176,-56.38880325,Canada,CHS,,America/St_Johns
+01125,"Hampden, NL",NL,49.5452688,-56.85334086,Canada,CHS,,America/St_Johns
+01135,"Sops Island, NL",NL,49.797178,-56.794615,Canada,CHS,,America/St_Johns
+01150,"Englee, NS",NS,50.732249638,-56.10674919,Canada,CHS,,America/St_Johns
+01165,"Locks Cove, NL",NL,51.337356,-55.954712,Canada,CHS,,America/St_Johns
+01170,"St Anthony, NL",NL,51.3639566,-55.58490847,Canada,CHS,,America/St_Johns
+01180,"Ship Cove, NL",NL,51.6027255,-55.62597008,Canada,CHS,,America/St_Johns
+01181,"Cooks Harbour, NL",NL,51.607009,-55.862446,Canada,CHS,,America/St_Johns
+01182,"Black Joke Cove, NL",NL,51.999257,-55.279315,Canada,CHS,,America/St_Johns
+01185,"Chateau Bay, NL",NL,51.975223,-55.855186,Canada,CHS,,America/St_Johns
+01186,"Henley Harbour, NL",NL,51.9925867,-55.8553451,Canada,CHS,,America/St_Johns
+01190,"Battle Harbour, NL",NL,52.2736235,-55.58394272,Canada,CHS,,America/St_Johns
+01195,"Port Marnham, NL",NL,52.383568,-55.733203,Canada,CHS,,America/St_Johns
+01199,"Williams Harbour, South Labrador, NL",NL,52.5596724,-55.7698364,Canada,CHS,,America/St_Johns
+01200,"Denbigh Island, Labrador, NL",NL,52.531128,-55.82491,Canada,CHS,,America/St_Johns
+01202,"White Bear Arm, NL",NL,52.734901,-55.829688,Canada,CHS,"Square Island Harbour, Square Island Harbour",America/St_Johns
+01205,"Nevile Island, NL",NL,52.55116,-56.111893,Canada,CHS,Cooper's Island,America/St_Johns
+01210,"Port Hope Simpson, NL",NL,52.54908,-56.296152,Canada,CHS,,America/St_Johns
+01214,"Norman Bay, NL",NL,52.93597986,-55.90235541,Canada,CHS,,America/St_Johns
+01217,"Punchbowl, NL",NL,53.250676,-55.751618,Canada,CHS,,America/St_Johns
+01245,"Cartwright, NL",NL,53.70421458,-57.020407,Canada,CHS,,America/Goose_Bay
+01247,"Sandwich Bay (East Arm), NL",NL,53.566561,-57.161563,Canada,CHS,,America/Goose_Bay
+01248,"Paradise River, NL",NL,53.440361,-57.285765,Canada,CHS,,America/Goose_Bay
+01263,"Snooks Rocks, NL",NL,54.2627,-58.1955,Canada,CHS,,America/Goose_Bay
+01267,"Jordans Point, NL",NL,54.218294,-58.241539,Canada,CHS,,America/Goose_Bay
+01280,"Rigolet, NL",NL,54.180469,-58.427962,Canada,CHS,,America/Goose_Bay
+01285,"Caravalla Cove, NL",NL,54.054143,-58.593691,Canada,CHS,,America/Goose_Bay
+01287,"Long Point Island, NL",NL,54.015302,-58.566696,Canada,CHS,,America/Goose_Bay
+01320,"Cabot Point, NL",NL,53.719117,-59.0644,Canada,CHS,,America/Goose_Bay
+01331,"Mulligan Bay, NL",NL,53.8356,-59.871383,Canada,CHS,,America/Goose_Bay
+01335,"North West River, NL",NL,53.523929,-60.1457805,Canada,CHS,,America/Goose_Bay
+01345,"Rabbit Island, NL",NL,53.401117,-60.137636,Canada,CHS,,America/Goose_Bay
+01350,"Terrington Basin, NL",NL,53.344237,-60.401007,Canada,CHS,,America/Goose_Bay
+01365,"Broomfield, NL",NL,54.47233,-57.182573,Canada,CHS,Icy Tickle,America/Goose_Bay
+01370,"Emily Harbour, NL",NL,54.541068,-57.191598,Canada,CHS,,America/Goose_Bay
+01374,"Byron Bay (Copper Island), NL",NL,54.728082,-57.688218,Canada,CHS,,America/Goose_Bay
+01376,"Jeanette Bay, Lab, NL",NL,54.749478,-57.891383,Canada,CHS,,America/Goose_Bay
+01377,"Mostyn Cove, NL",NL,54.7401315,-57.982024,Canada,CHS,,America/Goose_Bay
+01390,"Makkovik, NL",NL,55.082942,-59.1701008,Canada,CHS,,America/Goose_Bay
+01397,"Postville, NL",NL,54.907125,-59.766688,Canada,CHS,,America/Goose_Bay
+01398,"Jackos Point, NL",NL,55.121487,-59.443562,Canada,CHS,,America/Goose_Bay
+01400,"Turnavik Island, NL",NL,55.285606,-59.34282,Canada,CHS,,America/Goose_Bay
+01405,"Hopedale, NL",NL,55.4541256,-60.2228018,Canada,CHS,,America/Goose_Bay
+01410,"Shoal Tickle, NL",NL,55.771765,-60.352145,Canada,CHS,,America/Goose_Bay
+01416,"Davis Inlet, NL",NL,55.892393,-60.901578,Canada,CHS,,America/Goose_Bay
+01420,"House Harbour, NL",NL,56.235527,-61.049647,Canada,CHS,,America/Goose_Bay
+01421,"Nukasusutok Island, NL",NL,56.370108,-61.241776,Canada,CHS,North Harbour,America/Goose_Bay
+01422,"John Hayes Harbour, NL",NL,56.399527,-61.614195,Canada,CHS,,America/Goose_Bay
+01425,"Ford Harbour, NL",NL,56.4663686,-61.19228058,Canada,CHS,,America/Goose_Bay
+01430,"Nain, NL",NL,56.543452,-61.686473,Canada,CHS,"Nain, Nunainguk, Unity Bay",America/Goose_Bay
+01435,"Young's Harbour, NL",NL,56.633,-61.061,Canada,CHS,,America/Goose_Bay
+01450,"Port Manvers, NL",NL,56.954676,-61.506858,Canada,CHS,,America/Goose_Bay
+01452,"Kiglapait Harbour, NL",NL,57.158904,-61.56302,Canada,CHS,,America/Goose_Bay
+01458,"Igloksoatalik Island, NL",NL,57.67846,-61.816734,Canada,CHS,,America/Goose_Bay
+01465,"Hebron, NL",NL,58.199632,-62.624991,Canada,CHS,,America/Goose_Bay
+01470,"Saglek Bay, NL",NL,58.486817,-62.668467,Canada,CHS,,America/Goose_Bay
+01485,"Brownell Point, NL",NL,59.392177,-63.877661,Canada,CHS,,America/Goose_Bay
+01487,"Eclipse Channel, NL",NL,59.694339,-64.132595,Canada,CHS,,America/Goose_Bay
+01490,"Williams Harbour, North Labrador, NL",NL,60.009951,-64.316726,Canada,CHS,,America/Goose_Bay
+01495,"Cape Chidley, NL",NL,60.33468,-64.451803,Canada,CHS,,America/Goose_Bay
+01520,"Bay St. Lawrence, NS",NS,47.002654,-60.467522,Canada,CHS,,America/Glace_Bay
+01530,"St Paul Island, NS",NS,47.199,-60.146544,Canada,CHS,,America/Glace_Bay
+01539,"Cheticamp, NS",NS,46.625175,-61.016557,Canada,CHS,"La Digue, LA DIGUE",America/Glace_Bay
+01540,"La Pointe, NS",NS,46.603101,-61.0526,Canada,CHS,,America/Glace_Bay
+01545,"Margaree Trailer, NS",NS,46.440193,-61.11288,Canada,CHS,,America/Glace_Bay
+01546,"Margaree Harbour, NS",NS,46.4424,-61.112103,Canada,CHS,Belle Cote Breakwater,America/Glace_Bay
+01547,"East Margaree River, NS",NS,46.42772,-61.088565,Canada,CHS,Margaree Fish Pond,America/Glace_Bay
+01548,"East Margaree Bridge, NS",NS,46.39729,-61.078761,Canada,CHS,,America/Glace_Bay
+01550,"Broad Cove Marsh, NS",NS,46.300635,-61.257343,Canada,CHS,,America/Glace_Bay
+01560,"Port Hood, NS",NS,46.027909,-61.545014,Canada,CHS,,America/Glace_Bay
+01570,"Aulds Cove, NS",NS,45.648343,-61.435526,Canada,CHS,,America/Glace_Bay
+01576,"Havre Boucher, NS",NS,45.68962,-61.527238,Canada,CHS,,America/Glace_Bay
+01580,"Cape Jack, NS",NS,45.683753,-61.574802,Canada,CHS,,America/Glace_Bay
+01590,"Antigonish Harbour, NS",NS,45.672456,-61.907064,Canada,CHS,,America/Glace_Bay
+01597,"Cribbeans Point, NS",NS,45.755204,-61.896344,Canada,CHS,Cribbons Point,America/Glace_Bay
+01600,"Ballantynes Cove, NS",NS,45.858721,-61.918052,Canada,CHS,,America/Glace_Bay
+01610,"Arisaig, NS",NS,45.7619714,-62.1716137,Canada,CHS,,America/Glace_Bay
+01620,"Merigomish, NS",NS,45.648764,-62.448885,Canada,CHS,,America/Halifax
+01630,"Pictou, NS",NS,45.6740806,-62.7033375,Canada,CHS,,America/Halifax
+01635,"Pictou Island, NS",NS,45.802557,-62.585592,Canada,CHS,,America/Halifax
+01640,"Caribou, NS",NS,45.73928,-62.688116,Canada,CHS,Caribou Ferry Terminal,America/Halifax
+01650,"Souris, PE",PE,46.349625,-62.251762,Canada,CHS,,America/Halifax
+01660,"Georgetown, PE",PE,46.17951,-62.531618,Canada,CHS,,America/Halifax
+01662,"Montague, PE",PE,46.164725,-62.646332,Canada,CHS,,America/Halifax
+01665,"Graham Pond, PE",PE,46.095961,-62.453698,Canada,CHS,,America/Halifax
+01670,"Murray Harbour, PE",PE,46.005478,-62.523515,Canada,CHS,,America/Halifax
+01680,"Wood Islands, PE",PE,45.952878,-62.749395,Canada,CHS,,America/Halifax
+01690,"Point Prim, PE",PE,46.056251,-63.030217,Canada,CHS,,America/Halifax
+01700,"Charlottetown, PE",PE,46.23012108,-63.1221766,Canada,CHS,,America/Halifax
+01710,"Canoe Cove, PE",PE,46.149224,-63.303736,Canada,CHS,,America/Halifax
+01715,"Victoria, PEI, PE",PE,46.212623,-63.489466,Canada,CHS,,America/Halifax
+01725,"Port Borden, PE",PE,46.246127,-63.700721,Canada,CHS,,America/Halifax
+01735,"Summerside, PE",PE,46.386486,-63.789649,Canada,CHS,,America/Halifax
+01745,"Skinners Cove, NS",NS,45.79447,-63.04467,Canada,CHS,,America/Halifax
+01760,"Malagash, NS",NS,45.77520205,-63.2961563,Canada,CHS,,America/Halifax
+01770,"Cape Cliff, NS",NS,45.876731,-63.480512,Canada,CHS,,America/Halifax
+01775,"Pugwash, NS",NS,45.8483972,-63.663297,Canada,CHS,,America/Halifax
+01780,"Tidnish, NS",NS,45.997582,-64.007441,Canada,CHS,,America/Halifax
+01785,"Port Elgin, NB",NB,46.051875,-64.082768,Canada,CHS,,America/Moncton
+01790,"Cape Tormentine, NB",NB,46.134676,-63.776757,Canada,CHS,,America/Moncton
+01800,"Cap Pelé, NB",NB,46.235841,-64.26127,Canada,CHS,"Cape Bald, CAPE BALD",America/Moncton
+01804,"Pointe-du-Chêne, NB",NB,46.24061389,-64.53000556,Canada,CHS,,America/Moncton
+01805,"Shediac Bay, NB",NB,46.22689722,-64.54510278,Canada,CHS,,America/Moncton
+01810,"Cap de Caissie, NB",NB,46.312812,-64.509737,Canada,CHS,,America/Moncton
+01812,"Cocagne, NB",NB,46.3380696,-64.61814202,Canada,CHS,,America/Moncton
+01815,"Saint Thomas De Kent, NB",NB,46.447615,-64.636837,Canada,CHS,,America/Moncton
+01820,"Richibucto Cape, NB",NB,46.67454025,-64.7125534,Canada,CHS,,America/Moncton
+01825,"Richibucto Bar, NB",NB,46.710852,-64.791113,Canada,CHS,,America/Moncton
+01827,"Richibucto, NB",NB,46.68032,-64.86042,Canada,CHS,,America/Moncton
+01830,"Pointe Sapin, NB",NB,46.9628154,-64.8300883,Canada,CHS,,America/Moncton
+01835,"Cape Egmont, PE",PE,46.408225,-64.133638,Canada,CHS,,America/Halifax
+01845,"West Point, PE",PE,46.620079,-64.371788,Canada,CHS,,America/Halifax
+01855,"Miminegash, PE",PE,46.88011,-64.234435,Canada,CHS,,America/Halifax
+01860,"Skinners Pond, PE",PE,46.964224,-64.122878,Canada,CHS,,America/Halifax
+01865,"North Point, PE",PE,47.0581997,-63.9960403,Canada,CHS,,America/Halifax
+01875,"Tignish, PE",PE,46.950947,-63.9938431,Canada,CHS,,America/Halifax
+01885,"Alberton, PE",PE,46.7951034,-64.0582548,Canada,CHS,,America/Halifax
+01896,"Goodwood River, PE",PE,46.616799,-63.916607,Canada,CHS,,America/Halifax
+01905,"Malpeque, PE",PE,46.523993,-63.696637,Canada,CHS,,America/Halifax
+01915,"Rustico, PE",PE,46.4560018,-63.2940585,Canada,CHS,,America/Halifax
+01918,"Covehead, PE",PE,46.429035,-63.146052,Canada,CHS,,America/Halifax
+01925,"Crowbush Cove, PE",PE,46.4269503,-62.8399476,Canada,CHS,,America/Halifax
+01935,"St Peters Bay, PE",PE,46.43862,-62.73313,Canada,CHS,,America/Halifax
+01945,"Naufrage, PE",PE,46.468428,-62.417173,Canada,CHS,,America/Halifax
+01955,"North Lake Harbour, PE",PE,46.4669804,-62.06881902,Canada,CHS,,America/Halifax
+01960,"Anse à la Cabane, QC",QC,47.21766667,-61.98541667,Canada,CHS,Millerand,America/Halifax
+01964,"Havre-Aubert, QC",QC,47.235189,-61.828083,Canada,CHS,Havre Aubert,America/Halifax
+01966,"Île d'Entrée, QC",QC,47.277444,-61.718639,Canada,CHS,,America/Halifax
+01970,"Cap-aux-Meules, QC",QC,47.378861,-61.857283,Canada,CHS,Grindstone Wharf,America/Halifax
+01976,"Havre-aux-Maisons, QC",QC,47.405333,-61.836,Canada,CHS,House Harbour,America/Halifax
+01981,"Pointe-Basse, QC",QC,47.389806,-61.789035,Canada,CHS,Pointe Basse,America/Halifax
+01985,"Grande-Entrée, QC",QC,47.555842,-61.558949,Canada,CHS,Grande Entrée,America/Halifax
+01986,"Old-Harry, QC",QC,47.570755,-61.467094,Canada,CHS,Old Harry Head,America/Halifax
+01987,"Leslie, QC",QC,47.627778,-61.515667,Canada,CHS,Leslie Grosse Île,America/Halifax
+01988,"Grosse Île - Mine Seleine, QC",QC,47.610739,-61.560078,Canada,CHS,Mine Seleine,America/Halifax
+01990,"L'Étang-du-Nord, QC",QC,47.37,-61.958922,Canada,CHS,Étang du Nord,America/Halifax
+02000,"Escuminac, NB",NB,47.082241,-64.885565,Canada,CHS,Lower Escuminac,America/Moncton
+02010,"Portage Island, NB",NB,47.177032,-65.037294,Canada,CHS,,America/Moncton
+02012,"Fox Island Range Light, NB",NB,47.11348,-65.043085,Canada,CHS,,America/Moncton
+02014,"Cormorant (underwater), NB",NB,47.124708,-65.148642,Canada,CHS,,America/Moncton
+02020,"Bas Neguac, NB",NB,47.256519,-65.053075,Canada,CHS,,America/Moncton
+02022,"Neguac, NB",NB,47.240992,-65.072306,Canada,CHS,,America/Moncton
+02025,"Burnt Church, NB",NB,47.190671,-65.134805,Canada,CHS,,America/Moncton
+02028,"Baie du Vin Island, NB",NB,47.039056,-65.146615,Canada,CHS,,America/Moncton
+02029,"Robichaud Spit, NB",NB,47.129705,-65.251003,Canada,CHS,,America/Moncton
+02030,"Oak Point, NB",NB,47.116441,-65.267016,Canada,CHS,,America/Moncton
+02033,"Loggieville, NB",NB,47.074387,-65.384277,Canada,CHS,,America/Moncton
+02034,"Gordon Point, NB",NB,47.079161,-65.393159,Canada,CHS,,America/Moncton
+02035,"Chatham, NB",NB,47.029867,-65.47223,Canada,CHS,,America/Moncton
+02040,"Newcastle, NB",NB,46.998039,-65.561618,Canada,CHS,,America/Moncton
+02060,"Tracadie, NB",NB,47.52295,-64.90893,Canada,CHS,,America/Moncton
+02070,"Shippagan Gully, NB",NB,47.7187001,-64.669771,Canada,CHS,,America/Moncton
+02071,"Shippagan, NB",NB,47.747852,-64.702431,Canada,CHS,,America/Moncton
+02090,"Miscou, NB",NB,47.896209,-64.578601,Canada,CHS,,America/Moncton
+02110,"Caraquet, NB",NB,47.79601475,-64.927602,Canada,CHS,,America/Moncton
+02120,"Stonehaven, NB",NB,47.7542608,-65.3618448,Canada,CHS,,America/Moncton
+02130,"Bathurst Harbour, NB",NB,47.614601,-65.639602,Canada,CHS,,America/Moncton
+02145,"Belledune, NB",NB,47.908954,-65.845892,Canada,CHS,Chaleur,America/Moncton
+02165,"Dalhousie, NB",NB,48.0720178,-66.3776873,Canada,CHS,,America/Moncton
+02175,"Campbellton, NB",NB,48.0115566,-66.6693986,Canada,CHS,,America/Moncton
+02196,"Miguasha, QC",QC,48.09878599,-66.34707575,Canada,CHS,,America/Toronto
+02200,"Carleton, QC",QC,48.100181,-66.130929,Canada,CHS,Carleton Center,America/Toronto
+02215,"Pointe Howatson, QC",QC,48.137764,-65.836794,Canada,CHS,"Les Caps Noirs, Black Cape",America/Toronto
+02230,"Bonaventure, QC",QC,48.037623,-65.481124,Canada,CHS,,America/Toronto
+02235,"Paspébiac, QC",QC,48.018652,-65.257383,Canada,CHS,Paspebiac,America/Toronto
+02240,"Saint-Godefroi, QC",QC,48.073804,-65.113371,Canada,CHS,St-Godefroi,America/Toronto
+02250,"Port-Daniel-Gascons, QC",QC,48.182612,-64.96142,Canada,CHS,,America/Toronto
+02253,"Gascons, QC",QC,48.19073,-64.861547,Canada,CHS,,America/Toronto
+02260,"Newport, QC",QC,48.284376,-64.71932,Canada,CHS,Newport Point,America/Toronto
+02269,"Chandler, QC",QC,48.34205,-64.657065,Canada,CHS,,America/Toronto
+02279,"Grande-Rivière, QC",QC,48.392651,-64.492455,Canada,CHS,,America/Toronto
+02285,"Sainte-Thérèse-de-Gaspé, QC",QC,48.415011,-64.39517,Canada,CHS,Petite Rivière Est,America/Toronto
+02290,"Cap-d'Espoir, QC",QC,48.414713,-64.327389,Canada,CHS,Cap-D'Espoir,America/Toronto
+02295,"L'Anse-à-Beaufils, QC",QC,48.472174,-64.30779,Canada,CHS,Anse-à-Beaufils,America/Toronto
+02309,"Mal-Bay, QC",QC,48.620111,-64.199972,Canada,CHS,Malbay,America/Toronto
+02310,"Pointe Saint-Pierre, QC",QC,48.633389,-64.166,Canada,CHS,,America/Toronto
+02314,"L'Anse-à-Brillant, QC",QC,48.72065004,-64.29060876,Canada,CHS,Anse-à-Brillant,America/Toronto
+02319,"Sandy Beach, QC",QC,48.825917,-64.440722,Canada,CHS,Sandy Beach Wharf,America/Toronto
+02330,"Rivière-au-Renard, QC",QC,48.997,-64.3805,Canada,CHS,,America/Toronto
+02335,"L'Anse-à-Valleau, QC",QC,49.081,-64.544667,Canada,CHS,Anse à Valleau,America/Toronto
+02340,"Cloridorme, QC",QC,49.185833,-64.847833,Canada,CHS,,America/Toronto
+02350,"Grande-Vallée, QC",QC,49.229833,-65.1345,Canada,CHS,Grande-Vallee,America/Toronto
+02360,"Port-Menier, QC",QC,49.811667,-64.366667,Canada,CHS,Port Menier,America/Toronto
+02375,"Pointe du Sud-Ouest, QC",QC,49.395,-63.59,Canada,CHS,Southwest Point,America/Toronto
+02415,"Baie du Renard, QC",QC,49.281667,-61.834,Canada,CHS,Baie-du-Renard,America/Toronto
+02470,"Mingan, QC",QC,50.289167,-64.020167,Canada,CHS,,America/Toronto
+02480,"Havre-Saint-Pierre, QC",QC,50.237056,-63.609194,Canada,CHS,,America/Toronto
+02490,"Baie-Johan-Beetz, QC",QC,50.283667,-62.810167,Canada,CHS,Baie Johan Beetz,America/Blanc-Sablon
+02510,"Natashquan, QC",QC,50.189167,-61.8415,Canada,CHS,Natashquan Harbour,America/Blanc-Sablon
+02518,"Kegaska, QC",QC,50.184286,-61.263938,Canada,CHS,Kégashka,America/Blanc-Sablon
+02530,"Gethsémani, QC",QC,50.212108,-60.689319,Canada,CHS,Gethsemani,America/Blanc-Sablon
+02550,"Harrington Harbour, QC",QC,50.496333,-59.476,Canada,CHS,Harrington-Harbour,America/Blanc-Sablon
+02554,"Tête-à-la-Baleine, QC",QC,50.68,-59.24,Canada,CHS,Tête-a-la-Baleine,America/Blanc-Sablon
+02556,"Baie des Moutons, QC",QC,50.769304,-59.03234,Canada,CHS,Baie-des-Moutons,America/Blanc-Sablon
+02558,"La Tabatière, QC",QC,50.838294,-58.972951,Canada,CHS,Baie de la Tabatière,America/Blanc-Sablon
+02564,"Saint-Augustin, QC",QC,51.176333,-58.534667,Canada,CHS,St Augustin,America/Blanc-Sablon
+02577,"Vieux-Fort, QC",QC,51.421833,-57.8145,Canada,CHS,Baie du Vieux Fort,America/Blanc-Sablon
+02579,"Rivière-Saint-Paul, QC",QC,51.4711,-57.7075,Canada,CHS,Rivière-St-Paul,America/Blanc-Sablon
+02580,"Île des Esquimaux, QC",QC,51.424,-57.7025,Canada,CHS,Rivière Saint-Paul,America/Blanc-Sablon
+02581,"Baie Chevalier, QC",QC,51.432483,-57.638472,Canada,CHS,,America/Blanc-Sablon
+02583,"Middle Bay, QC",QC,51.463,-57.485,Canada,CHS,Middle-Bay,America/Blanc-Sablon
+02588,"Blanc-Sablon, QC",QC,51.415333,-57.150667,Canada,CHS,Blanc Sablon,America/Blanc-Sablon
+02590,"Forteau Bay, NL",NL,51.46944,-56.953481,Canada,CHS,,America/St_Johns
+02595,"West St. Modeste, NL",NL,51.594882,-56.704036,Canada,CHS,,America/St_Johns
+02600,"Red Bay, NL",NL,51.732061,-56.43062,Canada,CHS,,America/St_Johns
+02633,"Savage Cove, NL",NL,51.3327256,-56.70043202,Canada,CHS,,America/St_Johns
+02635,"Flowers Cove, NL",NL,51.29992,-56.735151,Canada,CHS,,America/St_Johns
+02637,"Anchor Point, NL",NL,51.233626,-56.797733,Canada,CHS,,America/St_Johns
+02638,"St. Barbe, NL",NL,51.204308,-56.77283,Canada,CHS,,America/St_Johns
+02642,"Shoal Cove West, NL",NL,51.024546,-57.022789,Canada,CHS,,America/St_Johns
+02650,"Port Saunders, NL",NL,50.644007,-57.296997,Canada,CHS,,America/St_Johns
+02655,"Port Aux Choix, NL",NL,50.70732869,-57.35684758,Canada,CHS,,America/St_Johns
+02660,"Cow Head, NL",NL,49.9221072,-57.8039272,Canada,CHS,,America/St_Johns
+02670,"Norris Cove, NL",NL,49.5173444,-57.87582752,Canada,CHS,,America/St_Johns
+02680,"Corner Brook, NL",NL,48.95829816,-57.9431008,Canada,CHS,,America/St_Johns
+02685,"Lark Harbour, NL",NL,49.0959298,-58.37913541,Canada,CHS,,America/St_Johns
+02695,"Fox Island, NL",NL,48.695636,-58.683013,Canada,CHS,,America/St_Johns
+02710,"Port Harmon, NL",NL,48.53051075,-58.52627363,Canada,CHS,Stephenville Pond,America/St_Johns
+02720,"St Georges, NL",NL,48.430237,-58.484809,Canada,CHS,,America/St_Johns
+02725,"Crabbes River, NL",NL,48.2184586,-58.8634113,Canada,CHS,St. Davids,America/St_Johns
+02750,"Rivière-au-Tonnerre, QC",QC,50.273333,-64.761001,Canada,CHS,,America/Toronto
+02780,"Sept-Îles, QC",QC,50.200369,-66.385102,Canada,CHS,Seven Islands,America/Toronto
+02790,"Port-Cartier, QC",QC,50.0325,-66.7875,Canada,CHS,,America/Toronto
+02815,"Baie-Trinité, QC",QC,49.42165872,-67.28240575,Canada,CHS,,America/Toronto
+02826,"Godbout, QC",QC,49.322167,-67.592667,Canada,CHS,,America/Toronto
+02840,"Baie-Comeau, QC",QC,49.231333,-68.131001,Canada,CHS,,America/Toronto
+02880,"Forestville, QC",QC,48.738333,-69.052167,Canada,CHS,,America/Toronto
+02883,"Portneuf-sur-Mer, QC",QC,48.640833,-69.093333,Canada,CHS,Sainte-Anne-de-Portneuf,America/Toronto
+02900,"Les Escoumins, QC",QC,48.346167,-69.388833,Canada,CHS,,America/Toronto
+02920,"Mont-Louis, QC",QC,49.235167,-65.7375,Canada,CHS,,America/Toronto
+02933,"Petite-Tourelle, QC",QC,49.167833,-66.372833,Canada,CHS,Saint-Joachim-de-Tourelle,America/Toronto
+02935,"Sainte-Anne-des-Monts, QC",QC,49.134,-66.485833,Canada,CHS,,America/Toronto
+02940,"Cap-Chat, QC",QC,49.098333,-66.6815,Canada,CHS,,America/Toronto
+02945,"Le Gros Méchins, QC",QC,49.005833,-66.9775,Canada,CHS,,America/Toronto
+02955,"Matane, QC",QC,48.853333,-67.533167,Canada,CHS,,America/Toronto
+02975,"Pointe aux Cenelles, QC",QC,48.642833,-68.166667,Canada,CHS,Pointe-aux-Cenelles,America/Toronto
+02980,"Pointe-au-Père, QC",QC,48.519167,-68.473167,Canada,CHS,,America/Toronto
+02985,"Rimouski, QC",QC,48.478333,-68.513667,Canada,CHS,,America/Toronto
+02995,"Le Bic, QC",QC,48.377167,-68.7265,Canada,CHS,Bic,America/Toronto
+03000,"Île Bicquette, QC",QC,48.4155,-68.893333,Canada,CHS,,America/Toronto
+03005,"Trois-Pistoles, QC",QC,48.134667,-69.186833,Canada,CHS,,America/Toronto
+03030,"Saint-Siméon, QC",QC,47.840667,-69.873167,Canada,CHS,,America/Toronto
+03045,"Pointe-au-Pic, QC",QC,47.621667,-70.140833,Canada,CHS,,America/Toronto
+03052,"Cap-aux-Oies, QC",QC,47.487167,-70.232667,Canada,CHS,,America/Toronto
+03057,"Saint-Joseph-de-la-Rive, QC",QC,47.448833,-70.3655,Canada,CHS,,America/Toronto
+03058,"Saint-Bernard-sur-Mer, QC",QC,47.4205,-70.392167,Canada,CHS,"Saint-Bernard, Île aux Coudres",America/Toronto
+03060,"Cap-aux-Corbeaux, QC",QC,47.4255,-70.455667,Canada,CHS,,America/Toronto
+03070,"Sault-au-Cochon, QC",QC,47.199667,-70.635833,Canada,CHS,,America/Toronto
+03071,"Rocher de Neptune, QC",QC,47.161667,-70.6075,Canada,CHS,Rocher-Neptune,America/Toronto
+03072,"Bouée K92, QC",QC,47.158517,-70.658167,Canada,CHS,,America/Toronto
+03087,"Sainte-Anne-de-Beaupré, QC",QC,47.0185,-70.9255,Canada,CHS,,America/Toronto
+03095,"Montmorency, QC",QC,46.881167,-71.144667,Canada,CHS,,America/Toronto
+03100,"Saint-François I.O., QC",QC,46.9965,-70.808167,Canada,CHS,Saint-Francois I.O.,America/Toronto
+03104,"Bouée K136, QC",QC,46.924833,-70.869,Canada,CHS,,America/Toronto
+03105,"Saint-Jean I.O., QC",QC,46.915667,-70.8965,Canada,CHS,,America/Toronto
+03110,"Saint-Laurent I.O., QC",QC,46.85816667,-71.00333333,Canada,CHS,,America/Toronto
+03120,"Île Verte, QC",QC,48.051167,-69.424667,Canada,CHS,,America/Toronto
+03122,"L'Isle-Verte, QC",QC,48.024667,-69.408,Canada,CHS,Chenal de l'Île Verte,America/Toronto
+03125,"Gros-Cacouna, QC",QC,47.9275,-69.513667,Canada,CHS,,America/Toronto
+03130,"Rivière-du-Loup, QC",QC,47.846833,-69.571833,Canada,CHS,,America/Toronto
+03140,"Île aux Lièvres, QC",QC,47.801167,-69.770667,Canada,CHS,Îles-aux-Lièvres,America/Toronto
+03145,"Le Petit Pèlerin, QC",QC,47.701,-69.758333,Canada,CHS,Le Petit Pelerin,America/Toronto
+03150,"La Grande Île, QC",QC,47.624167,-69.860833,Canada,CHS,Grande-ile,America/Toronto
+03160,"Pointe-aux-Orignaux, QC",QC,47.487,-70.025833,Canada,CHS,,America/Toronto
+03170,"Saint-Jean-Port-Joli, QC",QC,47.216167,-70.274667,Canada,CHS,,America/Toronto
+03180,"L'Isle-aux-Grues, QC",QC,47.055333,-70.5315,Canada,CHS,L'ile-aux-Grues,America/Toronto
+03190,"La Grosse Île, QC",QC,47.0195,-70.670833,Canada,CHS,,America/Toronto
+03200,"Berthier-sur-Mer, QC",QC,46.936167,-70.737333,Canada,CHS,,America/Toronto
+03248,"Vieux-Québec, QC",QC,46.811111,-71.20175,Canada,CHS,,America/Toronto
+03250,"Lauzon, QC",QC,46.8325,-71.157833,Canada,CHS,Québec (Lauzon),America/Toronto
+03251,"Immigration Wharf, QC",QC,46.7923,-71.2265,Canada,CHS,,America/Toronto
+03260,"Saint-Romuald, QC",QC,46.761333,-71.240333,Canada,CHS,St-Romuald,America/Toronto
+03264,"Quai des Cageux, QC",QC,46.755,-71.2715,Canada,CHS,Quai Irving,America/Toronto
+03265,"Pont de Québec, QC",QC,46.745581,-71.287938,Canada,CHS,,America/Toronto
+03270,"Saint-Nicolas, QC",QC,46.712,-71.378833,Canada,CHS,,America/Toronto
+03280,"Neuville, QC",QC,46.6965,-71.572833,Canada,CHS,,America/Toronto
+03295,"Pointe Platon, QC",QC,46.670833,-71.846,Canada,CHS,Pointe-au-Platon,America/Toronto
+03300,"Portneuf, QC",QC,46.681167,-71.877167,Canada,CHS,,America/Toronto
+03304,"Lotbinière (moulin à blé), QC",QC,46.650667,-71.889833,Canada,CHS,Moulin a Ble,America/Toronto
+03325,"Grondines, QC",QC,46.585333,-72.038833,Canada,CHS,,America/Toronto
+03335,"Deschaillons-sur-Saint-Laurent, QC",QC,46.561033,-72.106222,Canada,CHS,Deschaillons,America/Toronto
+03337,"Les Bricailles, QC",QC,46.549833,-72.134333,Canada,CHS,Brickyard,America/Toronto
+03345,"Batiscan, QC",QC,46.500333,-72.245833,Canada,CHS,,America/Toronto
+03350,"Champlain, QC",QC,46.440167,-72.339667,Canada,CHS,,America/Toronto
+03353,"Bécancour, QC",QC,46.400333,-72.3795,Canada,CHS,Becancour,America/Toronto
+03360,"Trois-Rivières, QC",QC,46.3405,-72.539167,Canada,CHS,,America/Toronto
+03424,"Baie-Sainte-Catherine, QC",QC,48.126333,-69.72975,Canada,CHS,Anse du Portage,America/Toronto
+03425,"Tadoussac, QC",QC,48.138333,-69.714,Canada,CHS,,America/Toronto
+03440,"L'Anse-Saint-Jean, QC",QC,48.245,-70.179667,Canada,CHS,Anse Saint-Jean,America/Toronto
+03460,"Port-Alfred, QC",QC,48.3339,-70.869267,Canada,CHS,Port Alfred,America/Toronto
+03466,"Grande-Anse, QC",QC,48.401667,-70.832833,Canada,CHS,,America/Toronto
+03480,"Chicoutimi, QC",QC,48.43083333,-71.05483333,Canada,CHS,,America/Toronto
+03510,"Qarqortoq, Greenland",Greenland,60.716667,-46.033333,Canada,CHS,"Julianehaab, JULIANEHAAB",America/Nuuk
+03575,"Nuuk, Greenland",Greenland,64.183333,-51.75,Canada,CHS,"Godthaab, GODTHAAB",America/Nuuk
+03670,"North Star Bay, Greenland",Greenland,76.545,-68.875,Canada,CHS,Pituffik,America/Thule
+03671,"Thule, Greenland",Greenland,76.533333,-68.900002,Canada,CHS,Pituffik,America/Thule
+03690,"Foulke Harbour, Greenland",Greenland,78.3,-72.633333,Canada,CHS,"Foulke Fiord, FOULKE FIORD, Foulke Havn",America/Thule
+03710,"Rensselaer Bay, Greenland",Greenland,78.6258,-70.9658,Canada,CHS,,America/Thule
+03735,"Thank God Harbour, Greenland",Greenland,81.6,-61.633333,Canada,CHS,Thank God Havn,America/Nuuk
+03755,"Cape Bryant, Greenland",Greenland,82.338,-55.2044,Canada,CHS,,America/Nuuk
+03765,"Alert, NU",NU,82.494152,-62.3096,Canada,CHS,"Dumb Bell Bay, DUMB BELL BAY",America/Iqaluit
+03780,"Cape Sheridan , NU",NU,82.455349,-61.448051,Canada,CHS,,America/Iqaluit
+03785,"Wrangel Bay, NU",NU,82.0,-62.5,Canada,CHS,,America/Iqaluit
+03790,"Discovery Harbour, NU",NU,81.733333,-64.733333,Canada,CHS,DISCOVERY HBR.,America/Iqaluit
+03838,"Alexandra Fiord, NU",NU,78.9118,-75.479496,Canada,CHS,,America/Iqaluit
+03840,"Pim Island, NU",NU,78.671667,-74.171667,Canada,CHS,,America/Iqaluit
+03902,"Cape Liverpool, NU",NU,73.65,-78.05,Canada,CHS,,America/Iqaluit
+03916,"Nova Zembla Island, NU",NU,72.169083,-74.920444,Canada,CHS,,America/Iqaluit
+03940,"Clyde River, NU",NU,70.464361,-68.587167,Canada,CHS,,America/Iqaluit
+03960,"Cape Hooper, NU",NU,68.46276,-66.817,Canada,CHS,,America/Iqaluit
+03970,"Kivitoo, NU",NU,67.93,-64.93,Canada,CHS,,America/Iqaluit
+03980,"Qikiqtarjuaq, NU",NU,67.56052,-64.031752,Canada,CHS,"Broughton Island, BROUGHTON ISLAND",America/Iqaluit
+03995,"Cape Dyer, NU",NU,66.558333,-61.659444,Canada,CHS,,America/Iqaluit
+04029,"Pangnirtung, NU",NU,66.140883,-65.8284,Canada,CHS,,America/Iqaluit
+04031,"Aulatsivik Point, NU",NU,66.181086,-65.636452,Canada,CHS,,America/Iqaluit
+04040,"Clearwater Fiord, NU",NU,66.6,-67.316667,Canada,CHS,,America/Iqaluit
+04045,"Imigen Island, NU",NU,66.027274,-67.07126,Canada,CHS,,America/Iqaluit
+04070,"Brevoort Harbour, NU",NU,63.316667,-64.15,Canada,CHS,,America/Iqaluit
+04100,"Resor Island, NU",NU,63.214933,-67.9904,Canada,CHS,,America/Iqaluit
+04120,"Frobisher's Farthest, NU",NU,63.47985,-68.027527,Canada,CHS,,America/Iqaluit
+04135,"Lewis Bay, NU",NU,63.6,-68.075,Canada,CHS,,America/Iqaluit
+04140,"Iqaluit, NU",NU,63.712667,-68.5025,Canada,CHS,"Koojesse Inlet, Frobisher Bay, FROBISHER BAY, KOOJESSE INLET",America/Iqaluit
+04160,"Sorry Harbour, NU",NU,61.616667,-64.733333,Canada,CHS,,America/Iqaluit
+04170,"Acadia Cove, NU",NU,61.343078,-64.898161,Canada,CHS,,America/Iqaluit
+04205,"Kimmirut, NU",NU,62.796,-69.775,Canada,CHS,"Lake Harbour, LAKE HARBOUR",America/Iqaluit
+04215,"Ashe Inlet, NU",NU,62.54086,-70.54564,Canada,CHS,"Big Island, Big Island",America/Iqaluit
+04245,"Kinngait, NU",NU,64.22967,-76.49499,Canada,CHS,Cape Dorset,America/Iqaluit
+04255,"Schooner Harbour, NU",NU,64.4035,-77.875,Canada,CHS,,America/Iqaluit
+04265,"Port Burwell, NU",NU,60.4175,-64.842,Canada,CHS,"Killiniq, Killiniq",America/Iqaluit
+04275,"Beacon Island, QC",QC,58.900168,-66.334805,Canada,CHS,,America/Iqaluit
+04279,"Kangiqsualujjuaq, QC",QC,58.668433,-65.948088,Canada,CHS,,America/Toronto
+04294,"Rivière Koksoak est, QC",QC,58.524967,-68.149917,Canada,CHS,Koksoak #1,America/Toronto
+04295,"Rivière Koksoak, QC",QC,58.527251,-68.193244,Canada,CHS,Koksoak River Entrance,America/Toronto
+04296,"The Narrows, QC",QC,58.39675,-68.212194,Canada,CHS,Koksoak #2,America/Toronto
+04297,"Île Mackays, QC",QC,58.26045,-68.266283,Canada,CHS,"Ile Mackays, Koksoak #3, MacKay's Island",America/Toronto
+04298,"Kuujjuaq, QC",QC,58.1,-68.316667,Canada,CHS,"Fort Chimo, Koksoak #4, Little Elbow Island",America/Toronto
+04315,"Tasiujaq, QC",QC,58.733333,-69.833333,Canada,CHS,"Leaf Basin, LEAF BASIN, Lac Aux Feuilles",America/Toronto
+04325,"Hopes Advance Bay, QC",QC,59.332569,-69.692256,Canada,CHS,,America/Toronto
+04335,"Agvik Island, NU",NU,60.016667,-69.7,Canada,CHS,"Payne Bay, Payne Bay",America/Toronto
+04340,"Île Pikiyulik, QC",QC,59.996728,-69.913881,Canada,CHS,"Ile Pikiulik, Ile Pikiulik, Pikiyulik Island",America/Toronto
+04345,"Île Basking, QC",QC,59.98833,-70.07917,Canada,CHS,"Ile Basking, Basking Island, Ile Basking",America/Toronto
+04379,"Quaqtaq, QC",QC,61.047083,-69.669944,Canada,CHS,"Koartac, Koartac",America/Iqaluit
+04380,"Diana Bay, QC",QC,60.866667,-70.066667,Canada,CHS,"Quaqtaq, Quaqtaq",America/Toronto
+04400,"Stupart Bay, QC",QC,61.583333,-71.533333,Canada,CHS,,America/Toronto
+04415,"Doctor Island, QC",QC,61.680556,-71.568333,Canada,CHS,,America/Iqaluit
+04425,"Kangiqsujuaq, QC",QC,61.6061,-71.961358,Canada,CHS,"Baie Wakeham, Baie Wakeham, Wakeham Bay",America/Iqaluit
+04435,"Douglas Harbour, QC",QC,61.878667,-72.6802,Canada,CHS,"Havre Douglas, Havre Douglas",America/Iqaluit
+04460,"Deception Bay, QC",QC,62.147762,-74.694494,Canada,CHS,"Baie Deception, Baie Deception",America/Iqaluit
+04470,"Salluit, QC",QC,62.216667,-75.65,Canada,CHS,"Sugluk, Salluit, Sugluk, Saglouc",America/Iqaluit
+04480,"Digges Harbour, NU",NU,62.561361,-77.869833,Canada,CHS,,America/Iqaluit
+04490,"Port De Laperriere, NU",NU,62.566667,-78.066667,Canada,CHS,,America/Iqaluit
+04500,"Port De Boucherville, NU",NU,63.166667,-77.583333,Canada,CHS,,America/Iqaluit
+04538,"Akulivik, QC",QC,60.801507,-78.219061,Canada,CHS,,America/Iqaluit
+04548,"North Kopak Island, NU",NU,60.003637,-77.733327,Canada,CHS,"North Kopac Island , North Kopac Island",America/Iqaluit
+04550,"Povungnituk, QC",QC,60.0325,-77.279167,Canada,CHS,,America/Iqaluit
+04575,"Inukjuak, QC",QC,58.445883,-78.101725,Canada,CHS,"Port Harrison, Inoucdjouac, Port Harrison, Inoucdjouac",America/Iqaluit
+04597,"Gillies Island, NU",NU,56.549195,-76.640285,Canada,CHS,,America/Iqaluit
+04600,"Tukarak Island, NU",NU,56.316667,-78.833333,Canada,CHS,,America/Iqaluit
+04604,"Belanger Island, NU",NU,56.132021,-76.707148,Canada,CHS,,America/Iqaluit
+04610,"Innetalling Island, NU",NU,55.9,-79.066667,Canada,CHS,,America/Iqaluit
+04620,"Flaherty Island, NU",NU,55.9,-79.616667,Canada,CHS,,America/Iqaluit
+04628,"Sanikiluaq, NU",NU,56.624722,-79.224555,Canada,CHS,"Eskimo Harbour, Eskimo Harbour, Renouf Island",America/Iqaluit
+04645,"Kuujjuarapik, QC",QC,55.266667,-77.766667,Canada,CHS,"Great Whale, Poste-de-la-Baleine, POSTE-DE-LA-BALEINE, GREAT WHALE",America/Toronto
+04648,"Bear Island, NU",NU,55.1,-78.35,Canada,CHS,,America/Iqaluit
+04655,"Long Island, NU",NU,54.766667,-79.733333,Canada,CHS,"Pointe Louis-XIV, POINTE LOUIS-XIV",America/Iqaluit
+04662,"Roggan River, QC",QC,54.390764,-79.492806,Canada,CHS,,America/Iqaluit
+04680,"La Grande Riviere , QC",QC,53.85,-79.15,Canada,CHS,"Fort George River, Loon Point, Fort George River, Loon Point",America/Iqaluit
+04681,"Loon Island, NU",NU,53.814656,-79.170782,Canada,CHS,,America/Iqaluit
+04688,"Hook Island, NU",NU,53.435327,-79.122359,Canada,CHS,,America/Iqaluit
+04710,"Eastmain River, QC",QC,52.231944,-78.559777,Canada,CHS,,America/Toronto
+04720,"Strutton Islands, NU",NU,52.083333,-78.95,Canada,CHS,,America/Iqaluit
+04730,"Charlton Island, NU",NU,51.966667,-79.3,Canada,CHS,,America/Iqaluit
+04740,"Stag Island, QC",QC,51.633333,-79.033333,Canada,CHS,,America/Iqaluit
+04780,"Sand Head, ON",ON,51.416667,-80.35,Canada,CHS,,America/Iqaluit
+04790,"Ship Sands Island, ON",ON,51.333333,-80.433333,Canada,CHS,,America/Toronto
+04800,"Nicholson Creek, ON",ON,51.3,-80.566667,Canada,CHS,,America/Toronto
+04810,"Moosonee, ON",ON,51.283333,-80.633333,Canada,CHS,Moosonee Gov't Wharf,America/Toronto
+04840,"Fort Albany, ON",ON,52.218889,-81.635556,Canada,CHS,,America/Toronto
+04880,"Bear Island, NU",NU,54.353333,-81.083333,Canada,CHS,,America/Iqaluit
+04920,"Winisk, ON",ON,55.283333,-85.1,Canada,CHS,,America/Toronto
+04980,"Port Nelson, MB",MB,57.0,-92.5,Canada,CHS,"Nelson, Nelson",America/Winnipeg
+05010,"Churchill, MB",MB,58.773429,-94.1919,Canada,CHS,,America/Winnipeg
+05040,"Arviat, NU",NU,61.110005,-94.063663,Canada,CHS,"Eskimo Point, ESKIMO POINT",America/Rankin_Inlet
+05055,"Whale Cove, NU",NU,62.166667,-92.566667,Canada,CHS,,America/Rankin_Inlet
+05070,"Marble Island, NU",NU,62.683333,-91.2,Canada,CHS,,America/Rankin_Inlet
+05090,"Panorama Island, NU",NU,62.79141,-92.094102,Canada,CHS,,America/Rankin_Inlet
+05100,"Rankin Inlet, NU",NU,62.816667,-92.066667,Canada,CHS,,America/Rankin_Inlet
+05140,"Chesterfield Inlet, NU",NU,63.329917,-90.684583,Canada,CHS,,America/Rankin_Inlet
+05141,"Akreavenek Island, NU",NU,63.417306,-90.6665,Canada,CHS,Sandpiper Island,America/Rankin_Inlet
+05159,"Norton Island, NU",NU,64.0,-94.216667,Canada,CHS,,America/Rankin_Inlet
+05160,"Chesterfield Narrows, NU",NU,63.991528,-94.302611,Canada,CHS,Ice Cutter Point,America/Rankin_Inlet
+05161,"Schooner Cove, NU",NU,63.989217,-94.2686,Canada,CHS,,America/Rankin_Inlet
+05180,"Coral Harbour, NU",NU,64.130451,-83.261479,Canada,CHS,,America/Atikokan
+05190,"Cape Dobbs, NU",NU,65.10061,-86.963472,Canada,CHS,,America/Rankin_Inlet
+05193,"Paliak Islands, NU",NU,65.386722,-89.045389,Canada,CHS,,America/Rankin_Inlet
+05195,"Bennett Bay, NU",NU,65.875333,-89.528639,Canada,CHS,,America/Rankin_Inlet
+05200,"Naujaat, NU",NU,66.519333,-86.307472,Canada,CHS,Repulse Bay,America/Rankin_Inlet
+05275,"Sanirajak, NU",NU,68.75,-81.216667,Canada,CHS,Hall Beach,America/Iqaluit
+05295,"Igloolik, NU",NU,69.346283,-81.729617,Canada,CHS,,America/Iqaluit
+05310,"Sevigny Point, NU",NU,69.783333,-82.116667,Canada,CHS,,America/Iqaluit
+05330,"Purfur Cove, NU",NU,69.836361,-84.254,Canada,CHS,,America/Iqaluit
+05350,"Entrance Island, NU",NU,69.9,-85.6,Canada,CHS,,America/Rankin_Inlet
+05358,"Needle Cove, NU",NU,69.090317,-79.112332,Canada,CHS,,America/Iqaluit
+05430,"Dundas Harbour, NU",NU,74.52,-82.43,Canada,CHS,,America/Iqaluit
+05490,"Rigby Bay, NU",NU,74.556667,-90.165667,Canada,CHS,,America/Rankin_Inlet
+05500,"Radstock Bay, NU",NU,74.706667,-91.03,Canada,CHS,,America/Rankin_Inlet
+05510,"Beechey Island, NU",NU,74.716667,-91.9,Canada,CHS,,America/Rankin_Inlet
+05560,"Resolute, NU",NU,74.655667,-94.875833,Canada,CHS,,America/Resolute
+05600,"Cape Capel, NU",NU,75.031944,-98.083333,Canada,CHS,,America/Rankin_Inlet
+05615,"Hamilton Island, NU",NU,74.191667,-99.16,Canada,CHS,,America/Rankin_Inlet
+05643,"Natkusiak Peninsula, NT",NT,73.016667,-110.466667,Canada,CHS,,America/Edmonton
+05645,"Winter Harbour, NU",NU,74.783333,-110.8,Canada,CHS,"WINTER HARBOUR, N.W.T.",America/Edmonton
+05650,"Peel Point, NT",NT,73.266667,-115.183333,Canada,CHS,,America/Edmonton
+05790,"Koluktoo Bay, NU",NU,72.106564,-80.74431,Canada,CHS,"Navy Board Inlet, NAVY BOARD INLET",America/Iqaluit
+05795,"Pisiktarfik Island, NU",NU,72.576306,-80.35275,Canada,CHS,,America/Iqaluit
+05800,"Pond Inlet, NU",NU,72.7,-77.966667,Canada,CHS,POND INLET (SITE),America/Iqaluit
+05860,"Strathcona Sound, NU",NU,73.069722,-84.548333,Canada,CHS,,America/Iqaluit
+05865,"Arctic Bay, NU",NU,72.99271,-85.0619,Canada,CHS,,America/Rankin_Inlet
+05905,"Port Leopold, NU",NU,73.833333,-90.333333,Canada,CHS,,America/Rankin_Inlet
+05906,"Whaler Point, NU",NU,73.816666,-90.283333,Canada,CHS,,America/Rankin_Inlet
+05912,"Port Bowen, NU",NU,73.28,-89.041667,Canada,CHS,,America/Rankin_Inlet
+05917,"Bellot Strait East, NU",NU,72.016666,-94.333333,Canada,CHS,,America/Cambridge_Bay
+05918,"Fury Point, NU",NU,72.900002,-91.783333,Canada,CHS,,America/Rankin_Inlet
+05930,"Fort Ross, NU",NU,72.00802,-94.2165,Canada,CHS,,America/Cambridge_Bay
+05935,"Cape Kater, NU",NU,71.966666,-90.066666,Canada,CHS,,America/Rankin_Inlet
+05940,"Cape Augherston, NU",NU,71.3735,-93.01,Canada,CHS,,America/Cambridge_Bay
+05948,"Lavoie Islands, NU",NU,71.02,-87.6085,Canada,CHS,,America/Rankin_Inlet
+05960,"Martin Islands, NU",NU,70.316666,-91.666666,Canada,CHS,,America/Cambridge_Bay
+05970,"Crown Prince Frederik Island, NU",NU,69.99725,-87.1,Canada,CHS,,America/Rankin_Inlet
+05975,"Cape Chapman, NU",NU,69.27475,-89.24025,Canada,CHS,,America/Cambridge_Bay
+05976,"Cape Berens, NU",NU,69.066666,-90.633333,Canada,CHS,,America/Cambridge_Bay
+05978,"Cape Miles, NU",NU,69.333,-85.43175,Canada,CHS,,America/Rankin_Inlet
+05985,"Kugaaruk, NU",NU,68.52706,-89.848803,Canada,CHS,"Pelly Bay, Pelly Bay",America/Cambridge_Bay
+05990,"Cape Sibbald, NU",NU,69.333333,-85.7667,Canada,CHS,,America/Rankin_Inlet
+05992,"Cape Barclay, NU",NU,68.233333,-88.133333,Canada,CHS,,America/Rankin_Inlet
+05998,"Dease Peninsula, NU",NU,67.266667,-87.15,Canada,CHS,,America/Rankin_Inlet
+06100,"False Strait, NU",NU,71.983333,-95.166667,Canada,CHS,,America/Cambridge_Bay
+06110,"Tasmania Island, NU",NU,71.2,-96.416667,Canada,CHS,,America/Cambridge_Bay
+06140,"Cape Felix, NU",NU,69.9465,-97.909639,Canada,CHS,,America/Cambridge_Bay
+06144,"Oscar Bay, NU",NU,69.7798,-95.833867,Canada,CHS,,America/Cambridge_Bay
+06150,"Taloyoak, NU",NU,69.529633,-93.536933,Canada,CHS,"Spence Bay, SPENCE BAY",America/Cambridge_Bay
+06160,"Shepherd Bay, NU",NU,68.76667,-93.566666,Canada,CHS,,America/Cambridge_Bay
+06170,"Gjoa Haven, NU",NU,68.617208,-95.888139,Canada,CHS,,America/Cambridge_Bay
+06210,"Gladman Point, NU",NU,68.648444,-97.737444,Canada,CHS,,America/Cambridge_Bay
+06213,"Island NE of M'Clintock Point, NU",NU,69.348617,-99.963433,Canada,CHS,Racon Island,America/Cambridge_Bay
+06225,"Jenny Lind Island, NU",NU,68.653333,-101.756667,Canada,CHS,,America/Cambridge_Bay
+06230,"Kean Point, NU",NU,68.955,-102.361667,Canada,CHS,"Kean Point, Victoria Island",America/Cambridge_Bay
+06240,"Cambridge Bay, NU",NU,69.116667,-105.066667,Canada,CHS,,America/Cambridge_Bay
+06250,"Baychimo, NU",NU,67.698,-107.9325,Canada,CHS,,America/Cambridge_Bay
+06255,"Quadyuk Island, NU",NU,66.91575,-107.8125,Canada,CHS,,America/Cambridge_Bay
+06284,"Austin Bay, NU",NU,68.5335,-113.300528,Canada,CHS,,America/Cambridge_Bay
+06285,"Black Berry Island, NU",NU,68.240483,-113.335983,Canada,CHS,,America/Cambridge_Bay
+06290,"Kugluktuk, NU",NU,67.879417,-115.217944,Canada,CHS,"Coppermine, COPPERMINE",America/Cambridge_Bay
+06310,"Bernard Harbour, NU",NU,68.784,-114.7585,Canada,CHS,,America/Cambridge_Bay
+06338,"Tysoe Point, NU",NU,69.616667,-120.783333,Canada,CHS,,America/Inuvik
+06340,"Pearce Point, NT",NT,69.816389,-122.666667,Canada,CHS,,America/Inuvik
+06350,"Paulatuk, NT",NT,69.35,-124.066667,Canada,CHS,,America/Inuvik
+06360,"Cape Parry, NT",NT,70.15,-124.666667,Canada,CHS,,America/Inuvik
+06367,"Franklin Bay, NT",NT,69.95,-126.916667,Canada,CHS,,America/Inuvik
+06380,"Ulukhaktok, NT",NT,70.736528,-117.756278,Canada,CHS,Holman,America/Edmonton
+06424,"Sachs Harbour, NT",NT,71.966667,-125.25,Canada,CHS,,America/Inuvik
+06443,"Baillie Is. (South Spit), NT",NT,70.516667,-128.35,Canada,CHS,,America/Inuvik
+06457,"Krubluyak Point, NT",NT,69.533333,-130.95,Canada,CHS,"Eskimo Lakes (Entrance), ESKIMO LAKES, Eskimo Lakes (Entrance)",America/Inuvik
+06472,"Cape Dalhousie, NT",NT,70.266667,-129.65,Canada,CHS,,America/Inuvik
+06476,"Atkinson Point, NT",NT,69.95,-131.416667,Canada,CHS,,America/Inuvik
+06485,"Tuktoyaktuk, NT",NT,69.438226,-132.994402,Canada,CHS,,America/Inuvik
+06495,"Hooper Island, YT",YT,69.683333,-134.833333,Canada,CHS,,America/Inuvik
+06497,"Pelly Island, NT",NT,69.616667,-135.366667,Canada,CHS,,America/Inuvik
+06505,"Shingle Point, YT",YT,68.933333,-137.2,Canada,CHS,,America/Whitehorse
+06515,"Kay Point, YT",YT,69.283333,-138.433333,Canada,CHS,,America/Dawson
+06525,"Herschel Island, YT",YT,69.570328,-138.924608,Canada,CHS,,America/Dawson
+06560,"Cape Skogn, NU",NU,75.763889,-84.216111,Canada,CHS,,America/Iqaluit
+06570,"Grise Fiord, NU",NU,76.41966,-83.133067,Canada,CHS,,America/Iqaluit
+06580,"Bay of Woe, NU",NU,76.416667,-89.016667,Canada,CHS,"BAY OF WOE, JONES SD.",America/Rankin_Inlet
+06640,"Eureka, NU",NU,79.985067,-85.908967,Canada,CHS,,America/Rankin_Inlet
+06660,"Iceberg Point, NU",NU,80.416667,-86.166667,Canada,CHS,,America/Rankin_Inlet
+06670,"Greely Fiord, NU",NU,80.6,-79.583333,Canada,CHS,,America/Iqaluit
+06680,"Tanquary Camp, NU",NU,81.4,-76.916667,Canada,CHS,,America/Iqaluit
+06704,"Kleybolte Peninsula, NU",NU,81.55,-91.55,Canada,CHS,,America/Rankin_Inlet
+06730,"Disreali Fiord, NU",NU,82.883333,-73.5,Canada,CHS,,America/Iqaluit
+06735,"Cape Aldrich, NU",NU,83.116667,-69.666667,Canada,CHS,,America/Iqaluit
+06758,"Little Cornwallis Island, NU",NU,75.383333,-96.95,Canada,CHS,"Polaris Mine, POLARIS MINE",America/Rankin_Inlet
+06765,"Airstrip Point, NU",NU,76.070241,-97.590035,Canada,CHS,"Penny Strait, PENNY STRAIT",America/Rankin_Inlet
+06780,"Northumberland Sound, NU",NU,76.866667,-96.7,Canada,CHS,,America/Rankin_Inlet
+06787,"Cameron Island, NU",NU,76.316666,-104.033333,Canada,CHS,,America/Cambridge_Bay
+06910,"Isachsen, NU",NU,78.780055,-103.507806,Canada,CHS,,America/Cambridge_Bay
+06955,"Mould Bay, NU",NU,76.283333,-119.466667,Canada,CHS,,America/Edmonton
+07010,"Point No Point, BC",BC,48.3951,-123.9709,Canada,CHS,,America/Vancouver
+07013,"Sheringham Point, BC",BC,48.377066,-123.921166,Canada,CHS,,America/Vancouver
+07020,"Sooke, BC",BC,48.3695,-123.726,Canada,CHS,,America/Vancouver
+07024,"Sooke Basin, BC",BC,48.3742,-123.6818,Canada,CHS,,America/Vancouver
+07030,"Becher Bay, BC",BC,48.3349,-123.6038,Canada,CHS,,America/Vancouver
+07080,"Pedder Bay, BC",BC,48.3317,-123.5501,Canada,CHS,,America/Vancouver
+07082,"William Head, BC",BC,48.341,-123.5369,Canada,CHS,,America/Vancouver
+07109,"Esquimalt Harbour, BC",BC,48.440433,-123.449833,Canada,CHS,,America/Vancouver
+07110,"Esquimalt Government  Hbr., BC",BC,48.432166,-123.438533,Canada,CHS,,America/Vancouver
+07115,"Clover Point, BC",BC,48.403816,-123.3486,Canada,CHS,,America/Vancouver
+07120,"Victoria Harbour, BC",BC,48.424363,-123.370828,Canada,CHS,,America/Vancouver
+07121,"Selkirk Water, BC",BC,48.439277,-123.379472,Canada,CHS,,America/Vancouver
+07122,"Gorge at Aaron Point, BC",BC,48.4444,-123.3952,Canada,CHS,,America/Vancouver
+07123,"Gorge at Tillicum, BC",BC,48.44775,-123.403583,Canada,CHS,,America/Vancouver
+07124,"Gorge at Craigflower, BC",BC,48.4509,-123.4215,Canada,CHS,,America/Vancouver
+07125,"Portage Inlet, BC",BC,48.4571,-123.4166,Canada,CHS,,America/Vancouver
+07130,"Oak Bay, BC",BC,48.4237,-123.3027,Canada,CHS,,America/Vancouver
+07140,"Finnerty Cove, BC",BC,48.473583,-123.296083,Canada,CHS,,America/Vancouver
+07255,"Saanichton Bay, BC",BC,48.5989,-123.3885,Canada,CHS,,America/Vancouver
+07260,"Sidney, BC",BC,48.649216,-123.3929,Canada,CHS,,America/Vancouver
+07270,"Swartz Bay, BC",BC,48.6892,-123.4108,Canada,CHS,,America/Vancouver
+07277,"Patricia Bay, BC",BC,48.6536,-123.4515,Canada,CHS,,America/Vancouver
+07280,"Brentwood Bay, BC",BC,48.578,-123.467,Canada,CHS,,America/Vancouver
+07284,"Finlayson Arm, BC",BC,48.4966,-123.5529,Canada,CHS,,America/Vancouver
+07310,"Cowichan Bay, BC",BC,48.7404,-123.6184,Canada,CHS,,America/Vancouver
+07315,"Maple Bay, BC",BC,48.8157,-123.60961,Canada,CHS,,America/Vancouver
+07330,"Fulford Harbour, BC",BC,48.769,-123.451,Canada,CHS,,America/Vancouver
+07345,"Narvaez Bay, BC",BC,48.7743,-123.0981,Canada,CHS,,America/Vancouver
+07350,"Bedwell Harbour, BC",BC,48.7478,-123.2273,Canada,CHS,,America/Vancouver
+07360,"Hope Bay, BC",BC,48.8034,-123.2759,Canada,CHS,,America/Vancouver
+07370,"Samuel Island, BC",BC,48.8217,-123.2084,Canada,CHS,,America/Vancouver
+07407,"Ganges, BC",BC,48.8534,-123.4973,Canada,CHS,,America/Vancouver
+07414,"Village Bay, BC",BC,48.8445,-123.3241,Canada,CHS,,America/Vancouver
+07420,"Montague Harbour, BC",BC,48.8927,-123.3922,Canada,CHS,,America/Vancouver
+07435,"North Galiano, BC",BC,48.9947,-123.5839,Canada,CHS,,America/Vancouver
+07437,"Porlier Pass, BC",BC,49.0113,-123.5859,Canada,CHS,,America/Vancouver
+07439,"Cardale Point, BC",BC,49.016667,-123.616667,Canada,CHS,,America/Vancouver
+07445,"Degnen Bay, BC",BC,49.133333,-123.716667,Canada,CHS,,America/Vancouver
+07450,"Crofton, BC",BC,48.874583,-123.643516,Canada,CHS,,America/Vancouver
+07455,"Chemainus, BC",BC,48.9256,-123.7144,Canada,CHS,,America/Vancouver
+07460,"Ladysmith, BC",BC,48.99895,-123.815316,Canada,CHS,,America/Vancouver
+07471,"Preedy Harbour, BC",BC,48.9802,-123.6777,Canada,CHS,,America/Vancouver
+07480,"Boat Harbour, BC",BC,49.09,-123.7982,Canada,CHS,,America/Vancouver
+07510,"Tumbo Channel, BC",BC,48.7932,-123.1088,Canada,CHS,,America/Vancouver
+07515,"Samuel Island, BC",BC,48.816667,-123.2,Canada,CHS,,America/Vancouver
+07525,"Georgina Point, BC",BC,48.8725,-123.2923,Canada,CHS,,America/Vancouver
+07528,"Miners Bay, BC",BC,48.85,-123.3,Canada,CHS,,America/Vancouver
+07532,"Whaler Bay, BC",BC,48.883333,-123.316667,Canada,CHS,,America/Vancouver
+07535,"Dionisio Point, BC",BC,49.0139,-123.5739,Canada,CHS,,America/Vancouver
+07542,"Valdes Island, BC",BC,49.058,-123.62,Canada,CHS,,America/Vancouver
+07550,"Silva Bay, BC",BC,49.15,-123.7,Canada,CHS,,America/Vancouver
+07577,"White Rock, BC",BC,49.016667,-122.8,Canada,CHS,,America/Vancouver
+07579,"Crescent Beach, BC",BC,49.033333,-122.883333,Canada,CHS,,America/Vancouver
+07590,"Tsawwassen, BC",BC,49.00677,-123.12933,Canada,CHS,,America/Vancouver
+07592,"Roberts Bank, BC",BC,49.015,-123.156,Canada,CHS,,America/Vancouver
+07594,"Sand Heads, BC",BC,49.1052,-123.3042,Canada,CHS,,America/Vancouver
+07607,"Steveston, BC",BC,49.1245,-123.1922,Canada,CHS,,America/Vancouver
+07609,"Deas Basin, BC",BC,49.1239,-123.083419,Canada,CHS,,America/Vancouver
+07610,"Woodward's Landing, BC",BC,49.1251,-123.0754,Canada,CHS,,America/Vancouver
+07654,"New Westminster, BC",BC,49.2,-122.91,Canada,CHS,,America/Vancouver
+07707,"Kitsilano, BC",BC,49.276583,-123.13936,Canada,CHS,,America/Vancouver
+07710,"False Creek, BC",BC,49.271,-123.12,Canada,CHS,,America/Vancouver
+07724,"Calamity Point, BC",BC,49.31257,-123.127678,Canada,CHS,,America/Vancouver
+07735,"Vancouver, BC",BC,49.2863,-123.0997,Canada,CHS,,America/Vancouver
+07755,"Port Moody, BC",BC,49.2877,-122.86583,Canada,CHS,,America/Vancouver
+07765,"Deep Cove, BC",BC,49.32683,-122.9485,Canada,CHS,,America/Vancouver
+07774,"Indian Arm Head, BC",BC,49.4618,-122.8861,Canada,CHS,,America/Vancouver
+07780,"Ambleside, BC",BC,49.32577,-123.15458,Canada,CHS,,America/Vancouver
+07786,"Sandy Cove, BC",BC,49.3405,-123.2319,Canada,CHS,"West Vancouver Laboratories, Ettershank Cove",America/Vancouver
+07795,"Point Atkinson, BC",BC,49.3375,-123.253583,Canada,CHS,Caulfeild Cove,America/Vancouver
+07803,"Port Mellon, BC",BC,49.519233,-123.485311,Canada,CHS,,America/Vancouver
+07808,"Darrell Bay, BC",BC,49.669,-123.169,Canada,CHS,,America/Vancouver
+07811,"Squamish Inner, BC",BC,49.695,-123.155,Canada,CHS,,America/Vancouver
+07820,"Gibsons, BC",BC,49.402,-123.505,Canada,CHS,,America/Vancouver
+07824,"Roberts Creek, BC",BC,49.419,-123.642,Canada,CHS,,America/Vancouver
+07830,"Halfmoon Bay, BC",BC,49.511,-123.912,Canada,CHS,,America/Vancouver
+07836,"Irvines Landing, BC",BC,49.633,-124.058,Canada,CHS,,America/Vancouver
+07837,"ḵalpilin, BC",BC,49.633,-124.032,Canada,CHS,Pender Harbour,America/Vancouver
+07842,"Egmont, BC",BC,49.749,-123.93,Canada,CHS,,America/Vancouver
+07843,"Boom Islet, BC",BC,49.745223,-123.903803,Canada,CHS,,America/Vancouver
+07847,"Storm Bay, BC",BC,49.662,-123.826,Canada,CHS,,America/Vancouver
+07852,"Porpoise Bay, BC",BC,49.482,-123.759,Canada,CHS,,America/Vancouver
+07860,"Malibu Islet, BC",BC,50.163,-123.85,Canada,CHS,,America/Vancouver
+07865,"Blind Bay, BC",BC,49.716,-124.179,Canada,CHS,"Ballet Bay, Ballet Bay",America/Vancouver
+07868,"Saltery Bay, BC",BC,49.783333,-124.183333,Canada,CHS,,America/Vancouver
+07875,"Blubber Bay, BC",BC,49.8,-124.616667,Canada,CHS,,America/Vancouver
+07880,"Powell River, BC",BC,49.866667,-124.55,Canada,CHS,,America/Vancouver
+07885,"Lund, BC",BC,49.983333,-124.766667,Canada,CHS,,America/Vancouver
+07892,"Twin Islands, BC",BC,50.03,-124.93,Canada,CHS,,America/Vancouver
+07895,"Mitlenatch, BC",BC,49.95,-124.998,Canada,CHS,,America/Vancouver
+07913,"Harmac, BC",BC,49.14,-123.846,Canada,CHS,,America/Vancouver
+07917,"Nanaimo Harbour, BC",BC,49.1628,-123.9235,Canada,CHS,Port of Nanaimo,America/Vancouver
+07930,"Nanoose Bay, BC",BC,49.25,-124.17,Canada,CHS,"Nanoose Harbour, B.C., Nanoose Harbour, B.C.",America/Vancouver
+07935,"Winchelsea Island, BC",BC,49.3,-124.086,Canada,CHS,,America/Vancouver
+07938,"Northwest Bay, BC",BC,49.303,-124.202,Canada,CHS,,America/Vancouver
+07940,"French Creek, BC",BC,49.349604,-124.358817,Canada,CHS,,America/Vancouver
+07953,"Hornby Island, BC",BC,49.49623,-124.676,Canada,CHS,"Ford Cove, B.C.",America/Vancouver
+07955,"Denman Island, BC",BC,49.53448,-124.8209,Canada,CHS,,America/Vancouver
+07965,"Comox, BC",BC,49.67,-124.928,Canada,CHS,,America/Vancouver
+07982,"False Bay, BC",BC,49.483,-124.35,Canada,CHS,,America/Vancouver
+07985,"Skerry Bay, BC",BC,49.5,-124.237,Canada,CHS,,America/Vancouver
+07990,"Welcome Bay, BC",BC,49.7,-124.55,Canada,CHS,,America/Vancouver
+07993,"Little River, BC",BC,49.741,-124.923,Canada,CHS,,America/Vancouver
+08006,"Okeover Inlet, BC",BC,49.98,-124.7,Canada,CHS,,America/Vancouver
+08008,"Prideaux Haven, BC",BC,50.15,-124.67,Canada,CHS,,America/Vancouver
+08015,"Channel Island, BC",BC,50.316667,-124.75,Canada,CHS,,America/Vancouver
+08025,"Redonda Bay, BC",BC,50.2604833,-124.95532,Canada,CHS,,America/Vancouver
+08035,"Heriot Bay, BC",BC,50.1,-125.2,Canada,CHS,,America/Vancouver
+08037,"Gorge Harbour, BC",BC,50.092,-124.989,Canada,CHS,,America/Vancouver
+08038,"Whaletown, BC",BC,50.108,-125.052,Canada,CHS,,America/Vancouver
+08045,"Surge Narrows, BC",BC,50.22719,-125.112,Canada,CHS,,America/Vancouver
+08050,"Octopus Islands, BC",BC,50.282,-125.224,Canada,CHS,,America/Vancouver
+08055,"Florence Cove, BC",BC,50.313,-125.165,Canada,CHS,,America/Vancouver
+08060,"Big Bay, Stuart Island, BC",BC,50.393,-125.13525,Canada,CHS,,America/Vancouver
+08065,"Orford Bay, BC",BC,50.597969,-124.864385,Canada,CHS,,America/Vancouver
+08069,"Waddington Harbour, BC",BC,50.873,-124.873,Canada,CHS,,America/Vancouver
+08074,"Campbell River, BC",BC,50.042,-125.247,Canada,CHS,,America/Vancouver
+08079,"Quathiaski Cove, BC",BC,50.047,-125.218,Canada,CHS,,America/Vancouver
+08082,"Gowlland Hbr., BC",BC,50.065,-125.217,Canada,CHS,,America/Vancouver
+08087,"Duncan Bay, BC",BC,50.076,-125.301,Canada,CHS,,America/Vancouver
+08095,"Bloedel - Menzies Bay, BC",BC,50.118,-125.381,Canada,CHS,,America/Vancouver
+08105,"Seymour Narrows, BC",BC,50.135,-125.346,Canada,CHS,,America/Vancouver
+08110,"Brown Bay, BC",BC,50.162,-125.375,Canada,CHS,,America/Vancouver
+08120,"Owen Bay, BC",BC,50.31045,-125.22343,Canada,CHS,,America/Vancouver
+08135,"Mermaid Bay, BC",BC,50.404,-125.1854,Canada,CHS,,America/Vancouver
+08142,"Thurlow Point, BC",BC,50.42016,-125.32823,Canada,CHS,,America/Vancouver
+08145,"Shoal Bay, BC",BC,50.46,-125.361,Canada,CHS,,America/Vancouver
+08150,"Cordero Islands, BC",BC,50.442,-125.492,Canada,CHS,,America/Vancouver
+08155,"Blind Channel, BC",BC,50.414,-125.502,Canada,CHS,,America/Vancouver
+08162,"Sidney Bay, BC",BC,50.516667,-125.583333,Canada,CHS,,America/Vancouver
+08180,"Chatham Pt., BC",BC,50.331,-125.442,Canada,CHS,,America/Vancouver
+08195,"Knox Bay, BC",BC,50.387,-125.619,Canada,CHS,,America/Vancouver
+08210,"Billy Goat Bay, BC",BC,50.398,-125.865,Canada,CHS,,America/Vancouver
+08215,"Kelsey Bay, BC",BC,50.398,-125.961,Canada,CHS,,America/Vancouver
+08233,"Yorke Island, BC",BC,50.444,-125.978,Canada,CHS,,America/Vancouver
+08245,"Port Neville, BC",BC,50.496,-126.087,Canada,CHS,,America/Vancouver
+08250,"Port Harvey, BC",BC,50.568,-126.268,Canada,CHS,,America/Vancouver
+08258,"Lagoon Cove, BC",BC,50.597716,-126.31895,Canada,CHS,,America/Vancouver
+08270,"Growler Cove, BC",BC,50.53,-126.62,Canada,CHS,,America/Vancouver
+08280,"Alert Bay, BC",BC,50.587,-126.931,Canada,CHS,,America/Vancouver
+08290,"Port McNeill, BC",BC,50.593,-127.094,Canada,CHS,,America/Vancouver
+08310,"Glendale Cove, BC",BC,50.674293,-125.736856,Canada,CHS,,America/Vancouver
+08311,"Siwash Bay, BC",BC,50.687166,-125.76065,Canada,CHS,,America/Vancouver
+08313,"Montagu Point, BC",BC,50.63908,-126.21283,Canada,CHS,,America/Vancouver
+08318,"Shewell Island, BC",BC,50.65833,-126.239167,Canada,CHS,,America/Vancouver
+08325,"Cedar Island, BC",BC,50.656667,-126.675,Canada,CHS,,America/Vancouver
+08340,"Sunday Harbour, BC",BC,50.72,-126.7,Canada,CHS,,America/Vancouver
+08347,"Kwatsi Bay, BC",BC,50.8643,-126.2486,Canada,CHS,,America/Vancouver
+08348,"Kingcome Inlet, BC",BC,50.908717,-126.19945,Canada,CHS,,America/Vancouver
+08364,"Sullivan Bay, BC",BC,50.886,-126.826,Canada,CHS,,America/Vancouver
+08371,"Jessie Point, BC",BC,50.951,-126.812,Canada,CHS,,America/Vancouver
+08379,"Stuart Narrows, BC",BC,50.897,-126.896,Canada,CHS,,America/Vancouver
+08384,"Jennis Bay, BC",BC,50.913,-127.026,Canada,CHS,,America/Vancouver
+08394,"Raynor Group, BC",BC,50.886,-127.243,Canada,CHS,,America/Vancouver
+08408,"Port Hardy, BC",BC,50.722,-127.489,Canada,CHS,,America/Vancouver
+08416,"Shushartie Bay, BC",BC,50.856,-127.859,Canada,CHS,,America/Vancouver
+08426,"Walker Group, BC",BC,50.899,-127.526,Canada,CHS,,America/Vancouver
+08438,"Fox Islands, BC",BC,51.081,-127.604,Canada,CHS,,America/Vancouver
+08440,"Treadwell Bay, BC",BC,51.103,-127.541,Canada,CHS,,America/Vancouver
+08458,"Frederick Sound, BC",BC,51.04,-126.734,Canada,CHS,,America/Vancouver
+08464,"Nugent Sound, BC",BC,51.083333,-127.25,Canada,CHS,,America/Vancouver
+08470,"Johnson Point, BC",BC,51.11,-127.537,Canada,CHS,,America/Vancouver
+08476,"Mereworth Sound, BC",BC,51.176,-127.409,Canada,CHS,"Village Cove, B.C., Village Cove, B.C.",America/Vancouver
+08482,"Belize Inlet, BC",BC,51.122,-127.274,Canada,CHS,,America/Vancouver
+08488,"Alison Sound, BC",BC,51.161,-126.982,Canada,CHS,,America/Vancouver
+08525,"Port Renfrew, BC",BC,48.555,-124.421,Canada,CHS,,America/Vancouver
+08545,"Bamfield, BC",BC,48.836,-125.136,Canada,CHS,,America/Vancouver
+08556,"Mutine Point, BC",BC,48.942,-125.019,Canada,CHS,,America/Vancouver
+08558,"Brooksby Point, BC",BC,48.982,-124.985,Canada,CHS,,America/Vancouver
+08559,"Head of Uchucklesit, BC",BC,49.016667,-125.05,Canada,CHS,,America/Vancouver
+08565,"Franklin River, BC",BC,49.108,-124.812,Canada,CHS,,America/Vancouver
+08575,"Port Alberni, BC",BC,49.225621,-124.813613,Canada,CHS,,America/Vancouver
+08585,"Effingham Bay, BC",BC,48.878,-125.313,Canada,CHS,,America/Vancouver
+08588,"Stopper Islands, BC",BC,48.993,-125.346,Canada,CHS,,America/Vancouver
+08595,"Ucluelet, BC",BC,48.947,-125.552,Canada,CHS,,America/Vancouver
+08615,"Tofino, BC",BC,49.154,-125.913,Canada,CHS,"Clayoquot , CLAYOQUOT",America/Vancouver
+08623,"Kennedy Cove, BC",BC,49.14,-125.671,Canada,CHS,,America/Vancouver
+08626,"Warn Bay, BC",BC,49.238868,-125.745536,Canada,CHS,,America/Vancouver
+08630,"Cypress Bay, BC",BC,49.261,-125.871,Canada,CHS,,America/Vancouver
+08632,"Herbert Inlet, BC",BC,49.346,-125.984,Canada,CHS,,America/Vancouver
+08634,"Sulphur Passage, BC",BC,49.404,-126.068,Canada,CHS,,America/Vancouver
+08637,"Riley Cove, BC",BC,49.391,-126.225,Canada,CHS,,America/Vancouver
+08645,"Saavedra Islands, BC",BC,49.622,-126.617,Canada,CHS,,America/Vancouver
+08650,"Gold River, BC",BC,49.679,-126.126,Canada,CHS,,America/Vancouver
+08664,"Ceepeecee, BC",BC,49.874,-126.716,Canada,CHS,,America/Vancouver
+08665,"Esperanza, BC",BC,49.872,-126.744,Canada,CHS,,America/Vancouver
+08670,"Zeballos, BC",BC,49.979,-126.846,Canada,CHS,,America/Vancouver
+08710,"Kyuquot, BC",BC,50.026,-127.376,Canada,CHS,,America/Vancouver
+08714,"Copp Island, BC",BC,50.045938,-127.190348,Canada,CHS,,America/Vancouver
+08715,"Fair Harbour, BC",BC,50.068867,-127.138867,Canada,CHS,,America/Vancouver
+08720,"Bunsby Islands, BC",BC,50.11756,-127.5096,Canada,CHS,,America/Vancouver
+08735,"Winter Harbour, BC",BC,50.513,-128.029,Canada,CHS,,America/Vancouver
+08736,"Hunt Islet, BC",BC,50.474,-128.03,Canada,CHS,,America/Vancouver
+08750,"Port Alice, BC",BC,50.384,-127.455,Canada,CHS,,America/Vancouver
+08751,"Port Alice South, BC",BC,50.41101,-127.48592,Canada,CHS,,America/Vancouver
+08754,"Bergh Cove, BC",BC,50.537,-127.624,Canada,CHS,,America/Vancouver
+08755,"Kwokwesta Creek, BC",BC,50.527,-127.569,Canada,CHS,,America/Vancouver
+08756,"Makwazniht Island, BC",BC,50.556,-127.554,Canada,CHS,,America/Vancouver
+08765,"Coal Harbour, BC",BC,50.599,-127.581,Canada,CHS,,America/Vancouver
+08790,"Cape Scott, BC",BC,50.78,-128.43,Canada,CHS,,America/Vancouver
+08805,"Egg Island, BC",BC,51.249,-127.836,Canada,CHS,,America/Vancouver
+08810,"Leroy Bay, BC",BC,51.273,-127.664,Canada,CHS,,America/Vancouver
+08812,"Boswell Inlet, BC",BC,51.372,-127.469,Canada,CHS,Security Bay,America/Vancouver
+08814,"Smith Inlet, BC",BC,51.336,-127.188,Canada,CHS,,America/Vancouver
+08830,"Draney Inlet, BC",BC,51.476,-127.551,Canada,CHS,,America/Vancouver
+08840,"Wadhams, BC",BC,51.51,-127.524,Canada,CHS,,America/Vancouver
+08860,"Addenbroke Island, BC",BC,51.605,-127.826,Canada,CHS,,America/Vancouver
+08863,"Pruth Bay, BC",BC,51.654504,-128.129455,Canada,CHS,,America/Vancouver
+08865,"Adams Harbour, BC",BC,51.683333,-128.1,Canada,CHS,,America/Vancouver
+08866,"Starfish Island, BC",BC,51.686,-128.123,Canada,CHS,,America/Vancouver
+08870,"Namu, BC",BC,51.86153,-127.8657,Canada,CHS,,America/Vancouver
+08906,"Gosling Island, BC",BC,51.899,-128.442,Canada,CHS,,America/Vancouver
+08909,"Goose Island, BC",BC,51.992,-128.413,Canada,CHS,,America/Vancouver
+08912,"Spider Island, BC",BC,51.845,-128.231,Canada,CHS,,America/Vancouver
+08917,"Stryker Island, BC",BC,52.093,-128.348,Canada,CHS,,America/Vancouver
+08922,"Joassa Channel, BC",BC,52.192,-128.309,Canada,CHS,,America/Vancouver
+08932,"Larso Bay, BC",BC,52.179,-126.862,Canada,CHS,,America/Vancouver
+08937,"Bella Coola, BC",BC,52.374,-126.796,Canada,CHS,,America/Vancouver
+08941,"Labouchere Channel East, BC",BC,52.3829,-127.20847,Canada,CHS,,America/Vancouver
+08952,"Luke Passage, BC",BC,52.095,-127.853,Canada,CHS,,America/Vancouver
+08958,"Forit Bay, BC",BC,52.174,-127.91,Canada,CHS,,America/Vancouver
+08962,"Ocean Falls, BC",BC,52.352,-127.693,Canada,CHS,,America/Vancouver
+08970,"Kimsquit Channel, BC",BC,52.814,-127.001,Canada,CHS,,America/Vancouver
+08976,"Bella Bella, BC",BC,52.163,-128.143,Canada,CHS,,America/Vancouver
+08978,"Kynumpt Harbour, BC",BC,52.208,-128.162,Canada,CHS,,America/Vancouver
+08981,"Troup Passage, BC",BC,52.242,-128.039,Canada,CHS,,America/Vancouver
+08996,"Gerald Point, BC",BC,52.438,-128.084,Canada,CHS,,America/Vancouver
+08998,"Thompson Bay, BC",BC,52.16,-128.358,Canada,CHS,,America/Vancouver
+09005,"Port Blackney, BC",BC,52.312,-128.351,Canada,CHS,,America/Vancouver
+09010,"Tom Bay, BC",BC,52.402,-128.264,Canada,CHS,,America/Vancouver
+09020,"Griffin Passage, BC",BC,52.77,-128.346,Canada,CHS,,America/Vancouver
+09035,"Klemtu, BC",BC,52.594,-128.521,Canada,CHS,,America/Vancouver
+09051,"Cann Inlet, BC",BC,52.547181,-128.695281,Canada,CHS,,America/Vancouver
+09052,"Marvin Island, BC",BC,52.529639,-128.73885,Canada,CHS,,America/Vancouver
+09053,"Butedale, BC",BC,53.16,-128.694,Canada,CHS,,America/Vancouver
+09056,"Higgins Passage, BC",BC,52.483,-128.762,Canada,CHS,,America/Vancouver
+09058,"Price Island, BC",BC,52.278,-128.675,Canada,CHS,,America/Vancouver
+09060,"Meyers Narrows, BC",BC,52.604,-128.617,Canada,CHS,,America/Vancouver
+09063,"Milne Island, BC",BC,52.609,-128.769,Canada,CHS,,America/Vancouver
+09067,"Smithers Island, BC",BC,52.758,-129.073,Canada,CHS,,America/Vancouver
+09077,"McKenney Isl., BC",BC,52.65,-129.472,Canada,CHS,,America/Vancouver
+09078,"Moore Islands, BC",BC,52.673,-129.408,Canada,CHS,,America/Vancouver
+09080,"Borrowman Bay, BC",BC,52.737,-129.281,Canada,CHS,,America/Vancouver
+09082,"Beauchemin Channel, BC",BC,52.77758,-129.303048,Canada,CHS,,America/Vancouver
+09105,"Gillen Harbour, BC",BC,52.964,-129.606,Canada,CHS,,America/Vancouver
+09115,"Barnard Harbour, BC",BC,53.074,-129.117,Canada,CHS,,America/Vancouver
+09130,"Hartley Bay, BC",BC,53.424213,-129.251877,Canada,CHS,,America/Vancouver
+09140,"Kitimat, BC",BC,53.989,-128.696,Canada,CHS,,America/Vancouver
+09150,"Kemano Bay, BC",BC,53.478,-128.124,Canada,CHS,,America/Vancouver
+09163,"Oswald Bay, BC",BC,53.012917,-129.664639,Canada,CHS,,America/Vancouver
+09165,"Block Islands, BC",BC,53.157,-129.741,Canada,CHS,,America/Vancouver
+09180,"Patterson Inlet, BC",BC,53.4383,-129.8442,Canada,CHS,,America/Vancouver
+09195,"Lowe Inlet, BC",BC,53.55,-129.583333,Canada,CHS,,America/Vancouver
+09220,"Clear Passage, BC",BC,53.551,-129.964,Canada,CHS,,America/Vancouver
+09227,"Bonilla Island, BC",BC,53.493806,-130.636972,Canada,CHS,,America/Vancouver
+09230,"Griffith Harbour, BC",BC,53.599,-130.543,Canada,CHS,,America/Vancouver
+09232,"Larsen Island, BC",BC,53.619,-130.574,Canada,CHS,,America/Vancouver
+09242,"Kitkatla, BC",BC,53.803,-130.357,Canada,CHS,,America/Vancouver
+09250,"Seabreeze Point, BC",BC,53.987,-130.182,Canada,CHS,,America/Vancouver
+09260,"Claxton, BC",BC,54.079,-130.089,Canada,CHS,,America/Vancouver
+09266,"Haysport, BC",BC,54.178,-130.009,Canada,CHS,,America/Vancouver
+09275,"Khyex River, BC",BC,54.223,-129.8,Canada,CHS,,America/Vancouver
+09285,"Kwinitsa River, BC",BC,54.216667,-129.583333,Canada,CHS,,America/Vancouver
+09305,"Welcome Harbour, BC",BC,54.016667,-130.616667,Canada,CHS,,America/Vancouver
+09306,"Refuge Bay, BC",BC,54.053,-130.541,Canada,CHS,,America/Vancouver
+09309,"Humpback Bay, BC",BC,54.087,-130.395,Canada,CHS,,America/Vancouver
+09310,"Hunt Inlet, BC",BC,54.068,-130.446,Canada,CHS,,America/Vancouver
+09312,"Lawyer Islands, BC",BC,54.105,-130.334,Canada,CHS,,America/Vancouver
+09315,"Qlawdzeet Anchorage, BC",BC,54.208,-130.768,Canada,CHS,,America/Vancouver
+09325,"Moffatt Islands, BC",BC,54.446,-130.726,Canada,CHS,,America/Vancouver
+09329,"Hudson Bay Passage, BC",BC,54.457,-130.848,Canada,CHS,,America/Vancouver
+09333,"Brundige Inlet, BC",BC,54.613,-130.854,Canada,CHS,,America/Vancouver
+09338,"Aero Trading, BC",BC,54.212997,-130.288383,Canada,CHS,Aero Trading,America/Vancouver
+09339,"Pembina Terminal, BC",BC,54.236287,-130.303479,Canada,CHS,,America/Vancouver
+09340,"Inverness, BC",BC,54.194,-130.2249,Canada,CHS,,America/Vancouver
+09341,"Porpoise Channel East, BC",BC,54.21515,-130.28906,Canada,CHS,,America/Vancouver
+09342,"Port Edward, BC",BC,54.229,-130.296,Canada,CHS,,America/Vancouver
+09343,"Wainwright Basin, BC",BC,54.256216,-130.265239,Canada,CHS,,America/Vancouver
+09344,"Morse Basin, BC",BC,54.258319,-130.237624,Canada,CHS,,America/Vancouver
+09345,"Prince Rupert Grain, BC",BC,54.232778,-130.335875,Canada,CHS,,America/Vancouver
+09346,"Prince Rupert RoRo, BC",BC,54.234885,-130.335097,Canada,CHS,,America/Vancouver
+09348,"Fairview Terminal, BC",BC,54.290263,-130.359937,Canada,CHS,,America/Vancouver
+09350,"Casey Cove, BC",BC,54.279,-130.376,Canada,CHS,,America/Vancouver
+09354,"Prince Rupert, BC",BC,54.317,-130.324,Canada,CHS,,America/Vancouver
+09360,"Seal Cove, BC",BC,54.3311,-130.2796,Canada,CHS,,America/Vancouver
+09390,"Lax Kw'alaams, BC",BC,54.56,-130.431,Canada,CHS,Port Simpson,America/Vancouver
+09406,"Trail Bay, BC",BC,54.583,-130.357,Canada,CHS,,America/Vancouver
+09414,"Kumeon Bay, BC",BC,54.713,-130.24,Canada,CHS,,America/Vancouver
+09418,"Ranger Islet, BC",BC,54.837,-130.175,Canada,CHS,,America/Vancouver
+09422,"Gingolx, BC",BC,54.999,-129.978,Canada,CHS,Kincolith,America/Vancouver
+09425,"Mill Bay, BC",BC,54.994,-129.891,Canada,CHS,,America/Vancouver
+09435,"Salmon Cove, BC",BC,55.264,-129.846,Canada,CHS,,America/Vancouver
+09443,"Granby Bay, BC",BC,55.416,-129.818,Canada,CHS,,America/Vancouver
+09448,"Alice Arm, BC",BC,55.47,-129.496,Canada,CHS,,America/Vancouver
+09475,"Stewart, BC",BC,55.9166,-130.01,Canada,CHS,,America/Vancouver
+09502,"Cape St. James, BC",BC,51.938,-131.015,Canada,CHS,,America/Vancouver
+09511,"Houston Stewart Channel West, BC",BC,52.083333,-131.116667,Canada,CHS,Houston Stewart,America/Vancouver
+09512,"Gordon Islands, BC",BC,52.095,-131.141,Canada,CHS,,America/Vancouver
+09570,"Hunger Harbour, BC",BC,52.766,-132.047,Canada,CHS,,America/Vancouver
+09581,"Mudge Inlet, BC",BC,52.9619,-132.1218,Canada,CHS,,America/Vancouver
+09582,"Peel Inlet, BC",BC,52.98039,-132.10108,Canada,CHS,,America/Vancouver
+09583,"Leopold Island, BC",BC,52.98692,-132.17061,Canada,CHS,,America/Vancouver
+09585,"Security Cove, BC",BC,53.05647,-132.29061,Canada,CHS,,America/Vancouver
+09605,"Armentieres Channel, BC",BC,53.115,-132.389,Canada,CHS,,America/Vancouver
+09625,"Trounce Inlet, BC",BC,53.148,-132.322,Canada,CHS,,America/Vancouver
+09627,"Trounce Inlet North, BC",BC,53.15835,-132.32274,Canada,CHS,,America/Vancouver
+09635,"Dawson Harbour, BC",BC,53.166667,-132.466667,Canada,CHS,,America/Vancouver
+09650,"Shields Bay, BC",BC,53.313,-132.417,Canada,CHS,,America/Vancouver
+09667,"Nesto Inlet, BC",BC,53.55,-132.916667,Canada,CHS,,America/Vancouver
+09671,"Port Louis, BC",BC,53.685,-132.961,Canada,CHS,,America/Vancouver
+09708,"Heater Harbour, BC",BC,52.116667,-131.033333,Canada,CHS,,America/Vancouver
+09710,"High Island, BC",BC,52.124,-131.011,Canada,CHS,,America/Vancouver
+09713,"Rose Harbour, BC",BC,52.1552,-131.0909,Canada,CHS,,America/Vancouver
+09717,"Carpenter Bay, BC",BC,52.24,-131.156,Canada,CHS,,America/Vancouver
+09724,"Copper Islands, BC",BC,52.36,-131.181,Canada,CHS,,America/Vancouver
+09746,"Ramsay Island, BC",BC,52.583762,-131.378091,Canada,CHS,,America/Vancouver
+09753,"Sedgwick Bay, BC",BC,52.636,-131.583,Canada,CHS,,America/Vancouver
+09765,"Atli Inlet, BC",BC,52.714,-131.577,Canada,CHS,,America/Vancouver
+09775,"Pacofi Bay, BC",BC,52.832,-131.883,Canada,CHS,,America/Vancouver
+09781,"Louise Island, BC",BC,52.94128,-131.89934,Canada,CHS,,America/Vancouver
+09790,"McCoy Cove, BC",BC,53.041,-131.664,Canada,CHS,,America/Vancouver
+09795,"Sandspit Marina, BC",BC,53.237626,-131.863064,Canada,CHS,,America/Vancouver
+09808,"Shingle Bay, BC",BC,53.254,-131.822,Canada,CHS,,America/Vancouver
+09850,"Daajing Giids, BC",BC,53.252,-132.072,Canada,CHS,Queen Charlotte City,America/Vancouver
+09860,"Tlell, BC",BC,53.5517,-131.9078,Canada,CHS,,America/Vancouver
+09881,"Cape Ball, BC",BC,53.718333,-131.735,Canada,CHS,,America/Vancouver
+09910,"Masset, BC",BC,54.01,-132.149,Canada,CHS,,America/Vancouver
+09920,"Port Clements, BC",BC,53.6893,-132.184,Canada,CHS,,America/Vancouver
+09927,"Juskatla Inlet, BC",BC,53.628,-132.319,Canada,CHS,,America/Vancouver
+09930,"Dinan Bay, BC",BC,53.694094,-132.606175,Canada,CHS,,America/Vancouver
+09940,"Wiah Point, BC",BC,54.112,-132.31,Canada,CHS,,America/Vancouver
+09958,"Henslung Cove, BC",BC,54.191,-133.002,Canada,CHS,"Parry Passage, B.C., Parry Passage, B.C.",America/Vancouver
+09961,"Egeria Bay, BC",BC,54.216667,-132.966667,Canada,CHS,"Cohoe Pt., Egeria Bay",America/Vancouver
+09963,"McPherson Point, BC",BC,54.247,-132.98,Canada,CHS,,America/Vancouver
+09964,"Langara Point, BC",BC,54.256,-133.045,Canada,CHS,,America/Vancouver

--- a/app/database.py
+++ b/app/database.py
@@ -59,6 +59,7 @@ def init_database():
                 'longitude': 'REAL',
                 'province': 'TEXT',
                 'alternative_name': 'TEXT',
+                'timezone': 'TEXT',
             })
 
             cursor.execute('''
@@ -234,18 +235,19 @@ def _import_us_csv(csv_path):
                     csv_station_ids.add(station_id)
                     latitude = _parse_coord(row.get('latitude'), station_id, place_name, 'latitude')
                     longitude = _parse_coord(row.get('longitude'), station_id, place_name, 'longitude')
+                    tz = (row.get('timezone') or '').strip() or None
 
                     cursor.execute('''
                         INSERT OR IGNORE INTO tide_station_ids
-                        (station_id, place_name, country, api_source, latitude, longitude, lookup_count, last_lookup)
-                        VALUES (?, ?, 'USA', 'NOAA', ?, ?, 1, CURRENT_TIMESTAMP)
-                    ''', (station_id, place_name, latitude, longitude))
+                        (station_id, place_name, country, api_source, latitude, longitude, timezone, lookup_count, last_lookup)
+                        VALUES (?, ?, 'USA', 'NOAA', ?, ?, ?, 1, CURRENT_TIMESTAMP)
+                    ''', (station_id, place_name, latitude, longitude, tz))
                     cursor.execute('''
                         UPDATE tide_station_ids
                         SET place_name = ?, country = 'USA', api_source = 'NOAA',
-                            latitude = ?, longitude = ?
+                            latitude = ?, longitude = ?, timezone = COALESCE(?, timezone)
                         WHERE station_id = ?
-                    ''', (place_name, latitude, longitude, station_id))
+                    ''', (place_name, latitude, longitude, tz, station_id))
                     imported_count += 1
 
             if csv_station_ids:
@@ -346,7 +348,7 @@ def get_station_info(station_id):
             cursor = conn.cursor()
 
             result = cursor.execute('''
-                SELECT station_id, place_name, country, api_source, latitude, longitude, province
+                SELECT station_id, place_name, country, api_source, latitude, longitude, province, timezone
                 FROM tide_station_ids
                 WHERE station_id = ?
             ''', (station_id,)).fetchone()
@@ -359,7 +361,8 @@ def get_station_info(station_id):
                     'api_source': result[3] if result[3] else 'NOAA',
                     'latitude': result[4],
                     'longitude': result[5],
-                    'province': result[6]
+                    'province': result[6],
+                    'timezone': result[7],
                 }
 
             return None
@@ -469,21 +472,22 @@ def import_canadian_stations_from_csv():
                     api_source = row.get('api_source', 'CHS')
                     # Tolerate a CSV without the column (defaults to NULL)
                     alternative_name = row.get('alternative_name') or None
+                    tz = (row.get('timezone') or '').strip() or None
 
                     # Insert or update station (Canadian stations)
                     # Use INSERT OR IGNORE to preserve lookup_count for existing stations
                     cursor.execute('''
                         INSERT OR IGNORE INTO tide_station_ids
-                        (station_id, place_name, country, api_source, latitude, longitude, province, alternative_name, lookup_count, last_lookup)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
-                    ''', (station_id, place_name, country, api_source, latitude, longitude, province, alternative_name))
+                        (station_id, place_name, country, api_source, latitude, longitude, province, alternative_name, timezone, lookup_count, last_lookup)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
+                    ''', (station_id, place_name, country, api_source, latitude, longitude, province, alternative_name, tz))
 
                     # Update metadata for existing stations without touching lookup_count
                     cursor.execute('''
                         UPDATE tide_station_ids
-                        SET place_name = ?, country = ?, api_source = ?, latitude = ?, longitude = ?, province = ?, alternative_name = ?
+                        SET place_name = ?, country = ?, api_source = ?, latitude = ?, longitude = ?, province = ?, alternative_name = ?, timezone = COALESCE(?, timezone)
                         WHERE station_id = ?
-                    ''', (place_name, country, api_source, latitude, longitude, province, alternative_name, station_id))
+                    ''', (place_name, country, api_source, latitude, longitude, province, alternative_name, tz, station_id))
                     imported_count += 1
 
             # Remove Canadian stations from database that are NOT in the CSV
@@ -642,3 +646,39 @@ def get_popular_stations_by_country(country=None, limit=16):
     except sqlite3.Error as e:
         logging.error(f"Database error getting popular stations: {e}")
         return []
+
+
+def backfill_timezones_from_csv(csv_paths=None):
+    """Fill NULL/empty `timezone` on existing DB rows from the shipped CSVs.
+
+    Needed because the US CSV import short-circuits on a warm DB, and Canadian
+    stations imported via the live CHS API have no timezone. Source is the
+    shipped CSV (no network, no heavy library). Idempotent. Returns rows updated.
+    """
+    if csv_paths is None:
+        here = os.path.dirname(__file__)
+        csv_paths = [os.path.join(here, 'tide_stations_new.csv'),
+                     os.path.join(here, 'canadian_tide_stations.csv')]
+    updated = 0
+    try:
+        with sqlite3.connect(DB_PATH) as conn:
+            for path in csv_paths:
+                if not os.path.exists(path):
+                    continue
+                with open(path, 'r', encoding='utf-8') as f:
+                    for row in csv.DictReader(f):
+                        tz = (row.get('timezone') or '').strip()
+                        sid = row.get('station_id')
+                        if not tz or not sid:
+                            continue
+                        cur = conn.execute(
+                            "UPDATE tide_station_ids SET timezone = ? "
+                            "WHERE station_id = ? AND (timezone IS NULL OR timezone = '')",
+                            (tz, sid))
+                        updated += cur.rowcount
+            conn.commit()
+        logging.info("Timezone backfill: set timezone on %d station(s)", updated)
+        return updated
+    except (sqlite3.Error, OSError) as e:
+        logging.error("Timezone backfill failed: %s", e)
+        return updated

--- a/app/get_tides.py
+++ b/app/get_tides.py
@@ -187,6 +187,14 @@ def generate_calendar(station_id, year, month, output_path, location_name=None):
     lat = station_info.get('latitude')
     lng = station_info.get('longitude')
 
+    # A CHS station with no timezone can't be localized: tide times would silently
+    # stay in UTC and no sun line would be drawn. Surface it so it's diagnosable
+    # (the fix is to re-run scripts/fetch_station_timezones.py for the new station).
+    if (api_source or '').upper() == 'CHS' and not iana_tz:
+        logging.warning(
+            "CHS station %s has no timezone; tide times will render in UTC and "
+            "no sunrise/sunset line will be shown", station_id)
+
     csv_data = download_tide_data(station_id, year, month)
     # CHS times are UTC -> convert to the station's local zone and trim to the
     # local month (NOAA passes through unchanged).

--- a/app/get_tides.py
+++ b/app/get_tides.py
@@ -20,6 +20,11 @@ except ImportError:
     from database import log_station_lookup, get_station_info
     from tide_adapters import get_adapter_for_station
 
+try:
+    from app.sun_times import sun_times_for_month, format_sun_line, localize_and_filter_csv
+except ImportError:
+    from sun_times import sun_times_for_month, format_sun_line, localize_and_filter_csv
+
 # Per-invocation timeout for each external tool (pcal, ps2pdf)
 SUBPROCESS_TIMEOUT = 60
 
@@ -68,18 +73,30 @@ def download_tide_data(station_id, year, month):
     return csv_data
 
 
-def convert_tide_data_to_pcal(csv_data, pcal_filename, location_name=None, station_id=None):
+def convert_tide_data_to_pcal(csv_data, pcal_filename, location_name=None, station_id=None, sun_times=None):
     """Convert tide CSV text to a pcal custom dates file.
 
-    Parameters:
-    - csv_data: CSV text with header line, then `datetime,prediction,H|L` rows.
-    - pcal_filename: Path of the pcal custom dates file to write.
-    - location_name: Optional human-readable location for the calendar note.
-    - station_id: Fallback identifier for the note when location_name is absent.
+    sun_times: optional {day:int -> ("HH:MM","HH:MM") | note str} from
+    sun_times_for_month(); when present, a `Rise … Set …` line is written for
+    each day BEFORE that day's tide lines so it sits at the top of the cell.
     """
     lines = csv_data.splitlines()
 
     with open(pcal_filename, 'w') as pcal_file:
+        # Sun lines first so pcal places them above the tide events for each day.
+        if sun_times:
+            month_num = None
+            for line in lines[1:]:
+                if line.strip():
+                    try:
+                        month_num = int(line.strip().split(',')[0].split()[0].split('-')[1])
+                        break
+                    except (IndexError, ValueError):
+                        continue
+            if month_num is not None:
+                for day in sorted(sun_times):
+                    pcal_file.write(f"{month_num}/{day}  {format_sun_line(sun_times[day])}\n")
+
         valid_lines = 0
         skipped_lines = 0
 
@@ -163,22 +180,20 @@ def _run_tool(cmd):
 
 
 def generate_calendar(station_id, year, month, output_path, location_name=None):
-    """Fetch tide data and render a PDF calendar at output_path.
+    """Fetch tide data and render a PDF calendar at output_path. See module docs."""
+    station_info = get_station_info(station_id) or {}
+    api_source = station_info.get('api_source')
+    iana_tz = station_info.get('timezone')
+    lat = station_info.get('latitude')
+    lng = station_info.get('longitude')
 
-    All intermediate files (pcal events, PostScript) live in a per-invocation
-    temp directory, and the PDF is renamed into place atomically, so
-    concurrent requests for the same station/month can never serve a
-    truncated file from the cache.
-
-    Raises TideDataError or CalendarGenerationError. Returns output_path.
-    """
     csv_data = download_tide_data(station_id, year, month)
+    # CHS times are UTC -> convert to the station's local zone and trim to the
+    # local month (NOAA passes through unchanged).
+    csv_data = localize_and_filter_csv(csv_data, api_source, iana_tz, year, month)
+    sun = sun_times_for_month(lat, lng, iana_tz, year, month)
 
     os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
-    # Same directory as the final path so os.replace() is an atomic rename.
-    # PID alone isn't unique here — gunicorn threads share a PID, so include
-    # the thread id to keep concurrent same-station requests off each other's
-    # temp file.
     tmp_pdf = f"{output_path}.tmp.{os.getpid()}.{threading.get_ident()}"
 
     try:
@@ -188,23 +203,17 @@ def generate_calendar(station_id, year, month, output_path, location_name=None):
 
             convert_tide_data_to_pcal(csv_data, pcal_path,
                                       location_name=location_name,
-                                      station_id=station_id)
+                                      station_id=station_id,
+                                      sun_times=sun)
 
-            # -s r:g:b -- colour of day numerals (blue)
-            # -m -- show the month name
-            # -C text -- centered footer text
-            # -n font/size -- event text inside day boxes (~50% larger than default)
-            # mini-calendars for prev/next month shown by default (-S suppresses)
             _run_tool(["pcal", "-f", pcal_path, "-o", ps_path,
                        "-s", "0.0:0.0:1.0", "-n", "Helvetica-Narrow/9",
                        "-m", "-C", "tidecalendar.xyz",
                        str(month), str(year)])
-
             _run_tool(["ps2pdf", ps_path, tmp_pdf])
 
             if not os.path.exists(tmp_pdf) or os.path.getsize(tmp_pdf) == 0:
                 raise CalendarGenerationError("ps2pdf produced no output")
-
             os.replace(tmp_pdf, output_path)
     finally:
         if os.path.exists(tmp_pdf):

--- a/app/run.py
+++ b/app/run.py
@@ -1,7 +1,7 @@
 from dotenv import load_dotenv
 import os
 import logging
-from app.database import init_database, import_stations_from_csv
+from app.database import init_database, import_stations_from_csv, backfill_timezones_from_csv
 from app.canadian_station_sync import import_canadian_stations_from_api
 from app.station_coordinates import backfill_missing_coordinates
 from app.calendar_service import cleanup_previous_month_pdfs
@@ -18,6 +18,7 @@ init_database()
 import_stations_from_csv()
 import_canadian_stations_from_api()
 backfill_missing_coordinates()
+backfill_timezones_from_csv()
 # Old cached PDFs only go stale once a month; sweeping at startup keeps the
 # request path free of directory scans (containers redeploy on every push).
 cleanup_previous_month_pdfs()

--- a/app/sun_times.py
+++ b/app/sun_times.py
@@ -1,0 +1,92 @@
+# app/sun_times.py
+"""Local-timezone helpers for the PDF calendar: sunrise/sunset computation and
+CHS UTC->local tide-time conversion.
+
+Runtime deps: astral (pure-Python) + stdlib zoneinfo. The IANA timezone per
+station is precomputed offline (scripts/fetch_station_timezones.py) and read
+from the DB; nothing here needs timezonefinder.
+"""
+import calendar as _calendar
+import logging
+from datetime import date as _date, datetime as _datetime, timezone as _utc
+from zoneinfo import ZoneInfo
+
+from astral import Observer
+from astral import sun as _astral_sun
+
+
+def _zone(iana_tz):
+    try:
+        return ZoneInfo(iana_tz) if iana_tz else None
+    except Exception:
+        logging.warning("Unknown timezone %r", iana_tz)
+        return None
+
+
+def _day_sun(observer, d, tz):
+    """Return ("HH:MM" rise, "HH:MM" set) or a polar note string for one day."""
+    try:
+        rise = _astral_sun.sunrise(observer, date=d, tzinfo=tz)
+        sset = _astral_sun.sunset(observer, date=d, tzinfo=tz)
+        return (rise.strftime('%H:%M'), sset.strftime('%H:%M'))
+    except ValueError:
+        noon = _datetime(d.year, d.month, d.day, 12, 0, tzinfo=tz)
+        try:
+            up = _astral_sun.elevation(observer, noon) > 0
+        except Exception:
+            return '24h daylight'
+        return '24h daylight' if up else 'polar night'
+
+
+def sun_times_for_month(lat, lng, iana_tz, year, month):
+    """{day:int -> ("HH:MM","HH:MM") | note str}. Empty dict if tz/coords missing."""
+    tz = _zone(iana_tz)
+    if lat is None or lng is None or tz is None:
+        return {}
+    observer = Observer(latitude=lat, longitude=lng)
+    _, last = _calendar.monthrange(year, month)
+    return {day: _day_sun(observer, _date(year, month, day), tz)
+            for day in range(1, last + 1)}
+
+
+def format_sun_line(value):
+    """Render a day's sun value as the pcal cell text."""
+    if isinstance(value, tuple):
+        return f"Rise {value[0]}  Set {value[1]}"
+    return f"Sun: {value}"
+
+
+def localize_and_filter_csv(csv_data, api_source, iana_tz, year, month):
+    """Convert CHS (UTC) tide rows to local time and keep only the target local
+    month. NOAA rows (already local) pass through unchanged.
+
+    csv_data: header line + `YYYY-MM-DD HH:MM,value,Type` rows.
+    """
+    if (api_source or '').upper() != 'CHS':
+        return csv_data
+
+    tz = _zone(iana_tz)
+    lines = csv_data.splitlines()
+    if not lines:
+        return csv_data
+    header, body = lines[0], lines[1:]
+    out = [header]
+    for line in body:
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(',')
+        if len(parts) != 3:
+            continue
+        dt_str, value, ttype = parts
+        try:
+            naive = _datetime.strptime(dt_str.strip(), '%Y-%m-%d %H:%M')
+        except ValueError:
+            continue
+        if tz is None:
+            local = naive
+        else:
+            local = naive.replace(tzinfo=_utc).astimezone(tz)
+        if local.year == year and local.month == month:
+            out.append(f"{local.strftime('%Y-%m-%d %H:%M')},{value},{ttype}")
+    return '\n'.join(out)

--- a/app/sun_times.py
+++ b/app/sun_times.py
@@ -86,7 +86,7 @@ def localize_and_filter_csv(csv_data, api_source, iana_tz, year, month):
         if tz is None:
             local = naive
         else:
-            local = naive.replace(tzinfo=_utc).astimezone(tz)
+            local = naive.replace(tzinfo=_utc.utc).astimezone(tz)
         if local.year == year and local.month == month:
             out.append(f"{local.strftime('%Y-%m-%d %H:%M')},{value},{ttype}")
     return '\n'.join(out)

--- a/app/test_get_tides_sun.py
+++ b/app/test_get_tides_sun.py
@@ -1,0 +1,28 @@
+import os, tempfile, unittest
+import get_tides
+
+
+class PcalSunLineTest(unittest.TestCase):
+    def test_writes_sun_line_before_tides(self):
+        csv_data = "Date Time,Prediction,Type\n2026-06-15 05:23,4.8,H\n2026-06-15 11:40,0.1,L"
+        sun = {15: ('05:14', '21:09')}
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'events.txt')
+            get_tides.convert_tide_data_to_pcal(csv_data, path, location_name='Test',
+                                                sun_times=sun)
+            text = open(path).read()
+        self.assertIn('6/15  Rise 05:14  Set 21:09', text)
+        self.assertLess(text.index('Rise 05:14'), text.index('05:23 High'))
+
+    def test_no_sun_times_is_backward_compatible(self):
+        csv_data = "Date Time,Prediction,Type\n2026-06-15 05:23,4.8,H"
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'events.txt')
+            get_tides.convert_tide_data_to_pcal(csv_data, path, location_name='Test')
+            text = open(path).read()
+        self.assertNotIn('Rise', text)
+        self.assertIn('05:23 High', text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_get_tides_sun.py
+++ b/app/test_get_tides_sun.py
@@ -10,7 +10,8 @@ class PcalSunLineTest(unittest.TestCase):
             path = os.path.join(d, 'events.txt')
             get_tides.convert_tide_data_to_pcal(csv_data, path, location_name='Test',
                                                 sun_times=sun)
-            text = open(path).read()
+            with open(path) as f:
+                text = f.read()
         self.assertIn('6/15  Rise 05:14  Set 21:09', text)
         self.assertLess(text.index('Rise 05:14'), text.index('05:23 High'))
 
@@ -19,7 +20,8 @@ class PcalSunLineTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, 'events.txt')
             get_tides.convert_tide_data_to_pcal(csv_data, path, location_name='Test')
-            text = open(path).read()
+            with open(path) as f:
+                text = f.read()
         self.assertNotIn('Rise', text)
         self.assertIn('05:23 High', text)
 

--- a/app/test_sun_times.py
+++ b/app/test_sun_times.py
@@ -1,0 +1,90 @@
+import os, sqlite3, tempfile, unittest, csv
+
+import database
+
+
+class TimezoneDBTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        database.DB_PATH = self.tmp.name
+        database.init_database()
+
+    def tearDown(self):
+        os.unlink(self.tmp.name)
+
+    def test_station_info_returns_timezone(self):
+        with sqlite3.connect(database.DB_PATH) as conn:
+            conn.execute("INSERT INTO tide_station_ids (station_id, place_name, country, timezone) "
+                         "VALUES ('9449639','Point Roberts, WA','USA','America/Vancouver')")
+            conn.commit()
+        info = database.get_station_info('9449639')
+        self.assertEqual(info['timezone'], 'America/Vancouver')
+
+    def test_backfill_timezones_from_csv(self):
+        with sqlite3.connect(database.DB_PATH) as conn:
+            conn.execute("INSERT INTO tide_station_ids (station_id, place_name, country) "
+                         "VALUES ('07735','Vancouver, BC','Canada')")
+            conn.commit()
+        csv_path = self.tmp.name + '.csv'
+        with open(csv_path, 'w', newline='', encoding='utf-8') as f:
+            w = csv.DictWriter(f, fieldnames=['station_id', 'timezone'])
+            w.writeheader()
+            w.writerow({'station_id': '07735', 'timezone': 'America/Vancouver'})
+        n = database.backfill_timezones_from_csv([csv_path])
+        self.assertEqual(n, 1)
+        self.assertEqual(database.get_station_info('07735')['timezone'], 'America/Vancouver')
+
+
+class SunTimesTest(unittest.TestCase):
+    def test_point_roberts_june(self):
+        import sun_times
+        m = sun_times.sun_times_for_month(48.97, -123.07, 'America/Vancouver', 2026, 6)
+        self.assertEqual(len(m), 30)
+        rise, sset = m[15]
+        self.assertRegex(rise, r'^\d{2}:\d{2}$')
+        self.assertRegex(sset, r'^\d{2}:\d{2}$')
+        self.assertIn(int(rise[:2]), range(4, 7))
+        self.assertIn(int(sset[:2]), range(20, 23))
+
+    def test_polar_day_returns_note(self):
+        import sun_times
+        m = sun_times.sun_times_for_month(78.0, 15.0, 'Arctic/Longyearbyen', 2026, 6)
+        self.assertEqual(m[15], '24h daylight')
+
+    def test_missing_tz_returns_empty(self):
+        import sun_times
+        self.assertEqual(sun_times.sun_times_for_month(48.0, -123.0, None, 2026, 6), {})
+
+    def test_format_sun_line(self):
+        import sun_times
+        self.assertEqual(sun_times.format_sun_line(('05:14', '21:09')), 'Rise 05:14  Set 21:09')
+        self.assertEqual(sun_times.format_sun_line('24h daylight'), 'Sun: 24h daylight')
+
+
+class LocalizeCsvTest(unittest.TestCase):
+    HEADER = 'Date Time,Prediction,Type'
+
+    def test_chs_converts_and_crosses_midnight(self):
+        import sun_times
+        csv_in = self.HEADER + '\n2026-06-15 05:23,4.8,H'
+        out = sun_times.localize_and_filter_csv(csv_in, 'CHS', 'America/Vancouver', 2026, 6)
+        self.assertIn('2026-06-14 22:23,4.8,H', out)
+
+    def test_chs_recovers_last_day_evening_and_drops_prev_month(self):
+        import sun_times
+        csv_in = (self.HEADER
+                  + '\n2026-06-01 02:00,1.0,L'
+                  + '\n2026-07-01 04:00,2.0,H')
+        out = sun_times.localize_and_filter_csv(csv_in, 'CHS', 'America/Vancouver', 2026, 6)
+        self.assertNotIn('05-31', out)
+        self.assertIn('2026-06-30 21:00,2.0,H', out)
+
+    def test_noaa_passthrough(self):
+        import sun_times
+        csv_in = self.HEADER + '\n2026-06-15 05:23,4.8,H'
+        self.assertEqual(sun_times.localize_and_filter_csv(csv_in, 'NOAA', None, 2026, 6), csv_in)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_tide_adapters.py
+++ b/app/test_tide_adapters.py
@@ -503,6 +503,32 @@ class CHSPaddingTest(unittest.TestCase):
         self.assertEqual(captured['params']['from'], '2026-05-31T00:00:00Z')
         self.assertEqual(captured['params']['to'], '2026-07-01T23:59:59Z')
 
+    def test_padding_crosses_year_boundaries(self):
+        import tide_adapters
+        from unittest import mock
+        captured = {}
+
+        class FakeResp:
+            status_code = 200
+            text = '[]'
+        def fake_get(url, params=None, headers=None, timeout=None):
+            if url.endswith('/data'):
+                captured['params'] = params
+            return FakeResp()
+
+        a = tide_adapters.CHSAdapter()
+        with mock.patch.object(a, '_lookup_station_uuid', return_value='uuid'), \
+             mock.patch('tide_adapters.requests.get', side_effect=fake_get):
+            a.get_predictions('07735', 2026, 1)   # January -> pad into prior Dec
+        self.assertEqual(captured['params']['from'], '2025-12-31T00:00:00Z')
+        self.assertEqual(captured['params']['to'], '2026-02-01T23:59:59Z')
+
+        with mock.patch.object(a, '_lookup_station_uuid', return_value='uuid'), \
+             mock.patch('tide_adapters.requests.get', side_effect=fake_get):
+            a.get_predictions('07735', 2026, 12)  # December -> pad into next Jan
+        self.assertEqual(captured['params']['from'], '2026-11-30T00:00:00Z')
+        self.assertEqual(captured['params']['to'], '2027-01-01T23:59:59Z')
+
 
 if __name__ == '__main__':
     import sys

--- a/app/test_tide_adapters.py
+++ b/app/test_tide_adapters.py
@@ -482,6 +482,28 @@ def run_tests():
     return 0 if result.wasSuccessful() else 1
 
 
+class CHSPaddingTest(unittest.TestCase):
+    def test_get_predictions_pads_one_day(self):
+        import tide_adapters
+        from unittest import mock
+        captured = {}
+
+        class FakeResp:
+            status_code = 200
+            text = '[]'
+        def fake_get(url, params=None, headers=None, timeout=None):
+            if url.endswith('/data'):
+                captured['params'] = params
+            return FakeResp()
+
+        a = tide_adapters.CHSAdapter()
+        with mock.patch.object(a, '_lookup_station_uuid', return_value='uuid'), \
+             mock.patch('tide_adapters.requests.get', side_effect=fake_get):
+            a.get_predictions('07735', 2026, 6)
+        self.assertEqual(captured['params']['from'], '2026-05-31T00:00:00Z')
+        self.assertEqual(captured['params']['to'], '2026-07-01T23:59:59Z')
+
+
 if __name__ == '__main__':
     import sys
     sys.exit(run_tests())

--- a/app/tide_adapters.py
+++ b/app/tide_adapters.py
@@ -431,13 +431,17 @@ class CHSAdapter(TideAdapter):
             station_uuid = station_id
             self.logger.debug(f"Station {station_id} is already a UUID")
 
-        # Calculate date range for the month
+        # Calculate the month range, padded ±1 day in UTC. The pad lets the
+        # local-month filter (sun_times.localize_and_filter_csv) recover events
+        # that fall in the target LOCAL month but land on an adjacent UTC day
+        # after UTC->local conversion (west-of-UTC stations lose late-evening
+        # tides on the last day otherwise).
+        from datetime import date as _date, timedelta as _timedelta
         _, last_day = calendar.monthrange(year, month)
-
-        # Build request parameters for CHS IWLS API
-        # Format: ISO 8601 datetime (YYYY-MM-DDTHH:MM:SSZ)
-        from_date = f"{year}-{month:02d}-01T00:00:00Z"
-        to_date = f"{year}-{month:02d}-{last_day}T23:59:59Z"
+        pad_from = _date(year, month, 1) - _timedelta(days=1)
+        pad_to = _date(year, month, last_day) + _timedelta(days=1)
+        from_date = pad_from.strftime('%Y-%m-%dT00:00:00Z')
+        to_date = pad_to.strftime('%Y-%m-%dT23:59:59Z')
 
         params = {
             "time-series-code": "wlp-hilo",

--- a/app/tide_stations_new.csv
+++ b/app/tide_stations_new.csv
@@ -1,2133 +1,2133 @@
-station_id,place_name,latitude,longitude
-1611347,"Port Allen, Hanapepe Bay, Kauai Island, HI",21.9033,-159.592
-1611400,"Nawiliwili, HI",21.9544,-159.3561
-1612340,"Honolulu, HI",21.30333333333334,-157.8645277777778
-1612366,"Fort Kamehameha, Bishop Point, Pearl Hbr, HI",21.33,-157.967
-1612401,"Pearl Harbor, HI",21.36750030517578,-157.96389770507812
-1612404,"Ford Island, Ferry Dock, Pearl Harbor, HI",21.3683,-157.94
-1612480,"Mokuoloe, HI",21.43305555555556,-157.79
-1613198,"Kaunakakai Harbor, HI",21.085,-157.032
-1614465,"Kaumalapau Harbor, Lanai Island, HI",20.79,-156.995
-1615680,"Kahului, Kahului Harbor, HI",20.89494444444445,-156.469
-1617433,"Kawaihae, HI",20.0366,-155.8294
-1617760,"Hilo, Hilo Bay, Kuhio Bay, HI",19.73027777777778,-155.0555555555555
-1619000,"Johnston Atoll, United States Of America",16.7383,-169.53
-1619910,"Sand Island, Midway Islands, United States Of America",28.2116667,-177.36
-1630000,"Apra Harbor, Guam, United States Of America",13.44338888888889,144.6563611111111
-1631428,"Pago Bay, Guam, United States Of America",13.4283333,144.7988888888889
-1633227,"Saipan, Gu",15.2267,145.737
-1732417,Fare Ute Point,-17.535,-149.572
-1770000,"Pago Pago, American Samoa, American Samoa",-14.279999732971191,-170.69000244140625
-1820000,"Kwajalein, Marshall Islands, United States Of America",8.731666564941406,167.7361145019531
-1840000,"Chuuk, Moen Island, E. Caroline Islands, Fm",7.44667,151.847
-1890000,"Wake Island, Pacific Ocean, United States Of America",19.2905556,166.6175
-1910000,"Suva, Suva Harbor, Fiji",-18.1333,178.425
-2431000,"Diego Garcia, United Kingdom",-7.29,72.3933
-2695535,"Bermuda Biological Station, Bermuda",32.37022399902344,-64.69572448730469
-2695540,"Bermuda, St. Georges Island, Bermuda",32.3734016418457,-64.70330047607422
-8410140,"Eastport, ME",44.90460968017578,-66.9828872680664
-8410714,"Coffin Point, Coffin Neck, ME",44.87,-67.1083
-8410715,"Garnet Point, Hersey Neck, ME",44.9233,-67.13
-8410834,"Pettegrove Point, Dochet Island, ME",45.12844444444445,-67.14466666666667
-8410864,"Gravelly Point, Whiting Bay, ME",44.823299407958984,-67.15170288085938
-8411060,"Cutler Farris Wharf, ME",44.656700134277344,-67.20999908447266
-8411250,"Cutler Naval Base, ME",44.6417,-67.2967
-8412581,"Milbridge, ME",44.54,-67.875
-8413320,"Bar Harbor, ME",44.39219444444444,-68.20427777777778
-8413801,"Ellsworth, ME",44.535,-68.4217
-8413825,"Mackerel Cove, Swans Island, ME",44.16999816894531,-68.43499755859375
-8414249,"Oceanville, Deer Isle, ME",44.19230555555556,-68.62093055555556
-8414612,"Bangor, ME",44.785,-68.7667
-8414684,"Bucksport, ME",44.5717,-68.8017
-8414692,"Sandy Point, ME",44.505,-68.805
-8414721,"Fort Point, ME",44.4717,-68.8133
-8414781,"Winterport, Penobscot River, ME",44.63669967651367,-68.8416976928711
-8414856,"North Haven, ME",44.1267,-68.8733
-8414888,"Pulpit Harbor, Penobscot Bay, ME",44.1567,-68.8867
-8415191,"Belfast, Penobscot Bay, ME",44.4267,-69.005
-8415490,"Rockland, ME",44.105,-69.1017
-8415709,"Thomaston, ME",44.0717,-69.1817
-8416731,"Walpole, Damariscotta River, ME",43.9333,-69.58
-8416921,"Wiscasset, ME",44.0,-69.6667
-8417134,"Gardiner, ME",44.2333,-69.7667
-8417177,"Hunniwell Point, ME",43.755,-69.785
-8417208,"Richmond, ME",44.0883,-69.7983
-8417227,"Bath, ME",43.925,-69.815
-8417821,"Cliff Island, Luckse Sound, ME",43.695,-70.11
-8417874,"Doyle Point, Casco Bay, ME",43.7517,-70.14
-8417881,"Great Chebeague Island, ME",43.7217,-70.1417
-8417941,"Long Island, Casco Bay, ME",43.69,-70.17
-8417948,"Prince Point, Yarmouth, ME",43.7617,-70.1733
-8417988,"Great Diamond Is., Casco Bay, ME",43.67,-70.2
-8417997,"Cushing Island, Casco Bay, ME",43.645,-70.1983
-8418009,"Cow Island, Casco Bay, ME",43.69,-70.19
-8418015,"Falmouth Foreside, ME",43.7317,-70.205
-8418031,"Portland Head Light Station, ME",43.6233,-70.2067
-8418150,"Portland, ME",43.65805555555556,-70.24416666666667
-8418268,"Fore River, Portland, ME",43.6417,-70.285
-8418445,"Pine Point, ME",43.545,-70.3333
-8418606,"Camp Ellis, Saco River, ME",43.4617,-70.3817
-8418828,"Biddeford, Saco River, ME",43.4917,-70.4467
-8418911,"Kennebunkport, Kennebunk River, ME",43.3583,-70.4767
-8419317,"Wells, ME",43.31999969482422,-70.56330108642578
-8419399,"Cape Neddick, ME",43.1667,-70.5933
-8419528,"Fort Point, York Harbor, ME",43.13,-70.6383
-8419688,"Gerrish Island, Kittery, ME",43.0667,-70.6967
-8419870,"Seavey Island, ME",43.0797222,-70.74111111111111
-8420411,"Dover, Cocheco River, NH",43.1983,-70.8683
-8423635,"Atlantic Heights, NH",43.09,-70.7633
-8423898,"Fort Point, NH",43.07170104980469,-70.71170043945312
-8440273,"Salisbury Point, Merrimack River, MA",42.8383,-70.9083
-8440369,"Merrimacport, Merrimack River, MA",42.825,-70.9883
-8440452,"Plum Island, Merrimack River Entrance, MA",42.8167,-70.82
-8440466,"Newburyport, Merrimack River, MA",42.815,-70.8733
-8440889,"Riverside, Merrimack River, MA",42.763889,-71.034028
-8441241,"Plum Island South, MA",42.71013888888889,-70.78861111111111
-8441551,"Rockport Harbor, MA",42.6583,-70.615
-8441571,"Lobster Cove, Annisquam River, MA",42.654998779296875,-70.67669677734375
-8441771,"Essex, Essex River, MA",42.6317,-70.7767
-8441841,"Gloucester Harbor, MA",42.61000061035156,-70.66000366210938
-8442417,"Beverly, Beverly Harbor, MA",42.540000915527344,-70.88670349121094
-8442645,"Salem, Salem Harbor, MA",42.5233,-70.8767
-8443187,"Lynn, Lynn Harbor, MA",42.4583,-70.9433
-8443662,"Amelia Earhart Dam, Mystic River, MA",42.395,-71.0767
-8443725,"Chelsea, MA",42.3867,-71.0233
-8443970,"Boston, MA",42.35388888888889,-71.05027777777778
-8444162,"Boston Light, MA",42.3283,-70.8917
-8444525,"Nut Island, MA",42.28,-70.9533
-8444788,"Weymouth Fore River, MA",42.2483,-70.9667
-8445138,"Scituate, Scituate Harbor, MA",42.2017,-70.7267
-8446009,"Brant Rock, Green Harbor River, MA",42.0833,-70.6467
-8446121,"Provincetown, MA",42.04959166666666,-70.18215833333333
-8446166,"Duxbury, Duxbury Harbor, MA",42.0383,-70.67
-8446493,"Plymouth, Plymouth Harbor, MA",41.96,-70.6617
-8447173,"Sagamore, Cape Cod Canal (Sta. 115), MA",41.775,-70.535
-8447180,"Sandwich, MA",41.7717,-70.5067
-8447191,"Bournedale, Cape Cod Canal (Sta. 200), MA",41.77,-70.5617
-8447241,"Sesuit Harbor, East Dennis, MA",41.7517,-70.155
-8447259,"Bourne Bridge, Cape Cod Canal (Sta. 320), MA",41.745,-70.5933
-8447270,"Buzzards Bay, MA",41.7417,-70.6167
-8447277,"Onset Beach T-12, MA",41.7417,-70.6583
-8447281,"Steepbrook, MA",41.74,-71.1317
-8447295,"Gray Gables, MA",41.735,-70.6233
-8447355,"Monument Beach T-8, MA",41.715,-70.6167
-8447368,"Great Hill, MA",41.711700439453125,-70.71499633789062
-8447385,"Marion, Buzzard'S Bay, MA",41.705,-70.7617
-8447386,"Fall River, MA",41.70429992675781,-71.16410064697266
-8447416,"Piney Point, MA",41.695,-70.72
-8447435,"Chatham, MA",41.688499450683594,-69.95110321044922
-8447495,"Saquatucket Harbor, MA",41.6683,-70.0567
-8447504,"South Yarmouth, Bass River, MA",41.665,-70.1833
-8447505,"Chatham, Stage Harbor, MA",41.6667,-69.9667
-8447506,"Wychmere Hbr., Harwichport, MA",41.665000915527344,-70.06500244140625
-8447531,"Mattapoisett, MA",41.6567,-70.8133
-8447605,"Hyannisport, MA",41.6317,-70.3
-8447636,"New Bedford Harbor, MA",41.62120056152344,-70.9136962890625
-8447685,"Chappaquoit Point, MA",41.605,-70.6517
-8447712,"New Bedford, Clarks Point, MA",41.5933,-70.9
-8447842,"Round Hill Point, MA",41.5383,-70.9283
-8447930,"Woods Hole, MA",41.52361297607422,-70.67111206054688
-8448157,"Vineyard Haven, Vineyard Hvn Hbr, MA",41.4583,-70.6
-8448208,"Oak Bluffs, Martha'S Vineyard, MA",41.4583,-70.555
-8448248,"Penikese Island, MA",41.45,-70.9217
-8448251,"Quick'S Hole, MA",41.4483,-70.8567
-8448376,"Cuttyhunk, MA",41.42499923706055,-70.91670227050781
-8448558,"Edgartown, MA",41.3883,-70.5117
-8448725,"Menemsha Harbor, Ma, MA",41.35444444444445,-70.76783333333333
-8448875,"Martha'S Vineyard Gps Buoy, MA",41.32622222222222,-70.59033333333333
-8449130,"Nantucket Island, MA",41.28499984741211,-70.0967025756836
-8450768,"Sakonnet, RI",41.465,-71.1933
-8450898,"Sakonnet River, North End, Bay Oil Pier, RI",41.6517,-71.21
-8450948,"Anthony Point, RI",41.6383,-71.2117
-8450954,"Nannaquaket, RI",41.6183,-71.2033
-8451301,"The Glen,Sakonnet River, RI",41.5583,-71.2367
-8451351,"Sachuest, Flint Point, RI",41.4867,-71.2383
-8451552,"Bristol Ferry, RI",41.6367,-71.255
-8452154,"Bristol Highlands, RI",41.69670104980469,-71.29329681396484
-8452555,"Navy Pier, Prudence Island, RI",41.58,-71.3217
-8452660,"Newport, RI",41.5043333,-71.3261389
-8452944,"Conimicut Light, RI",41.71670150756836,-71.34329986572266
-8453033,"Bay Spring, Bullock Cove, RI",41.75170135498047,-71.35169982910156
-8453201,"Castle Hill, RI",41.4633,-71.3617
-8453433,"Rumford, Seekonk River, RI",41.84000015258789,-71.37329864501953
-8453465,"Conanicut Point, RI",41.5733,-71.3717
-8453742,"West Jamestown, RI",41.4967,-71.3867
-8453767,"Pawtuxet Cove, Providence River, RI",41.76169967651367,-71.38829803466797
-8453999,"Beavertail Point, RI",41.4517,-71.4017
-8454000,"Providence, RI",41.80716666666667,-71.40066666666667
-8454049,"Quonset Point, RI",41.58679962158203,-71.41100311279297
-8454341,"Boston Neck, RI",41.46,-71.4283
-8454538,"Wickford, Narragansett Bay, RI",41.5717,-71.445
-8454578,"East Greenwich, RI",41.665000915527344,-71.44499969482422
-8454658,"Narragansett Pier, RI",41.4217,-71.455
-8455083,"Point Judith, Harbor Of Refuge, RI",41.3633,-71.49
-8455137,"Kickamuit River, RI",41.707801818847656,-71.24169921875
-8455189,"Westerly Pawcatuck, RI",41.3817,-71.8317
-8458022,"Weekapaug Point, Block Island Sound, RI",41.3283,-71.7617
-8458694,"Watch Hill Point, RI",41.305,-71.86
-8459338,"Block Island, RI",41.1733,-71.5567
-8459681,"Block Island, RI",41.1633,-71.61
-8460751,"West Mystic River, CT",41.343299865722656,-71.9749984741211
-8461392,"Norwich, Thames River, CT",41.5233,-72.0783
-8461467,"Yale Boathouse, Thames River, CT",41.43,-72.0933
-8461490,"New London, CT",41.371667,-72.095556
-8461925,"Niantic, Niantic River, CT",41.325,-72.1867
-8463348,"Tylerville, Connecticut R., CT",41.4517,-72.465
-8463701,"Clinton Harbor, CT",41.2683,-72.5317
-8463827,"Maromas, Connecticut River, CT",41.5417,-72.5517
-8463836,"Higganum Creek, Connecticut R., CT",41.5033,-72.5533
-8464255,"Rocky Hill,Connecticut River, CT",41.6633,-72.63
-8464336,"Middletown, Connecticut River, CT",41.56,-72.645
-8464445,"Guilford, Guilford Harbor, CT",41.2717,-72.6667
-8465692,"Lighthouse Point, New Haven Harbor, CT",41.2517,-72.905
-8465705,"New Haven, CT",41.28329849243164,-72.9083023071289
-8466375,"Gulf Beach, CT",41.205,-73.0417
-8466442,"Milford Harbor, CT",41.2183,-73.055
-8466573,"Shelton, Housatonic River, CT",41.3017,-73.0717
-8466664,"Murphy'S Boat Yard, Housatonic River, CT",41.275,-73.0883
-8466791,"Sniffens Point, Housatonic River, CT",41.1867,-73.1133
-8466797,"I-95 Bridge, Housatonic River, CT",41.2033,-73.1117
-8467150,"Bridgeport, CT",41.17581944444444,-73.18396944444444
-8467373,"Black Rock Harbor, CT",41.1567,-73.2133
-8467726,"Southport, Southport Harbor, CT",41.1333,-73.2833
-8468191,"Saugatuck River, CT",41.119998931884766,-73.36830139160156
-8468448,"South Norwalk, CT",41.0967,-73.415
-8468609,"Rowayton, Fivemile River, CT",41.065,-73.445
-8468799,"Long Neck Point, Long Island Sound, CT",41.0383,-73.48
-8469198,"Stamford Harbor, CT",41.0383,-73.5467
-8510448,"Lake Montauk, NY",41.0733,-71.935
-8510560,"Montauk, NY",41.0483333,-71.9594444
-8510719,"Silver Eel Pond, NY",41.2567,-72.03
-8511171,"Threemile Harbor Entrance, NY",41.035,-72.19
-8511236,"Plum Island Plum Gut Harbor, NY",41.1717,-72.205
-8511629,"Sag Harbor, NY",41.0033,-72.2967
-8511671,"Orient Harbor, NY",41.1367,-72.3067
-8511907,"Greenport, NY",41.101,-72.36116666666666
-8512354,"Shinnecock Inlet Open Coast, NY",40.8367,-72.48
-8512451,"Ponquogue Point, NY",40.85,-72.5033
-8512668,"Mattituck Inlet, Long Island, NY",41.01499938964844,-72.56169891357422
-8512671,"Shinnecock Bay, NY",40.82,-72.5617
-8512735,"South Jamesport, NY",40.935,-72.5817
-8512769,"Shinnecock Yacht Club, Penniman Creek, NY",40.81855555555556,-72.58661111111111
-8512987,"Northville, NY",40.9817,-72.645
-8513388,"Moriches Cgs, Moriches Bay, NY",40.7867,-72.75
-8513398,"Moriches Inlet, NY",40.76441666666667,-72.75597222222223
-8513825,"Smith Point Bridge, Narrow Bay, NY",40.7383,-72.8683
-8514322,"Patchogue, Patchogue River, NY",40.75,-73.0
-8514422,"Cedar Beach, NY",40.965,-73.0433
-8514560,"Port Jefferson, NY",40.95000076293945,-73.07669830322266
-8514779,"Seaview Ferry Dock, NY",40.64925,-73.15061111111112
-8515102,"Bayshore, Long Island, NY",40.7167,-73.24
-8515186,"Fire Island, NY",40.6267,-73.26
-8515586,"Northport, Northport Bay, NY",40.9,-73.3533
-8515786,"Eatons Neck, NY",40.9533,-73.4
-8515921,"Lloyd Harbor Lighthouse, NY",40.91,-73.4317
-8516061,"Cold Spring Harbor, NY",40.87329864501953,-73.47000122070312
-8516155,"Green Island, NY",40.6233,-73.5017
-8516299,"Bayville Bridge, Oyster Bay, NY",40.9033,-73.55
-8516402,"Point Lookout, NY",40.59388888888889,-73.58397222222223
-8516501,"Parsonnage Cove, NY",40.6333,-73.6167
-8516607,"Harry Tappen Marina, NY",40.83461111111111,-73.65241666666667
-8516614,"Glen Cove Yacht Club, Long Island, NY",40.8633,-73.655
-8516661,"Bay Park, Ny, NY",40.63,-73.67
-8516663,"Long Beach, New York, NY",40.59633333333333,-73.65508333333334
-8516761,"Port Washington, Manhassset Bay, NY",40.8317,-73.7033
-8516881,"Atlantic Beach, NY",40.595,-73.7433
-8516891,"Norton Point, Hook Creek, New York, NY",40.635,-73.7467
-8516945,"Kings Point, NY",40.810298919677734,-73.76490020751953
-8516990,"Willets Point, NY",40.7933,-73.7817
-8517125,"Whitestone, NY",40.7983,-73.8133
-8517137,"Beach Channel (Bridge), NY",40.5883,-73.82
-8517201,"North Channel, NY",40.645,-73.8367
-8517251,"Worlds Fair Marina, NY",40.761,-73.85036111111111
-8517276,"College Pt, Ft. Of 110Th St, Li, NY",40.7833,-73.8567
-8517401,"Wards Is., NY",40.7867,-73.9217
-8517732,"Wallabout Bay, Bkln Navy Yard, NY",40.7067,-73.975
-8517756,"Kingsborough Cc, NY",40.581199645996094,-73.93379974365234
-8517811,"Gravesend Bay, Norton Pt. Bkln, NY",40.59,-73.9983
-8517847,"Brooklyn Bridge, NY",40.7033,-73.995
-8517921,"Gowanus Bay, NY",40.665,-74.0133
-8518091,"Rye Beach, Amusement Park, NY",40.9617,-73.6717
-8518490,"New Rochelle, NY",40.8933,-73.7817
-8518526,"Throgs Neck, NY",40.805,-73.795
-8518621,"Hunts Pt., NY",40.8,-73.8733
-8518639,"Port Morris, NY",40.8017,-73.9067
-8518643,"Randalls Island, NY",40.8,-73.9283
-8518668,"Horns Hook, NY",40.7767,-73.9417
-8518687,"Queensboro Bridge, NY",40.7583,-73.9583
-8518695,"East 41St Street Pier, NY",40.7467,-73.9683
-8518699,"Williamsburg Bridge, NY",40.7117,-73.9683
-8518750,"The Battery, NY",40.70055389404297,-74.01416778564453
-8518902,"Dyckman Street, NY",40.8683,-73.9333
-8518903,"Spuyten Duyvil Ck, Ent., Hudson R,, NY",40.8783,-73.925
-8518905,"Riverdale, Hudson River, NY",40.9033,-73.9167
-8518924,"Haverstraw Bay, NY",41.2183,-73.9633
-8518934,"Beacon, Hudson River, NY",41.5,-73.9833
-8518951,"Hyde Park, NY",41.7833,-73.95
-8518962,"Turkey Point Hudson River Nerrs, NY",42.01390075683594,-73.93920135498047
-8518979,"Coxsackie, Hudson River, NY",42.352638244628906,-73.79486083984375
-8518995,"Albany, Hudson River, NY",42.65,-73.7467
-8519050,"Uscg Station Ny, NY",40.612,-74.0598611111111
-8519200,"Port Ivory, Arthur Kill, NY",40.645,-74.18
-8519436,"Great Kills Harbor, NY",40.5433,-74.14
-8519483,"Bergen Point West Reach, NY",40.63911111111111,-74.14630555555556
-8519789,"Rossville, Staten Island, NY",40.5567,-74.2233
-8530095,"Alpine, Hudson River, NJ",40.945,-73.9183
-8530186,"New Milford, Hackensack River, NJ",40.935,-74.03
-8530278,"Hackensack, Hackensack River, NJ",40.88,-74.04
-8530398,"Ridgefield Park Hackensack River, NJ",40.85,-74.03
-8530403,"East Rutherford, Passaic River, NJ",40.8467,-74.12
-8530528,"Carlstadt, Hackensack River, NJ",40.8067,-74.06
-8530531,"North Secaucus, Hack. River, NJ",40.805,-74.0533
-8530586,"Berrys Creek, Fish Creek, NJ",40.7933,-74.0917
-8530591,"Belleville, Passaic River, NJ",40.7867,-74.1467
-8530645,"Union City Hudson River, NJ",40.765,-74.0183
-8530696,"Amtrack Rr Swingbridge, Hackensack River, NJ",40.7517,-74.0967
-8530743,"Point No Point, Passaic River, NJ",40.7317,-74.1167
-8530772,"Kearny Point, Hackensack River, NJ",40.7283,-74.1033
-8530882,"Port Elizabeth, Newark Bay, NJ",40.673301696777344,-74.13999938964844
-8530985,"Constable Hook Upper Bay, NJ",40.655,-74.085
-8531077,"Rahway River #1, NJ",40.5983,-74.2317
-8531142,"Port Reading, NJ",40.55500030517578,-74.24500274658203
-8531156,"Woodbridge Creek #1, NJ",40.545,-74.265
-8531223,"Cheesequake Creek, NJ",40.4533,-74.2733
-8531232,"South Amboy Raritan River, NJ",40.4917,-74.2817
-8531262,"Keasbey, Raritan River, NJ",40.50830078125,-74.31169891357422
-8531369,"North Old Bridge, South River, NJ",40.41669845581055,-74.36329650878906
-8531390,"Sayreville, Raritan River, NJ",40.47829818725586,-74.35669708251953
-8531463,"New Brunswick Raritan River, NJ",40.48830032348633,-74.43499755859375
-8531526,"Matawan Creek Raritan Bay, NJ",40.4333,-74.2183
-8531545,"Keyport, Raritan Bay, NJ",40.44,-74.1983
-8531592,"Waackaack Ck, Raritan Bay, NJ",40.4483,-74.1433
-8531662,"Atlantic Highlands, Sandy Hook, NJ",40.4183,-74.035
-8531680,"Sandy Hook, NJ",40.46689987182617,-74.0093994140625
-8531712,"Highlands Bridge, Shrewsbury River, NJ",40.3967,-73.9817
-8531753,"Oceanic, Navesink River, NJ",40.3767,-74.015
-8531804,"Sea Bright, NJ",40.365,-73.975
-8531833,"Red Bank, Navesink River, NJ",40.355,-74.065
-8531925,"Gooseneck Bridge, Shrewsbury R, NJ",40.3267,-74.0167
-8531942,"Long Branch, Inside, NJ",40.325,-73.9967
-8531991,"Long Branch,Fishing Pier, NJ",40.3033,-73.9767
-8532322,"Shark River Hills, NJ",40.1917,-74.0383
-8532337,"Belmar Outside, NJ",40.185,-74.0083
-8532339,"Avon Shark River, NJ",40.1867,-74.0267
-8532371,"Wall Township, Shark River, NJ",40.1783,-74.0467
-8532585,"Point Pleasant Beach, Manasquan River, NJ",40.105,-74.055
-8532591,"Manasquan Inlet, NJ",40.1017,-74.035
-8532611,"Riviera Beach, Manasquan River, NJ",40.0967,-74.0867
-8532703,"Forge Pond, Metedeconk River, NJ",40.065,-74.135
-8532715,"Beaver Dam Creek, NJ",40.0617,-74.0617
-8532716,"Beaver Dam Creek (Inside), NJ",40.0617,-74.0733
-8532721,"Tall Pines Camp, Metedeconk R., NJ",40.0583,-74.1167
-8532786,"Mantoloking, Barnegat Bay, NJ",40.0367,-74.0533
-8532835,"Kettle Creek, NJ",40.0133,-74.1133
-8532885,"Ocean Beach, Barnegat Bay, NJ",39.9883,-74.0683
-8532921,"Silver Bay, NJ",39.9967,-74.1483
-8533005,"Goose Creek Barnegat Bay, NJ",39.9633,-74.115
-8533051,"Toms River, NJ",39.95000076293945,-74.19830322265625
-8533055,"Coates Point, Barnegat Bay, NJ",39.9483,-74.115
-8533071,"Seaside Heights, NJ",39.9433,-74.035
-8533135,"Seaside Park, NJ",39.9217,-74.0833
-8533141,"Barnegat Pier, Barnegat Bay, NJ",39.9183,-74.11
-8533185,"Sloop Creek, NJ",39.905,-74.1333
-8533295,"Cedar Creek, NJ",39.87,-74.155
-8533345,"Island Beach Barnegat Bay, NJ",39.8517,-74.0883
-8533365,"Stouts Creek, NJ",39.845001220703125,-74.15170288085938
-8533391,"Forked River, NJ",39.825,-74.1733
-8533465,"Oyster Creek, NJ",39.8083,-74.1883
-8533535,"Island Beach, Sedge Islands, NJ",39.7883,-74.0983
-8533541,"Waretown Barnegat Bay, NJ",39.7917,-74.1817
-8533615,"Barnegat Inlet (Inside), NJ",39.7617,-74.1117
-8533631,"High Bar, Barnegat Bay, NJ",39.7567,-74.1283
-8533665,"Double Creek, NJ",39.745,-74.2017
-8533738,"Loveladies, NJ",39.725,-74.1367
-8533780,"Flat Creek, NJ",39.7067,-74.1917
-8533862,"North Beach, Manahawkin Bay, NJ",39.675,-74.16
-8533905,"Mill Creek, Manahawkin Bay, NJ",39.665,-74.2317
-8533909,"Manahawkin Creek, NJ",39.6667,-74.215
-8533935,"Manahawkin Drawbridge, NJ",39.6533,-74.185
-8533941,"Cedar Rkun, Li Egg Harbor, NJ",39.6533,-74.2567
-8533982,"Dinner Point Creek, NJ",39.6567,-74.27
-8533987,"West Creek, Westecunk Creek, NJ",39.6317,-74.2967
-8534002,"Upper Mullica River, NJ",39.625,-74.6417
-8534043,"Wading River, NJ",39.6183,-74.4967
-8534044,"Long Point, Little Egg Harbor, NJ",39.6133,-74.2633
-8534048,"Beach Haven Crest (Inside), NJ",39.6133,-74.21
-8534049,"Parker Run, Little Egg Harbor, NJ",39.6167,-74.31
-8534080,"Tuckerton, Tuckertoncreek, NJ",39.6017,-74.3417
-8534104,"New Gretna, Bass River, NJ",39.5917,-74.4417
-8534117,"Green Bank, Mullica River, NJ",39.6117,-74.59
-8534139,"Tuckerton, Little Egg Harbor, NJ",39.5767,-74.3317
-8534208,"Beach Haven Cg Station, NJ",39.5483,-74.2567
-8534212,"Cramers Boatyard, Mullica River, NJ",39.5483,-74.4617
-8534244,"Graveling Point, NJ",39.540000915527344,-74.38670349121094
-8534256,"Nancote Creek, NJ",39.535,-74.4633
-8534287,"Little Sheepshead Creek, NJ",39.5217,-74.32
-8534319,"Great Bay, Shooting Thorofare, NJ",39.50830078125,-74.32499694824219
-8534393,"Main Marsh Thorofare, NJ",39.4783,-74.3833
-8534468,"Mays Landing, Great Egg Harbor River, NJ",39.4483,-74.7283
-8534496,"Brigantine Channel, NJ",39.435,-74.3633
-8534540,"Absecon, Absecon Creek, NJ",39.4233,-74.5
-8534638,"Absecon Channal, NJ",39.385,-74.425
-8534657,"Pleasantville, Lakes Bay, NJ",39.3817,-74.5183
-8534691,"Great Egg Harbor River, NJ",39.3683,-74.7167
-8534720,"Atlantic City, NJ",39.356666564941406,-74.41805267333984
-8534739,"Dock Thorofare, NJ",39.3517,-74.54
-8534770,"Ventnor City, Fishing Pier, NJ",39.335,-74.4767
-8534778,"Steelmanville, Patcong River, NJ",39.334999084472656,-74.5967025756836
-8534836,"Longport, Risely Channel, NJ",39.3083,-74.5333
-8534883,"Tuckahoe,Tuckahoe River, NJ",39.295,-74.7483
-8534975,"Great Egg Harbor Bay, NJ",39.2883,-74.6283
-8535001,"Cedar Swamp, Tuckahoe River, NJ",39.2467,-74.7183
-8535055,"Bivalve, Maurice River, NJ",39.23249816894531,-75.03279876708984
-8535101,"Corson Inlet, NJ",39.215,-74.6483
-8535163,"Strathmere, Strathmere Bay, NJ",39.2,-74.6567
-8535221,"Ludlam Bay, NJ",39.1767,-74.71
-8535309,"Townsend Sound, NJ",39.1467,-74.75
-8535357,"Stites Sound, NJ",39.12,-74.755
-8535375,"Townsend Inlet, NJ",39.1217,-74.7167
-8535419,"Ingram Thorofare, NJ",39.11,-74.7383
-8535451,"Longreach, NJ",39.1017,-74.755
-8535581,"Stone Harbor, Great Channel, NJ",39.05670166015625,-74.76499938964844
-8535661,"Nummy Is.,Grassy Snd.Ch., NJ",39.0283,-74.8017
-8535695,"Old Turtle, Richardson Sound, NJ",39.0183,-74.8417
-8535726,"West Wildwood, Grassy Sound, NJ",39.005,-74.8267
-8535805,"Swain Channel, NJ",38.98,-74.8633
-8535835,"Wildwood Crest, NJ",38.975,-74.8233
-8535838,"Sunset Lake, NJ",38.9783,-74.8367
-8535901,"Cape May Harbor, NJ",38.9483,-74.8917
-8535902,"Cape Island Creek, NJ",38.9467,-74.9133
-8535962,"Cape May, Atlantic Ocean, NJ",38.93,-74.935
-8536021,"Cape May Point, NJ",38.9467,-74.9717
-8536110,"Cape May, NJ",38.968299865722656,-74.95999908447266
-8536271,"Villas-Jackson Pier, NJ",39.0183,-74.9533
-8536449,"Dias Creek, NJ",39.0833,-74.8867
-8536551,"Upper Bidwell Creek, NJ",39.1183,-74.8683
-8536581,"Bidwell Creek Entrance, Delaware Bay, NJ",39.1283,-74.8917
-8536687,"Sluice Creek, NJ",39.1617,-74.8317
-8536736,"Dennis Creek, Delaware Bay, NJ",39.1783,-74.8517
-8536752,"Upper Dennis Creek, NJ",39.1833,-74.8217
-8536764,"West Creek, Delaware Bay, NJ",39.1883,-74.915
-8536780,"East Point, NJ",39.2,-75.02
-8536801,"Riggins Ditch, NJ",39.2,-74.97
-8536823,"East Creek, NJ",39.2083,-74.9017
-8536848,"Fishing Creek, NJ",39.2167,-75.1583
-8536849,"Lower Dividing Creek, NJ",39.2167,-75.1033
-8536851,"West Creek, NJ",39.2167,-74.925
-8536855,"Riggins Ditch, Heislarville, NJ",39.2183,-74.98
-8536931,"Fortescue Creek, NJ",39.2383,-75.175
-8536935,"Weir Creek, Delaware Bay, NJ",39.25,-75.1283
-8537026,"Hollywood Beach, NJ",39.275,-75.1417
-8537052,"Money Island, NJ",39.285,-75.2383
-8537059,"Mauricetown, Maurice River, NJ",39.285,-74.9917
-8537079,"Newport Ldg., Nantuxent Creek, NJ",39.2917,-75.1983
-8537101,"Cedar Creek, NJ",39.2983,-75.2467
-8537116,"Back Creek, Del. Bay, NJ",39.305,-75.2783
-8537121,"Ship John Shoal, NJ",39.30538888888889,-75.37667777777777
-8537147,"Manumuskin River, NJ",39.3133,-74.985
-8537242,"Manantico Creek, NJ",39.3433,-75.0083
-8537353,"Tyndalls Wharf, NJ",39.3783,-75.235
-8537359,"Millville, NJ",39.3917,-75.0417
-8537374,"Greenwich, Cohansey River, NJ",39.3833,-75.35
-8537416,"Stathems Neck, Stow Ck., NJ",39.4067,-75.405
-8537488,"Pine Island, NJ",39.4217,-75.4283
-8537489,"Raccoon Ditch, NJ",39.4217,-75.3817
-8537535,"Mad Horse Creek, Delaware Bay, NJ",39.4317,-75.4467
-8537562,"Stow Creek,Delaware Bay, NJ",39.4617,-75.4033
-8537614,"Artificial Is., NJ",39.46,-75.5317
-8537667,"Hope Creek, Delaware Bay, NJ",39.4583,-75.495
-8537731,"Lower Alloway Creek, Del.Bay, NJ",39.4967,-75.5167
-8537753,"Hancocks Bridge, Alloway Creek, NJ",39.505,-75.4833
-8537774,"Abbots Meadow, NJ",39.5117,-75.4933
-8537779,"Cooper Creek, NJ",39.5133,-75.4467
-8537889,"Quinton, Alloway Creek, NJ",39.5483,-75.415
-8537961,"Sinnickson Landing, Salem R., NJ",39.57,-75.4983
-8537979,"Salem, NJ",39.5767,-75.4767
-8538231,"Deepwater, Delaware River, NJ",39.6833,-75.51
-8538274,"Auburn, Oldmans Creek, NJ",39.715,-75.36
-8538369,"Pedricktown, Oldmans Creek, NJ",39.7617,-75.4033
-8538438,"Mantua, NJ",39.795,-75.1767
-8538449,"Bridgeport, Racoon Creek, NJ",39.8067,-75.355
-8538512,"Paulsboro, Mantua Creek, NJ",39.835,-75.2383
-8538548,"Woodbury Creek, NJ",39.86,-75.1867
-8538552,"Billingsport, NJ",39.85,-75.25
-8538601,"Westville, Big Timber Creek, NJ",39.8733,-75.1233
-8538848,"North Branch,Rancocas Ck, Del B, NJ",39.9983,-74.8183
-8538853,"Palmyra, Pennsauken Creek, NJ",39.9933,-75.0283
-8538875,"Pompeston Creek, Delaware River, NJ",40.0133,-75.0083
-8538886,"Tacony-Palmyra Bridge, NJ",40.01190185546875,-75.04299926757812
-8538921,"Bridgeboro, Rancocas Creek, NJ",40.0283,-74.9317
-8539094,"Burlington, Delaware River, NJ",40.08169937133789,-74.86969757080078
-8539487,"Fieldsboro, Delaware River, NJ",40.1367,-74.7367
-8539993,"Trenton Marine Terminal, NJ",40.1883,-74.755
-8540433,"Marcus Hook, PA",39.81180555555556,-75.4095
-8542699,"Norwood, Darby Creek, PA",39.88,-75.29
-8542885,"Tinicum 4, Darby Creek, PA",39.8783,-75.2767
-8543024,"Tinicum 3, Darby Creek, PA",39.8867,-75.265
-8545240,"Philadelphia, PA",39.93305555555556,-75.14198055555556
-8545530,"Philadelphia (Pier 11 North), Del. River, PA",39.9533,-75.1383
-8546252,"Bridesburg, PA",39.97968333333333,-75.07931666666667
-8548989,"Newbold, PA",40.13733333333333,-74.75183333333334
-8549424,"Meenan, PA",40.1283,-74.8233
-8550438,"Edgemoor, DE",39.75,-75.4933
-8550714,"Wilmington, Christina R. Ent., DE",39.7183,-75.52
-8551201,"New Castle, DE",39.6567,-75.5617
-8551702,"Pea Patch Island, DE",39.5833,-75.5733
-8551762,"Delaware City, DE",39.58219444444445,-75.58897222222222
-8551851,"Delaware City Bridge, DE",39.57,-75.59
-8551910,"Reedy Point, DE",39.5583333,-75.5719444
-8554399,"Mahon River Entrance, DE",39.185,-75.4
-8555388,"Murderkill River Entrance, DE",39.0583,-75.3967
-8555889,"Brandywine Shoal Light, DE",38.98666666666667,-75.11333333333333
-8556198,"Mispillion River Entrance, DE",38.945,-75.3133
-8557380,"Lewes, DE",38.78283333333334,-75.11927777777778
-8557863,"Rehoboth Beach, DE",38.72,-75.0833
-8558690,"Indian River Inlet, DE",38.61,-75.07
-8558814,"Rosedale Beach, Indian River, DE",38.59149932861328,-75.21160125732422
-8559957,"Little Assawoman Bay, DE",38.45500183105469,-75.05829620361328
-8570255,"Keydash, Isle Of Wight Bay, MD",38.3417,-75.085
-8570280,"Ocean City, Fishing Pier, MD",38.3267,-75.0833
-8570282,"Ocean City, MD",38.3317,-75.09
-8570283,"Ocean City Inlet, MD",38.32833,-75.09166666666667
-8570536,"South Point, Sinepuxent Neck, Chinc. Bay, MD",38.215,-75.1917
-8570649,"Public Landing, Chincoteague Bay, MD",38.1483,-75.285
-8570691,"Buntings Bridge, MD",38.13894444444445,-75.18352777777778
-8571091,"Crisfield, MD",37.9767,-75.8633
-8571117,"Ewell, Smith Island, MD",37.995,-76.0317
-8571181,"Colbourn Creek, Big Annemessex R, MD",38.0483,-75.8033
-8571214,"Holland Bar Light, MD",38.0683,-76.0967
-8571351,"Chance, Nanticoke River, MD",38.1717,-75.945
-8571359,"Snow Hill, MD",38.17833,-75.39666666666666
-8571402,"Hooper Strait Lighthouse, MD",38.2267,-76.0767
-8571421,"Bishops Head, MD",38.22,-76.0383
-8571485,"Whitehaven, Wicomico River, MD",38.2683,-75.7883
-8571519,"Middle Hoopers Island, MD",38.2967,-76.205
-8571559,"Mccready'S Creek, MD",38.29999923706055,-76.00499725341797
-8571579,"Barren Island, MD",38.3417,-76.265
-8571616,"Salisbury, Wicomico River, MD",38.3650016784668,-75.60669708251953
-8571702,"Beaverdam Creek, MD",38.42833,-76.23666666666666
-8571773,"Vienna, MD",38.48333,-75.81833333333333
-8571858,"Sharpstown, Nanticoke River, MD",38.54499816894531,-75.72329711914062
-8571892,"Cambridge, MD",38.5725,-76.0616667
-8571901,"Avalon, Tilganan Island, MD",38.71,-76.335
-8571979,"Tilghman Island, Ferry Cove, MD",38.765,-76.3283
-8572271,"Poplar Island, MD",38.75833333333333,-76.375
-8572342,"St. Michaels, Miles River, MD",38.7867,-76.2217
-8572467,"Kent Point, MD",38.8367,-76.3733
-8572669,"Hillsboro, MD",38.9167,-75.945
-8572770,"Matapeake, MD",38.9567,-76.355
-8572955,"Love Point Pier, MD",39.0317,-76.3017
-8573137,"Cliff'S Wharf, MD",39.11,-76.1383
-8573211,"Deep Landing, Swan Creek, MD",39.145,-76.26
-8573349,"Crumpton, MD",39.245,-75.925
-8573364,"Tolchester Beach, MD",39.21344444444444,-76.24455555555555
-8573704,"Betterton, MD",39.3717,-76.0633
-8573903,"Town Point Wharf, MD",39.5033,-75.9167
-8573927,"Chesapeake City, MD",39.5266667,-75.81
-8574008,"Port Deposit, MD",39.6033,-76.1133
-8574070,"Havre De Grace, MD",39.5367,-76.09
-8574459,"Pond Point (Aberdeen P.G.), Bush River, MD",39.3883,-76.255
-8574680,"Baltimore, MD",39.266693115234375,-76.57830810546875
-8574683,"Fort Mchenry Marsh, MD",39.2617,-76.585
-8574821,"Hawkins Point, Patapsco River, MD",39.2083,-76.5333
-8574857,"North Point, MD",39.1967,-76.445
-8574931,"Stony Creek, MD",39.1633,-76.5267
-8575109,"Cornfield Creek, Magothy River, MD",39.1,-76.445
-8575512,"Annapolis, MD",38.983882904052734,-76.48003387451172
-8575550,"Gingerville Creek, South River, MD",38.9583,-76.555
-8575787,"Rhode River, MD",38.8867,-76.54
-8576363,"Chesapeake Beach, MD",38.7,-76.5333
-8577004,"Long Beach, MD",38.465,-76.4733
-8577188,"Cove Point, MD",38.3917,-76.3983
-8577330,"Solomons Island, MD",38.31669998168945,-76.45169830322266
-8578002,"Point Lookout, Potomac River, MD",38.04,-76.3233
-8578240,"Piney Point, MD",38.1333333,-76.5333333
-8579542,"Lower Marlboro, MD",38.655,-76.68333333333334
-8579997,"Bladensburg, Anacostia River, MD",38.9333,-76.9383
-8593005,"Washington Navy Yard,D.C., DC",38.8717,-76.995
-8593545,"Kingman Lake, Anacostia River, DC",38.895,-76.9683
-8593909,"East Lake, Anacostia River, DC",38.91,-76.955
-8594900,"Washington, DC",38.87333333333334,-77.02166666666666
-8630111,"Jesters Island, Chincoteague Bay, VA",37.9817008972168,-75.30169677734375
-8630249,"Chincoteague, Uscg Station, VA",37.93170166015625,-75.38330078125
-8630308,"Chincoteague Channel, South End, VA",37.9067,-75.405
-8630315,"Southern Chincoteague Island, VA",37.902400970458984,-75.40789794921875
-8631044,"Wachapreague, VA",37.60777777777778,-75.68583333333333
-8631542,"Sand Shoal Inlet, Cobb Island, VA",37.3017,-75.7783
-8631591,"Oyster Harbor, VA",37.2883,-75.925
-8632200,"Kiptopeke, VA",37.165199279785156,-75.9884033203125
-8632366,"Cape Charles Hbr (U.S. G. Wharf), VA",37.2633,-76.02
-8632837,"Rappahannock Light, VA",37.538299560546875,-76.01499938964844
-8632869,"Gaskins Pt., Occohannock Creek, VA",37.5567,-75.9167
-8633091,"Harborton, Pungoteague Creek, VA",37.6667,-75.8333
-8633362,"Schooner Bay, VA",37.7633,-75.7733
-8633532,"Tangier Island, VA",37.8283,-75.9933
-8633777,"Saxis, Starling Creek, VA",37.92169952392578,-75.72830200195312
-8635027,"Dahlgren, VA",38.31975277777778,-77.03659722222223
-8635150,"Colonial Beach, Potomac River, VA",38.2517,-76.96
-8635257,"Rappahannock Bend, VA",38.2133,-77.2433
-8635750,"Lewisetta, VA",37.99610137939453,-76.46440124511719
-8635985,"Wares Wharf, VA",37.8733,-76.7833
-8636128,"Fleet Pt, Great Wicomico River, VA",37.8133,-76.275
-8636580,"Windmill Point, VA",37.6155,-76.28977777777777
-8636653,"Lester Manor, VA",37.5833,-76.99
-8636654,"New Mill Creek, (Greys Point), VA",37.5833,-76.4183
-8636941,"Richmond Deepwater Terminal, James River, VA",37.45955555555555,-77.42077777777777
-8637624,"Gloucester Point, VA",37.2467,-76.5
-8637689,"Yorktown Uscg Training Center, VA",37.2265,-76.47880555555555
-8637712,"Jamestown, VA",37.22010040283203,-76.79139709472656
-8638017,"Fort Eustis (Marad), James River, VA",37.13822222222223,-76.62275
-8638339,"Western Branch, VA",36.82322222222222,-76.39911111111111
-8638421,"Burwell Bay, James River, VA",37.0567,-76.6683
-8638424,"Kingsmill, VA",37.22,-76.6633
-8638433,"Scotland, VA",37.185,-76.7833
-8638445,"Lanexa, Chickahominy River, VA",37.4033,-76.9117
-8638449,"Claremont, James River, VA",37.2317,-76.9483
-8638450,"Tettington, James River, VA",37.24,-76.9433
-8638464,"Wilcox Wharf, VA",37.315,-77.0983
-8638476,"Jordan Point, James River, VA",37.3133,-77.2233
-8638481,"Hopewell, VA",37.3133,-77.27
-8638489,"Puddledock, VA",37.2667,-77.3717
-8638491,"Chester, James River, VA",37.3833,-77.3783
-8638495,"Richmond River Locks, James River, VA",37.525,-77.42
-8638610,"Sewells Point, VA",36.9427778,-76.3286111
-8638660,"Portsmouth, Norfolk Naval Shipyard, VA",36.8217,-76.2933
-8638671,"Lafayette River, VA",36.88422222222222,-76.27585833333333
-8638863,"Chesapeake Bay Bridge Tunnel, VA",36.96670150756836,-76.11329650878906
-8638888,"Va. Pilots Dock, Lynnhaven Inlet, VA",36.9067,-76.09
-8638901,"Cbbt, Chesapeake Channel, VA",37.032901763916016,-76.08329772949219
-8638916,"Long Creek, Lynnhaven Bay, VA",36.9033,-76.07
-8638923,"Broad Bay Canal East, VA",36.9017,-76.0617
-8638999,"Cape Henry, VA",36.93000030517578,-76.00666809082031
-8639207,"Rudee Inlet, VA",36.8317,-75.9733
-8639214,"Rudee Heights, Lake Wesley, VA",36.825,-75.975
-8639219,"South End, Lake Rudee, VA",36.825,-75.9817
-8639348,"Money Point, VA",36.77819444444445,-76.30186111111111
-8639414,"Deep Creek Entrance, VA",36.755,-76.2933
-8639428,"Sandbridge, VA",36.6917,-75.92
-8651370,"Duck, NC",36.18330001831055,-75.74669647216797
-8652226,"Jennette'S Pier, NC",35.91,-75.59169444444444
-8652247,"Manns Harbor, NC",35.9033,-75.77
-8652437,"Oyster Creek, NC",35.845,-75.655
-8652547,"Roanoke Marshes Light, NC",35.8117,-75.7
-8652587,"Oregon Inlet Marina, NC",35.79569444444444,-75.54819444444445
-8652648,"Old House Channel, NC",35.77669906616211,-75.58499908447266
-8652678,"Uscg Lifeboat Station, Oregon Inlet, NC",35.7683,-75.5267
-8653215,"Rodanthe, Pamlico Sound, NC",35.595001220703125,-75.4717025756836
-8653244,"Pungo River Nc 45, NC",35.585201263427734,-76.48560333251953
-8653471,"Engelhard, NC",35.5093994140625,-75.98889923095703
-8653951,"Peter'S Ditch, NC",35.35013888888889,-75.51202777777777
-8654400,"Cape Hatteras Fishing Pier, NC",35.2233,-75.635
-8654467,"Uscg Station Hatteras, NC",35.20861111111111,-75.70419444444444
-8654769,"Ocracoke, Pamlico Sound, NC",35.115501403808594,-75.98690032958984
-8655133,"Oriental, Neuse River, NC",35.024600982666016,-76.69180297851562
-8655151,"Cedar Island, NC",35.01890182495117,-76.31430053710938
-8656084,"Core Creek Bridge, NC",34.82500076293945,-76.69000244140625
-8656201,"Davis, Core Sound, NC",34.79679870605469,-76.45549774169922
-8656225,"North River Bridge, Bettie, NC",34.7917,-76.6083
-8656306,"Morehead-Beaufort Y.C., Newport River, NC",34.7683,-76.6717
-8656451,"Gallant Channel, NC",34.7283,-76.6683
-8656467,"Spooners Creek, NC",34.725,-76.8033
-8656483,"Beaufort, Duke Marine Lab, NC",34.71733055555556,-76.67065833333334
-8656502,"Morehead City Harbor, Harbor Channel, NC",34.720001220703125,-76.71080017089844
-8656503,"Harkers Island Bridge, NC",34.715,-76.5783
-8656518,"Beaufort, Taylor Creek, NC",34.7117,-76.645
-8656539,"Lenoxville Point, North River Channel, NC",34.7083,-76.62
-8656566,"Coral Bay, Atlantic Beach, NC",34.7,-76.7683
-8656571,"Fort Macon, NC",34.6983,-76.6817
-8656590,"Atlantic Beach Triple S Pier, NC",34.6933,-76.7117
-8656613,"Swansboro, East Corbett Ave Bridge, NC",34.68659973144531,-77.11810302734375
-8656841,"Cape Lookout, Lookout Bight, NC",34.6133,-76.5383
-8656937,"Cape Lookout, Atlantic Ocean, NC",34.6083,-76.5283
-8657002,"Sneads Ferry, New River, NC",34.57630157470703,-77.39540100097656
-8657419,"Ocean City, Fishing Pier, NC",34.4517,-77.495
-8657813,"Hampstead, NC",34.33940124511719,-77.70600128173828
-8658120,"Wilmington, NC",34.22669982910156,-77.95330047607422
-8658145,"Shinn Point, NC",34.217899322509766,-77.81230163574219
-8658163,"Wrightsville Beach, NC",34.21330555555556,-77.78669444444445
-8658501,"Orton Point, Cape Fear River, NC",34.0567,-77.94
-8658559,"Wilmington Beach, NC",34.0317,-77.8933
-8658579,"Sunny Point, Motsu North Wharf, NC",34.0233,-77.9467
-8658622,"Reaves Point, Motsu Center, NC",34.0033,-77.955
-8658654,"Motsu South Wharf #1, Cape Fear River, NC",33.99,-77.9567
-8658715,"Federal Point, Cape Fear River, NC",33.9617,-77.94
-8658741,"Zekes Island, Cape Fear River, NC",33.95,-77.9517
-8658901,"Bald Head Island, Cape Fear River, NC",33.88,-78.0017
-8659084,"Southport, NC",33.915,-78.0183
-8659182,"Oak Island, Atlantic Ocean, NC",33.9017,-78.0817
-8659414,"Varnamtown, Lockwoods Folly River, NC",33.933101654052734,-78.21890258789062
-8659665,"Bowen Point, Shallotte Inlet, NC",33.915000915527344,-78.37329864501953
-8659897,"Sunset Beach, NC",33.865,-78.5067
-8660098,"Little River Neck, SC",33.87,-78.5733
-8660121,"Little River Town, Little R., SC",33.87,-78.6083
-8660147,"Dunn Sound, North, Little River, SC",33.86,-78.58
-8660148,"Dunn Sound, Little River, SC",33.8583,-78.57
-8660166,"Nixon Crossroads, Little River, SC",33.855,-78.6483
-8660195,"Dunn Sound, West End, SC",33.8517,-78.5883
-8660265,"Cherry Grove, Inside, SC",33.835,-78.6333
-8660266,"Hog Inlet Pier, SC",33.8367,-78.6067
-8660401,"Myrtle Beach Airport, SC",33.82,-78.7183
-8660642,"North Myrtle Beach, SC",33.766700744628906,-78.81500244140625
-8660854,"Combination Bridge, SC",33.7133,-78.9217
-8660983,"Socastee Bridge, SC",33.6867,-79.005
-8661070,"Springmaid Pier, SC",33.654998779296875,-78.91829681396484
-8661093,"Yauhannah Bridge, Pee Dee River, SC",33.66,-79.155
-8661119,"Sandy Island North, Bull Cr., SC",33.6017,-79.1183
-8661139,"Bucksport, Waccamaw River, SC",33.6467,-79.095
-8661299,"Lower Topsaw Landing, Pee Dee River, SC",33.6083,-79.1517
-8661347,"Waccamaw River, S. Of Bull Cr., SC",33.5967,-79.0983
-8661419,"Garden City Bridge, Murrells Inlet, SC",33.5783,-79.0033
-8661437,"Garden City Pier, Murrells Inlet, SC",33.575,-78.9967
-8661493,"Wachesaw Landing, Waccamaw R., SC",33.560001373291016,-79.08499908447266
-8661529,"Capt. Alex'S Marina, Murrells, SC",33.5517,-79.0367
-8661559,"Smith'S Dock, Murrells Inlet, SC",33.545,-79.045
-8661582,"Divine'S Dock, Murrells Inlet, SC",33.5417,-79.0283
-8661593,"Winea Plantation, Black River, SC",33.535,-79.3883
-8661608,"Allston Creek, Murrells Inlet, SC",33.5317,-79.0533
-8661609,"Oaks Cr. Inlet, Murrells Inlet, SC",33.53,-79.0433
-8661684,"Oaks Creek, Upper End, Murrells Inlet, SC",33.5117,-79.0683
-8661703,"Sandy Island, Thoroughfare Creek, SC",33.5067,-79.145
-8661734,"Mt. Pleasant Plant., Black R., SC",33.495,-79.4617
-8661989,"Bennett'S Dock, SC",33.435,-79.1267
-8661991,"Hagley, Waccamaw River, SC",33.435,-79.1817
-8662006,"Pawleys Island Pier, Atlantic Ocean, SC",33.4317,-79.1167
-8662071,"Pawleys Inlet, Wards Dock, SC",33.4117,-79.135
-8662216,"Cumberland, Sampit River, SC",33.37,-79.4333
-8662245,"Oyster Landing (N Inlet Estuary), SC",33.35169982910156,-79.18669891357422
-8662299,"Clambank Creek Dock, Goat Island, SC",33.3333,-79.1933
-8662405,"Jamestown Bridge, Santee River, SC",33.305,-79.6783
-8662549,"South Island Ferry, Winyah Bay, SC",33.2517,-79.2683
-8662670,"Pleasant Hill Landing, Santee River, SC",33.245,-79.5217
-8662746,"Winyah Bay, South Island Plantation, SC",33.235,-79.2033
-8662747,"Georgetown Lt.House, Winyah Bay, SC",33.2233,-79.185
-8662793,"N. Santee Bridge, N. Santee R., SC",33.21,-79.385
-8662796,"Minim Creek, SC",33.195,-79.275
-8662799,"Us Highway 17, South Santee River, SC",33.185,-79.4067
-8662926,"Georgetown, Sampit River Ent., SC",33.361698150634766,-79.27999877929688
-8662931,"Waccamaw River Entrance, SC",33.36669921875,-79.25499725341797
-8662953,"Windsor Plantation, Black River, SC",33.415,-79.25
-8663101,"Cape Romain, SC",33.025,-79.3483
-8663219,"S. Santee R.,Iww(4 Mi. Canal Cr), SC",33.15420150756836,-79.35440063476562
-8663381,"Cedar Island Pt, South Santee R, SC",33.12,-79.27
-8663461,"Casino Creek, SC",33.1083,-79.3933
-8663535,"Quinby Bridge, Quinby Creek, SC",33.095,-79.8083
-8663539,"Pimlico, West Branch Cooper River, SC",33.095,-79.9533
-8663618,"Mc Clellanville, Jeremy Creek, SC",33.0783,-79.46
-8663665,"Richmond Plantation, E. Br. Cooper River, SC",33.0767,-79.855
-8663757,"Dupont, Dean Hall, Cooper R., SC",33.0583,-79.9367
-8663781,"French Quarter Creek, SC",33.055,-79.88
-8663858,"Buck Hall, Awendaw Creek, SC",33.040000915527344,-79.55999755859375
-8664022,"Gen. Dynamics Pier, Cooper R., SC",33.0083,-79.9233
-8664442,"Moores Landing, Sewee Bay, SC",32.9367,-79.655
-8664515,"Snow Point, 0.4 Mile N Of, Cooper River, SC",32.9483,-79.9317
-8664531,"Bacon Bridge, Ashley River, SC",32.9583,-80.2033
-8664541,"Yeamans Hall, Goose Creek, SC",32.925,-79.9867
-8664545,"Cainhoy, Wando River, SC",32.9267,-79.83
-8664589,"Hanahan, Turkey Creek, SC",32.9183,-80.0117
-8664611,"Big Paradise Island, Wando River, SC",32.915,-79.7467
-8664621,"Bull Island, Summerhouse Creek, SC",32.9133,-79.6167
-8664662,"Army Depot, SC",32.91,-79.9517
-8664688,"Clouter Creek, North, SC",32.9067,-79.935
-8664699,"North Charleston, Ashley River, SC",32.900299072265625,-80.11750030517578
-8664701,"Nowell Creek, SC",32.9,-79.9
-8664782,"Horlbeck Creek, Wando River, SC",32.885,-79.845
-8664801,"Price Creek, North Capers Island, SC",32.8817,-79.6583
-8664878,"Old Capers Landing, Capers Island, SC",32.87,-79.6867
-8664941,"South Capers Island, SC",32.8567,-79.7067
-8664945,"Clouter Creek, South, SC",32.86,-79.9383
-8664992,"North Dewee'S Island, SC",32.85,-79.7033
-8665002,"Drayton, Bees Ferry, Ashley River, SC",32.8483,-80.0517
-8665099,"I-526 Bridge, Ashley River, SC",32.8367,-80.0217
-8665101,"Cosgrove Bridge, Ashley River, SC",32.835,-79.9867
-8665111,"South Dewees Island, Dewees Inlet, SC",32.8333,-79.7267
-8665167,"Hamlin Sound, SC",32.8267,-79.7867
-8665192,"Wando River Entrance, Hobcaw Point, SC",32.8217,-79.9
-8665257,"Edisto River, South Of Canaday Landing, SC",32.8133,-80.4067
-8665387,"Hamlin Creek, Isle Of Palms, SC",32.7867,-79.7917
-8665424,"Highway 171 Bridge, Folly Creek, SC",32.675,-79.9517
-8665426,"Shem Creek At 17, SC",32.7933,-79.8817
-8665475,"Limehouse Bridge, Stono River, SC",32.7867,-80.105
-8665494,"Isle Of Palms Pier, SC",32.7833,-79.785
-8665495,"South Ashley Bridge, Ashley River, SC",32.7833,-79.9567
-8665530,"Charleston, SC",32.7808333,-79.9236111
-8665552,"Breach Inlet, SC",32.7767,-79.8117
-8665567,"Ben Sawyer Bridge, Iww, SC",32.7733,-79.8417
-8665589,"Sandblasters, Penny'S Creek, SC",32.77,-80.0633
-8665599,"Penneys Creek W Entrance, Stono River, SC",32.7683,-80.07
-8665637,"The Cove, Ft Moultrie, Charleston Harbor, SC",32.7633,-79.8567
-8665641,"Elliott Cut Entrance, Stono River, SC",32.7633,-80.0017
-8665728,"Fort Sumter, Charleston Harbor, SC",32.7533,-79.8767
-8665737,"Jacksonboro Camp, South Edisto River, SC",32.7533,-80.45
-8665763,"Hollywood, Wadmalaw River, SC",32.746700286865234,-80.16500091552734
-8666017,"Edisto River, South Of Penny Creek, SC",32.715,-80.4367
-8666101,"Johns Island, Church Creek, SC",32.7067,-80.1567
-8666131,"Lower Toogoodoo Creek, SC",32.7033,-80.2783
-8666167,"Hope Creek, SC",32.7,-80.4267
-8666217,"Yonges Island, Wadmalaw River, SC",32.695,-80.2233
-8666282,"Oak Branch, Bohicket Creek, SC",32.6833,-80.0967
-8666283,"Mc Dermids Pier, Stono River, SC",32.6767,-80.0067
-8666359,"Bluff Plantation, Combahee River, SC",32.6833,-80.7383
-8666367,"Willtown Bluff, SC",32.6817,-80.4167
-8666433,"Toogoodoo Creek, SC",32.6683,-80.2933
-8666467,"Folly River, North, SC",32.67,-79.9167
-8666616,"South Edisto River At Dawhoo River, SC",32.6567,-80.3917
-8666652,"Folly River Bridge, Folly River, SC",32.6617,-79.945
-8666659,"Combahee River At Us Hwy. 17, SC",32.6517,-80.6833
-8666699,"Bluff Point, Wadmalaw River, SC",32.6467,-80.2567
-8666749,"Airy Hall, Ashepoo River, SC",32.6317,-80.4717
-8666767,"Snake Island, Stono River, SC",32.64,-80.015
-8666775,"Leadenwah Creek, SC",32.6367,-80.2017
-8666799,"Dawhoo Bridge, Dawhoo River, SC",32.6367,-80.3417
-8666918,"Ho-Non-Wah Boyscout Camp, Bohicket Cr, SC",32.625,-80.1667
-8667062,"Kiawah Bridge, Kiawah River, SC",32.6033,-80.1317
-8667067,"Pine Landing, South Edisto R., SC",32.6033,-80.3883
-8667074,"Wiggins, Chehaw River, SC",32.6017,-80.5417
-8667075,"Steamboat Creek Landing, SC",32.6033,-80.2867
-8667172,"Sheldon, Huspa Creek, SC",32.5833,-80.7833
-8667178,"Point Of Pines, N. Edisto R., SC",32.585,-80.2283
-8667199,"Wimbee Creek, SC",32.5783,-80.67
-8667209,"Musselboro Island, Mosquito Creek, SC",32.5783,-80.4483
-8667259,"Fields Point, Combahee R., SC",32.5683,-80.5533
-8667281,"Ocella Creek, SC",32.5617,-80.2383
-8667295,"White House Woods, Mosquito Creek, SC",32.55870056152344,-80.45439910888672
-8667309,"Fenwick Island, South Edisto River, SC",32.56,-80.4183
-8667411,"Lobeco, Whale Branch, Coosaw River, SC",32.5733,-80.745
-8667425,"Peters Point, St. Pierre Creek, SC",32.54,-80.34
-8667524,"Seabrook, Ashepoo River, SC",32.5233,-80.4067
-8667612,"Air Station Beaufort, Mccalleys Creek, SC",32.50189971923828,-80.68489837646484
-8667630,"Edisto Beach, Edisto Island, SC",32.5017,-80.2967
-8667633,"Clarendon Plantation, SC",32.5025,-80.7841
-8667676,"Edisto Marina, Big Bay Creek, SC",32.4933,-80.34
-8667679,"Carter'S Dock, Big Bay Creek, SC",32.4933,-80.3267
-8667733,"Sams Point, Lucy Point Creek, SC",32.4833,-80.6
-8667783,"Otter Island, St. Helena Sound, SC",32.4767,-80.42
-8667909,"Salt Creek At Rt. 21, SC",32.45,-80.7317
-8667972,"Eddings Point Creek, SC",32.4467,-80.5333
-8667982,"Jenkins Creek, SC",32.44,-80.5533
-8667999,"Beaufort, SC",32.43,-80.675
-8668092,"Battery Creek, SC",32.4133,-80.7
-8668146,"Harbor River Bridge, St. Helena Sound, SC",32.4033,-80.4533
-8668155,"Distant Island Creek, Upper End, SC",32.4017,-80.6533
-8668223,"Broad River Bridge, SC",32.3867,-80.7767
-8668227,"Johnson'S Creek, Harbor Island, SC",32.3917,-80.4383
-8668301,"Chechessee Bluff, Chechessee R., SC",32.3733,-80.8367
-8668482,"Baileys Landing, Okatee River, SC",32.3467,-80.89
-8668498,"Fripps Inlet, SC",32.34,-80.465
-8668511,"Callawassie Island Bridge, SC",32.3417,-80.8567
-8668601,"Station Creek, SC",32.325,-80.6017
-8668619,"Colleton River Entrance, SC",32.3217,-80.7917
-8668701,"Purrysburg Landing, Savannah River, SC",32.3033,-81.1217
-8668918,"Ribaut Island, Skull Creek, SC",32.2667,-80.7367
-8669103,"Bluffton, May River, SC",32.23,-80.8617
-8669133,"Skull Creek South, SC",32.2233,-80.7717
-8669167,"Port Royal Pltn., Hilton Head, SC",32.22,-80.6683
-8669262,"North Bull Island, May River, SC",32.2,-80.815
-8669338,"Broad Creek, SC",32.185,-80.7533
-8669415,"U.S. Highway 17, Little Back River, SC",32.165,-81.13
-8669601,"Pine Island, Ramshorn Creek, SC",32.1217,-80.8983
-8669691,"Daufuskie Landing, New River, SC",32.1033,-80.895
-8669801,"Bloody Point, New River, SC",32.0817,-80.8783
-8670424,"Port Wentworth, GA",32.14330555555556,-81.14169444444444
-8670870,"Fort Pulaski, GA",32.03469444444445,-80.90302777777778
-8671086,"Skidaway Institute, Skidaway River, GA",31.99,-81.0233
-8671314,"Halfmoon Reef, Halfmoon River, GA",31.963300704956055,-80.94329833984375
-8671315,"Priest Landing, Wilmington River, GA",31.963300704956055,-81.01170349121094
-8671489,"Richmond Hill, Ogeechee River, GA",31.94300079345703,-81.28980255126953
-8671946,"Little Wassaw Island, Green Island Sound, GA",31.889699935913086,-81.06169891357422
-8672667,"Range A Light, Bear River, GA",31.7933,-81.1817
-8672875,"Sunbury, Sunbury Channel, GA",31.7667,-81.2783
-8673171,"South Ossabaw Island, Bear River, GA",31.72302777777778,-81.1417
-8673381,"Halfmoon, Colonels Island, Timmons River, GA",31.695,-81.2717
-8674301,"Daymark #135, South Newport River, GA",31.575,-81.19
-8674975,"Daymark #156, Head Of Mud River, GA",31.4867,-81.32
-8675622,"Old Tower, Sapelo Island, Doboy Sound, GA",31.39,-81.2883
-8675761,"Daymark #185, Rockdedundy River Entrance, GA",31.37386111111111,-81.33394444444444
-8676329,"Mackay River, Icww, Buttermilk Sound, GA",31.285,-81.385
-8676808,"Crispen Island,Turtle River, GA",31.213300704956055,-81.55000305175781
-8677344,"St.Simons Island, GA",31.1317,-81.3967
-8677406,"Howe Street Pier, Brunswick, GA",31.14455555555556,-81.49680555555555
-8678124,"Raccoon Key Spit, GA",31.01480555555555,-81.45597222222223
-8678322,"Bailey Cut, Satilla River, GA",30.985,-81.5917
-8679511,"Kings Bay, GA",30.7967,-81.515
-8679598,"Kings Bay Msf Pier, GA",30.778099060058594,-81.49140167236328
-8679758,"Dungeness, Seacamp Dock, GA",30.7633,-81.4717
-8679945,"Beach Creek, GA",30.7267,-81.4767
-8679964,"St. Marys, St. Marys River, GA",30.72,-81.5483
-8720001,"St. Marys River Headwaters, FL",30.7867,-81.84
-8720004,"Crandall, St. Marys River, FL",30.7217,-81.6217
-8720006,"Little St. Marys River, FL",30.7317,-81.7267
-8720007,"Roses Bluff, FL",30.7033,-81.5767
-8720011,"Cut 1N Front Range, St Marys River Entr, FL",30.7083,-81.465
-8720023,"Chester, Bells River, FL",30.6833,-81.5333
-8720030,"Fernandina Beach, FL",30.67135555555556,-81.46584166666666
-8720051,"Lanceford Creek, Lofton, FL",30.6433,-81.5233
-8720058,"Kingsley Creek, Seaboard R.R., FL",30.6317,-81.4767
-8720059,"Vaughns Landing, FL",30.63,-81.5767
-8720084,"Boggy Creek, Upper Nassau River, FL",30.5883,-81.6633
-8720086,"Amelia City, South Amelia River, FL",30.5867,-81.4633
-8720093,"Halfmoon Island, FL",30.5767,-81.6083
-8720097,"Cuno, Lofton Creek, FL",30.5767,-81.5717
-8720098,"Nassauville, Nassau River East, FL",30.5683,-81.515
-8720119,"Mink Creek Ent., Nassau River, FL",30.5367,-81.5817
-8720135,"Nassau River Entrance, FL",30.518299102783203,-81.45330047607422
-8720137,"Sawpit Creek Entrance, FL",30.5133,-81.4567
-8720143,"Sawpit Creek, FL",30.5033,-81.4717
-8720145,"Edwards Creek, FL",30.5017,-81.5417
-8720148,"Tiger Point, Pumpkin Hills Creek, FL",30.5017,-81.495
-8720168,"Simpson Creek, FL",30.465,-81.4317
-8720186,"Fort George Island, FL",30.44,-81.4383
-8720189,"Cedar Heights, FL",30.4367,-81.6417
-8720196,"Sisters Creek, FL",30.4167,-81.4533
-8720198,"Clapboard Creek, FL",30.4067,-81.51
-8720203,"Blount Island Bridge, FL",30.4133,-81.545
-8720211,"Mayport Naval Sta., St Johns River, FL",30.4,-81.4133
-8720213,"Trout R., Sherwood Forest, FL",30.42,-81.7283
-8720214,"Degaussing Structure, FL",30.3967,-81.395
-8720215,"Navy Fuel Depot, FL",30.4,-81.6267
-8720216,"Ribault River, Lake Forest, FL",30.3983,-81.6983
-8720217,"Moncrief Creek Entrance, FL",30.3917,-81.6617
-8720218,"Mayport (Bar Pilots Dock), FL",30.39816666666667,-81.42788888888889
-8720219,"Dames Point, FL",30.386699676513672,-81.55829620361328
-8720220,"Mayport (Ferry Depot), FL",30.3933,-81.4317
-8720221,"Fulton, St. Johns River, FL",30.39,-81.5067
-8720225,"Phoenix Park, FL",30.3833,-81.6367
-8720226,"Southbank Riverwalk, St Johns River, FL",30.32,-81.6583
-8720232,"Pablo Creek Entrance, FL",30.3767,-81.4483
-8720242,"Long Branch, FL",30.360000610351562,-81.62000274658203
-8720267,"Pablo Creek, FL",30.3233,-81.4383
-8720274,"Little Pottsburg Creek, FL",30.31,-81.61
-8720291,"Jacksonville Beach, FL",30.2833,-81.3867
-8720296,"Ortega River Entrance, FL",30.2783,-81.705
-8720305,"Oak Landing, FL",30.2533,-81.43
-8720333,"Piney Point, St. Johns River, FL",30.2283,-81.6633
-8720357,"I-295 Buckman Bridge, FL",30.19241666666667,-81.68888888888888
-8720374,"Orange Park, St. Johns River, FL",30.16830062866211,-81.69499969482422
-8720398,"Palm Valley Icww, FL",30.1333,-81.3867
-8720406,"Doctors Lake, Peoria Point, FL",30.12,-81.7583
-8720409,"Julington Creek, FL",30.135000228881836,-81.62999725341797
-8720434,"Black Creek, FL",30.079999923706055,-81.76170349121094
-8720494,"Tolomato River, Icww, FL",29.994400024414062,-81.32949829101562
-8720496,"Green Cove Springs, St. Johns R., FL",29.99,-81.6633
-8720503,"Red Bay Point, St Johns River, FL",29.98166666666667,-81.63416666666667
-8720554,"Vilano Beach Icww, FL",29.9167,-81.3
-8720576,"St. Augustine, FL",29.8917,-81.31
-8720582,"State Road 312, Matanzas River, FL",29.8667,-81.3067
-8720587,"St. Augustine Beach, FL",29.8567,-81.2633
-8720596,"East Tocoi, St. Johns River, FL",29.8583,-81.5533
-8720625,"Racy Point, St Johns River, FL",29.8017,-81.5483
-8720651,"Crescent Beach, Matanzas River, FL",29.7683,-81.2583
-8720653,"Palmetto Bluff, St. Johns River, FL",29.7633,-81.5617
-8720686,"Fort Matanzas, FL",29.715,-81.2383
-8720692,"State Road A1A Bridge, FL",29.70453055555556,-81.22785555555555
-8720757,"Bings Landing, Matanzas River, FL",29.615,-81.205
-8720767,"Buffalo Bluff, St Johns River, FL",29.595,-81.6817
-8720774,"Palatka, St Johns River, FL",29.6433,-81.6317
-8720782,"Sutherlands Still, FL",29.5717,-81.6067
-8720793,"Piney Bluff Landing, FL",29.5583,-81.5733
-8720832,"Welaka, FL",29.4767,-81.675
-8720833,"Smith Creek, Flagler Beach, FL",29.4783,-81.1367
-8720954,"Ormond Beach, Halifax River, FL",29.28499984741211,-81.05329895019531
-8721120,"Daytona Beach Shores, FL",29.1467,-80.9633
-8721138,"Halifax River, Ponce Inlet, FL",29.0817,-80.9367
-8721147,"Ponce De Leon Inlet South, FL",29.06333333333333,-80.91583333333334
-8721164,"New Smyrna Beach, FL",29.0233,-80.9183
-8721222,"Packwood Place, FL",28.94,-80.87
-8721223,"Turtle Mound, FL",28.9267,-80.825
-8721604,"Trident Pier, Port Canaveral, FL",28.415800094604492,-80.59310150146484
-8721649,"Cocoa Beach, Atlantic Ocean, FL",28.3683,-80.6
-8721727,"Patrick Air Force Base, FL",28.245,-80.6
-8721804,"Canova, FL",28.1383,-80.5783
-8721843,"Melbourne Causeway, FL",28.08329963684082,-80.5916976928711
-8721994,"Micco, Indian River, FL",27.8733,-80.4967
-8722004,"Sebastian Inlet, FL",27.86,-80.4483
-8722029,"Sebastian, Indian River, FL",27.8117,-80.4633
-8722059,"Wabasso,Indian River, FL",27.755,-80.425
-8722125,"Vero Beach, FL",27.6317,-80.3717
-8722146,"Oslo,Indian River, FL",27.5933,-80.3567
-8722207,"St. Lucie,Indian River, FL",27.48,-80.3333
-8722212,"Fort Pierce, South Jetty, FL",27.47,-80.2883
-8722213,"Binney Dock, FL",27.4683,-80.3
-8722219,"South Beach Causeway, FL",27.4567,-80.3233
-8722274,"Ankona, Indian River, FL",27.355,-80.2733
-8722312,"Nettles Island, Indian River, FL",27.2867,-80.2267
-8722329,"Jensen Beach Causeway Park, FL",27.251699447631836,-80.21829986572266
-8722334,"North Fork, St. Lucie River, FL",27.2433,-80.3133
-8722357,"Stuart, St. Lucie River, FL",27.2,-80.2583
-8722366,"Seminole Shores, FL",27.1833,-80.1583
-8722371,"Sewall Point. St. Lucie River, FL",27.174999237060547,-80.18830108642578
-8722375,"South Point, St Lucie Inlet, FL",27.1583,-80.1567
-8722376,"South Fork,St. Lucie River, FL",27.165,-80.255
-8722383,"Port Salerno, FL",27.1517,-80.195
-8722404,"Peck Lake, St. Lucie Inlet, FL",27.1133,-80.145
-8722414,"Gomez, FL",27.0933,-80.1367
-8722429,"Hobe Sound Bridge, Hobe Sound, FL",27.065,-80.1233
-8722445,"Hobe Sound, State Park, FL",27.0367,-80.1067
-8722472,"North Loxahatchee River, FL",26.9867,-80.1417
-8722478,"North Fork, Loxahatchee River, FL",26.975,-80.1133
-8722481,"Loxahatchee River, FL",26.97,-80.1267
-8722486,"Tequesta, N.Fork,Loxahatchee R., FL",26.96,-80.105
-8722491,"Jupiter Sound, South End, FL",26.9517,-80.08
-8722492,"Jupiter West, FL",26.9467,-80.09
-8722495,"Jupiter Inlet, FL",26.9433,-80.0733
-8722496,"Loxahatchee River Lock, FL",26.935,-80.1433
-8722499,"Jupiter, Intracoastal Waterway, FL",26.935,-80.085
-8722512,"Lake Worth Creek, FL",26.9117,-80.08
-8722528,"Donald Ross Bridge, FL",26.8817,-80.07
-8722548,"Pga Boulevard Bridge, Palm Beach, FL",26.8433,-80.0667
-8722557,"North Palm Beach, FL",26.8267,-80.055
-8722588,"Port Of West Palm Beach, FL",26.77,-80.0517
-8722607,"Palm Beach, FL",26.7333,-80.0417
-8722621,"Palm Beach, FL",26.705,-80.045
-8722654,"West Palm Beach, FL",26.645,-80.045
-8722669,"Lake Worth Icw, FL",26.6133,-80.0467
-8722670,"Lake Worth Pier, Atlantic Ocean, FL",26.6127778,-80.0341667
-8722706,"Boynton Beach, FL",26.54829978942871,-80.05329895019531
-8722718,"Ocean Ridge, FL",26.52669906616211,-80.05329895019531
-8722746,"Delray Beach, FL",26.4733,-80.0617
-8722761,"South Delray Beach, FL",26.4467,-80.065
-8722784,"Yamato, FL",26.4033,-80.07
-8722802,"Lake Wyman, FL",26.37,-80.07
-8722816,"Boca Raton, FL",26.343299865722656,-80.07669830322266
-8722832,"Deerfield Beach, FL",26.31329917907715,-80.08170318603516
-8722859,"Hillsboro, FL",26.260000228881836,-80.08499908447266
-8722861,"Hillsboro Inlet, Inside, FL",26.2583,-80.0817
-8722862,"Hillsboro Inlet Ocean, FL",26.2567,-80.08
-8722899,"Lauderdale-By-The-Sea, FL",26.18829917907715,-80.09329986572266
-8722937,"Ft. Lauderdale, Andrews Avenue Bridge, FL",26.11829948425293,-80.1449966430664
-8722939,"Ft. Lauderdale Bahia Yacht Club, FL",26.1133,-80.1083
-8722951,"Port Everglades, Lake Mabel, FL",26.0917,-80.1233
-8722956,"South Port Everglades, FL",26.0816667,-80.1166667
-8722957,"North Dania Sound, FL",26.08,-80.1117
-8722968,"Port Laudania, FL",26.06,-80.13
-8722971,"Whiskey Creek, South Entrance, FL",26.055,-80.1133
-8722977,"West Lake, North End, FL",26.0433,-80.1267
-8722979,"Hollywood Beach, FL",26.04,-80.115
-8722982,"West Lake, South End, FL",26.0333,-80.1233
-8723026,"Golden Beach, FL",25.9667,-80.125
-8723044,"Dumfoundling Bay, FL",25.9417,-80.125
-8723050,"North Miami Beach, FL",25.93,-80.12
-8723073,"Haulover Inside, FL",25.9033,-80.125
-8723080,"Haulover Pier, N. Miami Beach, FL",25.9033,-80.12
-8723089,"Biscayne Creek, Intracoastal Waterway, FL",25.88,-80.1633
-8723155,"Miami Ship Base, FL",25.77,-80.1683
-8723165,"Miami, Biscayne Bay, FL",25.7783,-80.185
-8723170,"Miami Beach, FL",25.7683,-80.1317
-8723178,"Miami Beach, Government Cut, FL",25.7633,-80.13
-8723205,"Dinner Key Marina,Biscayne Bay, FL",25.7267,-80.2367
-8723214,"Virginia Key, FL",25.731399536132812,-80.16179656982422
-8723232,"Key Biscayne Yacht Club, FL",25.6983,-80.17
-8723251,"Cape Florida, Key Biscayne, FL",25.6517,-80.16
-8723289,"Cutler, Biscayne Bay, FL",25.615,-80.305
-8723350,"Ragged Key #3, FL",25.5333,-80.1717
-8723355,"Ragged Key No. 5, Biscayne Bay, FL",25.5233,-80.175
-8723372,"Sands Key, Elliott Key, FL",25.5067,-80.1883
-8723391,"Coon Point, Elliott Key, FL",25.48,-80.1883
-8723393,"Elliott Key (Outside), FL",25.4767,-80.18
-8723409,"Elliott Key Harbor, Elliott Key, FL",25.4533,-80.1967
-8723423,"Turkey Point, Biscayne Bay, FL",25.4367,-80.33
-8723439,"Billy'S Point, Elliott Key, FL",25.415,-80.21
-8723453,"Adams Key, FL",25.3967,-80.2333
-8723457,"Christmas Point, Elliott Key, FL",25.3917,-80.23
-8723465,"East Arsenicker, Card Sound, FL",25.3733,-80.29
-8723467,"Totten Key, Biscayne Bay, FL",25.3783,-80.2567
-8723506,"Pumpkin Key, Card Sound, FL",25.325,-80.2933
-8723518,"Wednesday Point, Key Largo, FL",25.31,-80.2983
-8723519,"Ocean Reef Harbor, Key Largo, FL",25.3083,-80.2767
-8723534,"Card Sound Bridge, FL",25.2883,-80.37
-8723583,"Carysfort Reef Lighthouse, FL",25.2217,-80.2117
-8723644,"Flamingo Visitors Center, FL",25.1417,-80.9233
-8723689,"Point Charles, Key Largo, FL",25.0817,-80.4467
-8723691,"Pt. Charles, Gage 'C', Key Largo, FL",25.0817,-80.45
-8723746,"Crane Key, FL",25.005,-80.6183
-8723747,"Tavernier Hawk Channel, FL",25.005,-80.5167
-8723752,"East Key, Florida Bay, FL",24.9967,-80.61
-8723769,"Plantation Key, Atlantic Side, FL",24.9733,-80.55
-8723786,"Uscg Sta., Islamorada, Snake Cr, FL",24.9533,-80.5867
-8723795,"Whale Harbor Marina, FL",24.94,-80.6083
-8723797,"Islamorada, Whale Harbor Channel, FL",24.9383,-80.61
-8723807,"Shell Key, N.W.Side, FL",24.9233,-80.6717
-8723808,"Upper Matecumbe Key,Florida Bay, FL",24.925,-80.6317
-8723812,"Shell Key Channel, FL",24.9133,-80.66
-8723814,"Upper Matecumbe Key,Atlan. Side, FL",24.915,-80.6317
-8723824,"Lignumvitae Key East, FL",24.9033,-80.695
-8723825,"Lignumvitae Key West, FL",24.9,-80.705
-8723828,"Upper Matecumbe Key, West End, FL",24.8967,-80.6583
-8723843,"Indian Key, Hawk Channel, FL",24.8767,-80.6767
-8723851,"Lower Matecumbe Key Hawk Channel, FL",24.8683,-80.7033
-8723852,"Lower Matecumbe Key, Fla. Bay, FL",24.865,-80.7167
-8723861,"Alligator Reef Lighthouse, FL",24.85,-80.6183
-8723873,"Long Key, Florida Bay, FL",24.83830555555556,-80.79830555555556
-8723906,"Long Key Channel West, FL",24.7917,-80.8833
-8723912,"Tom'S Harbor Cut, FL",24.7833,-80.9067
-8723918,"Tom'S Harbor Channel, FL",24.7767,-80.9233
-8723921,"Grassy Key North Side, Florida Bay, FL",24.7717,-80.94
-8723927,"Duck Key, FL",24.765,-80.9133
-8723933,"Grassy Key, Atlantic Side, FL",24.755,-80.9583
-8723949,"Fat Deer Key, FL",24.7333,-81.0167
-8723950,"Marthon Shores Key, Vaca Cut, FL",24.73,-81.03
-8723962,"Key Colony Beach, FL",24.7183,-81.0167
-8723970,"Vaca Key, Florida Bay, FL",24.711,-81.1065
-8723971,"Boot Key Harbor, FL",24.7033,-81.105
-8723999,"Sombrero Key Lighthouse, FL",24.6267,-81.1117
-8724008,"Knight Key Channel, FL",24.7067,-81.125
-8724032,"Pigeon Key Atlantic Side, FL",24.7033,-81.155
-8724033,"Pigeon Key (Inside), FL",24.705,-81.1567
-8724062,"Molasses Key, FL",24.6833,-81.1917
-8724082,"Money Key, FL",24.6833,-81.2167
-8724093,"Little Duck Key, FL",24.6817,-81.2283
-8724094,"East Bahia Honda Key, FL",24.775,-81.2267
-8724098,"Cocoanut Key, FL",24.745,-81.2367
-8724099,"Missouri-Little Duck Channel, FL",24.68,-81.235
-8724107,"Missouri-Ohio Channel, FL",24.6733,-81.2433
-8724112,"Ohio-Bahia Honda Channel, FL",24.67,-81.2517
-8724129,"West Bahia Honda Key, FL",24.78,-81.2717
-8724138,"Bahia Honda Key, FL",24.655,-81.2817
-8724139,"Horeshoe Keys, FL",24.7667,-81.2833
-8724153,"Johnson Keys South, FL",24.7433,-81.3
-8724154,"Little Pine Key South, FL",24.7133,-81.3033
-8724168,"No Name Key, FL",24.6983,-81.3183
-8724172,"Johnson Keys North, FL",24.7667,-81.3233
-8724177,"Little Pine Key North, FL",24.75,-81.3283
-8724178,"Spanish Harbor Viaduct, Big Pine Key, FL",24.6483,-81.33
-8724189,"Water Key, Big Spanish Channel, FL",24.74,-81.3417
-8724192,"Big Pine Key, Coupon Bight Inside, FL",24.6517,-81.35
-8724193,"Bogie Channel Landing, Big Pine Key, FL",24.6967,-81.3483
-8724196,"Porpoise Key, FL",24.7183,-81.3517
-8724199,"Crawl Key, Big Spanish Channel, FL",24.7567,-81.3583
-8724201,"Doctors Arm, FL",24.69,-81.3567
-8724205,"Mayo Key, FL",24.7333,-81.3617
-8724209,"Little Spanish Key Island, FL",24.7733,-81.3683
-8724211,"Big Pine Key Viaduct, FL",24.67,-81.3683
-8724215,"Newfound Harbor, FL",24.6517,-81.375
-8724224,"Little Torch Key, FL",24.665,-81.3867
-8724226,"Big Pine Key Ne, FL",24.7283,-81.3867
-8724227,"Big Pine Key, West Side, FL",24.69,-81.3833
-8724229,"Annette Key, FL",24.7583,-81.39
-8724231,"Big Pine Key North End, FL",24.745,-81.395
-8724238,"Munson Key, FL",24.6233,-81.4033
-8724239,"Ramrod Key Southeast, FL",24.65,-81.4033
-8724243,"Howe Key (Off South End), FL",24.725,-81.4067
-8724246,"Big Spanish Key, FL",24.7883,-81.4117
-8724255,"Ramrod Key, FL",24.66,-81.4233
-8724264,"Big Torch Key, West Side, FL",24.705,-81.4333
-8724266,"Summerland Key East, FL",24.6517,-81.435
-8724273,"Water Keys South End, FL",24.7467,-81.45
-8724276,"Summerland Key, West Side, FL",24.65,-81.4467
-8724292,"Kemp Channel Viaduct, FL",24.6617,-81.4683
-8724302,"Knockemdown Key, FL",24.715,-81.4783
-8724306,"Gopher Key, FL",24.6417,-81.485
-8724307,"Content Key, FL",24.79,-81.4833
-8724311,"Racoon Key, FL",24.7417,-81.4833
-8724313,"Cudjoe Bay, FL",24.66,-81.4917
-8724327,"Tarpon Creek (Outside), FL",24.6283,-81.51
-8724328,"Cudjoe Key No. Point, FL",24.7,-81.505
-8724332,"Cudjoe Key Pirates Cove, FL",24.6617,-81.515
-8724334,"Tarpon Creek, Sugarloaf Key, FL",24.63,-81.5167
-8724347,"Sugarloaf Key East Side, FL",24.6717,-81.5333
-8724353,"Perky Lake, Sugerloaf Key, FL",24.655,-81.54
-8724367,"North Harris Channel, FL",24.6533,-81.5533
-8724368,"Sugarloaf Key (North End), FL",24.6933,-81.555
-8724369,"Sawyer Key (Inside), FL",24.7583,-81.5617
-8724373,"Pumpkin Key, Sugarloaf Channel, FL",24.7167,-81.5617
-8724378,"Perky, Sugarloaf Sound, FL",24.6483,-81.57
-8724397,"Johnston Key, FL",24.71,-81.5933
-8724405,"Saddlebunch Channel No. 3, FL",24.6233,-81.6033
-8724409,"Inner Narrows, FL",24.6583,-81.6083
-8724417,"Saddlebunch Channel No. 4, FL",24.615,-81.6167
-8724422,"Similar Sound, FL",24.6,-81.6217
-8724423,"Saddlebunch Channel No. 5, FL",24.6117,-81.6233
-8724427,"Middle Narrows, FL",24.6667,-81.63
-8724436,"Bird Key, FL",24.5883,-81.6383
-8724438,"Shark Key, FL",24.6033,-81.645
-8724441,"O'Hara Key, North Point, FL",24.6167,-81.645
-8724448,"Waltz Key, FL",24.6467,-81.6533
-8724463,"Snipe Point, Snipe Keys, FL",24.6917,-81.6733
-8724474,"Duck Key Point, FL",24.6233,-81.685
-8724485,"Boca Chica,Long Point, FL",24.6033,-81.6983
-8724489,"Big Coppitt Key, FL",24.6017,-81.655
-8724493,"Boca Chica Marina, FL",24.575,-81.7083
-8724499,"Boca Chica, Southwest End, FL",24.5633,-81.7133
-8724503,"Stock Island, FL",24.5767,-81.7217
-8724507,"Channel Key, FL",24.6033,-81.725
-8724517,"Key Haven West, FL",24.58,-81.7383
-8724527,"Cow Key Channel, FL",24.57,-81.75
-8724529,"Riveria Canal, Key West, FL",24.565,-81.7517
-8724542,"Sigsbee Park, Garrison Bight Channel, FL",24.585,-81.775
-8724557,"Key West, White Street Pier, FL",24.545,-81.7833
-8724571,"Fleming Key, FL",24.5917,-81.795
-8724580,"Key West, FL",24.555700302124023,-81.80789947509766
-8724635,"Sand Key Lighthouse, FL",24.4533,-81.8783
-8724671,"Smith Shoal Light, FL",24.71827777777778,-81.92152777777778
-8724697,"Garden Key, Dry Tortugas, FL",24.6267,-82.8717
-8724698,"Loggerhead Key, FL",24.6317,-82.92
-8724919,"Chokoloskee, FL",25.8133,-81.3633
-8724932,Indian Key,25.799999237060547,-81.4666976928711
-8724947,"Cape Romano Island, FL",25.8533,-81.675
-8724948,Everglades City,25.8583,-81.3867
-8724963,"Dismal Key, Pumpkin Bay, FL",25.895,-81.5583
-8724964,"Coon Key Pass, Gullivan Bay, FL",25.8967,-81.6367
-8724967,"Marco Island, Caxambas Pass, FL",25.9083,-81.7283
-8724991,"Marco, Big Marco River, FL",25.9717,-81.7283
-8724996,"Mcilvaine Bay, FL",25.985,-81.7017
-8725019,"Keewaydin Island, Inside, FL",26.025,-81.7683
-8725110,"Naples, FL",26.1316667,-81.8075
-8725114,"Naples Bay, North, FL",26.136699676513672,-81.78829956054688
-8725228,"Cocohatchee River, U.S. 41, FL",26.2817,-81.8017
-8725235,"Wiggins Pass, Inside, FL",26.29,-81.8183
-8725283,"Little Hickory Is., Estero B., FL",26.353300094604492,-81.8550033569336
-8725319,"Coconut Point, Estero Bay, FL",26.4,-81.8433
-8725325,"Carlos Point, Estero Bay, FL",26.405000686645508,-81.88500213623047
-8725346,"Estero River, Estero Bay, FL",26.43,-81.8567
-8725351,"Estero Island, Estero Bay, FL",26.4383,-81.9183
-8725362,"Tarpon Bay, FL",26.4433,-82.0817
-8725377,"Hendry Creek, Estero Bay, FL",26.47,-81.8767
-8725383,"Captiva Island (So. End), FL",26.4783,-82.1833
-8725391,"Punta Rassa, San Carlos Bay, FL",26.488300323486328,-82.01329803466797
-8725393,"St. James City,Pine Island, FL",26.49169921875,-82.08170318603516
-8725411,"Galt Island,Pine Island Sd., FL",26.5133,-82.1067
-8725418,"Iona Shores, Caloosahatchee R., FL",26.5217,-81.965
-8725439,"Tropical Homesites,Matlacha Pass, FL",26.5483,-82.08
-8725441,"Redfish Pass,Captiva Is.(No. End), FL",26.55,-82.1967
-8725451,"Cape Coral Br.,Caloosahatchee R., FL",26.56329917907715,-81.93329620361328
-8725488,"North Captiva Island, FL",26.605,-82.2183
-8725506,"Matlacha Pass (Swing Br.), FL",26.63170051574707,-82.06829833984375
-8725520,"Fort Myers, FL",26.64777777777778,-81.8711111111111
-8725528,"Pine Island, Charlotte Harbor, FL",26.66,-82.155
-8725541,"Bokeelia, Charlotte Harbor, FL",26.70669937133789,-82.16329956054688
-8725577,"Port Boca Grande, Charlotte Hbr., FL",26.719999313354492,-82.25830078125
-8725649,"Turtle Bay, FL",26.7967,-82.1833
-8725667,"Placida, Gasparilla Sound, FL",26.8333,-82.265
-8725685,"Cutoff South, FL",26.855,-82.3033
-8725744,"Punta Gorda, FL",26.9283,-82.065
-8725745,"Locust Point, Hog Island, FL",26.93,-82.1367
-8725747,"Englewood, Lemon Bay, FL",26.9333,-82.3533
-8725769,"El Jobean, Myakka River, FL",26.9617,-82.21
-8725791,"Harbour Heights, Peace River, FL",26.9883,-81.9933
-8725809,"Manasota, FL",27.0117,-82.41
-8725837,"Myakka River, Us 41, FL",27.045,-82.2933
-8725858,"Venice, FL",27.0717,-82.4533
-8725889,"Venice, Roberts Bay, FL",27.1117,-82.4633
-8726034,"Siesta Key, Big Sarasota Pass, FL",27.283899307250977,-82.56500244140625
-8726083,"Sarasota, FL",27.3317,-82.545
-8726217,"Cortez, FL",27.4667,-82.6867
-8726243,"Anna Maria Outside, FL",27.4967,-82.7133
-8726247,"Bradenton, Manatee River, FL",27.5,-82.57330322265625
-8726265,"Ellenton, Manatee River, FL",27.51490020751953,-82.53379821777344
-8726278,"Redfish Point, Manatee River, FL",27.5267,-82.4817
-8726282,"Anna Maria, City Pier, FL",27.5333,-82.73
-8726347,"Egmont Key, Tampa Bay, FL",27.6017,-82.76
-8726364,"Mullet Key, Tampa Bay, FL",27.615,-82.7267
-8726384,"Port Manatee, FL",27.638700485229492,-82.56210327148438
-8726520,"St. Petersburg, FL",27.76059913635254,-82.62689971923828
-8726533,"Johns Pass, FL",27.785,-82.7817
-8726537,"Apollo Beach, Hillsborough Bay, FL",27.786699295043945,-82.42669677734375
-8726539,"Newman Branch, FL",27.7833,-82.4067
-8726574,"Boca Ciega Bay, FL",27.8083,-82.795
-8726607,"Old Port Tampa, FL",27.857799530029297,-82.55280303955078
-8726639,"Tampa, Ballast Point, FL",27.89,-82.48
-8726641,"Gandy Bridge, Old Tampa Bay, FL",27.8933,-82.5383
-8726651,"Pendola Point, Hillsborough Bay, FL",27.8983,-82.4267
-8726657,"Davis Island, Hillsborough Bay, FL",27.9083,-82.4517
-8726667,"Mckay Bay Entrance, FL",27.913299560546875,-82.42500305175781
-8726674,"East Bay, FL",27.923099517822266,-82.42140197753906
-8726689,"Bay Aristocrat Village, Old Tampa Bay, FL",27.9417,-82.72
-8726706,"Clearwater, Clearwater Harbor, FL",27.955,-82.8067
-8726724,"Clearwater Beach, FL",27.9783333,-82.8316667
-8726738,"Safety Harbor, Old Tampa Bay, FL",27.9883,-82.685
-8726761,"Dunedin City Dock, FL",28.0133,-82.7933
-8726769,"Mobbly Bayou, FL",28.0217,-82.655
-8726905,"Tarpon Springs, Anclote River, FL",28.16,-82.7683
-8726917,"Anclote Lighthouse, Anclote Key, FL",28.165,-82.8433
-8726924,"Anclote River, FL",28.1717,-82.785
-8726942,"North Anclote Key, FL",28.21,-82.84
-8727001,"Middle Pithlachascotee River, FL",28.2483,-82.7233
-8727012,"Pithlachascotee River, FL",28.2683,-82.7267
-8727061,"Hudson, Hudson Creek, FL",28.3617,-82.71
-8727097,"Aripeka, FL",28.4333,-82.6683
-8727122,"Rocky Cr.,Little Pine Is. Bay,, FL",28.4867,-82.6617
-8727151,"Bayport, FL",28.5333,-82.65
-8727235,"Johns Island, Chassahowitzka Bay, FL",28.6917,-82.6383
-8727246,"Chassahowitzka River, FL",28.715,-82.5767
-8727274,"Mason Creek, Homosassa Bay, FL",28.7617,-82.6383
-8727277,"Tuckers Island, Homosassa River, FL",28.7717,-82.695
-8727293,"Halls River Bridge, Halls River, FL",28.8,-82.6033
-8727306,"Ozello, FL",28.825,-82.6583
-8727328,"Ozello North, FL",28.8633,-82.6667
-8727333,"Mangrove Point, FL",28.87,-82.7233
-8727336,"Dixie Bay, FL",28.8817,-82.635
-8727343,"Crystal River, Kings Bay, FL",28.8983,-82.5983
-8727348,"Twin Rivers Marina, FL",28.905,-82.6383
-8727359,"Shell Island, Crystal River, FL",28.9233,-82.6917
-8727395,"Port Inglis, Withlacoochee River, FL",29.0017,-82.7583
-8727520,"Cedar Key, FL",29.135000228881836,-83.03170013427734
-8727535,"Shell Mound, FL",29.20639991760254,-83.0697021484375
-8727577,"Suwannee, FL",29.3283,-83.1517
-8727648,"Horseshoe Point, FL",29.4367,-83.2933
-8727695,"Steinhatchee, FL",29.6717,-83.39
-8727792,"Hagens Cove, FL",29.79669952392578,-83.58380126953125
-8727843,"Spring Warrior Creek, FL",29.92,-83.6717
-8727956,"Econfina River, Inside, FL",30.0533,-83.91
-8727976,"Snipe Island, FL",30.061899185180664,-83.95269775390625
-8727989,"Mandalay, Aucilla River, FL",30.1267,-83.975
-8728104,"Port Leon, FL",30.124399185180664,-84.14900207519531
-8728130,"St. Marks Lhtse., Apalachee Bay, FL",30.0783,-84.1783
-8728152,"St Marks, Wakulla River, FL",30.158899307250977,-84.21859741210938
-8728229,"Shell Point, Walker Creek, FL",30.05833333333333,-84.29055555555556
-8728237,"Bald Point, Ochlockonee Bay, FL",29.9483,-84.3417
-8728262,"Ochlockonee Bay, FL",29.980199813842773,-84.3958969116211
-8728269,"Panacea, Dickerson Bay, FL",30.02829933166504,-84.38670349121094
-8728288,"Alligator Point, FL",29.9033,-84.4133
-8728360,"Turkey Point, FL",29.915,-84.5117
-8728408,"Dog Island, East End, FL",29.81,-84.585
-8728412,"Lanark, St. Georges Sound, FL",29.878299713134766,-84.59500122070312
-8728464,"Carrabelle River, St. George Sound, FL",29.85,-84.665
-8728486,"Ne End, St. George Island, FL",29.766695022583008,-84.69999694824219
-8728488,"South Carrabelle Beach, FL",29.801700592041016,-84.73670196533203
-8728548,"St. George Island,East End, FL",29.6867,-84.7867
-8728552,"St. George Is.,Rattlesnake Cove, FL",29.6917,-84.7917
-8728593,"East Bayou, FL",29.818899154663086,-84.85030364990234
-8728619,"Cat Point, Apalachicola Bay, FL",29.72330093383789,-84.88670349121094
-8728626,"St. George Island, Bayside, FL",29.6533,-84.8967
-8728669,"Sikes Cut, St. George Island, FL",29.613300323486328,-84.95829772949219
-8728690,"Apalachicola, FL",29.7244444,-84.9805556
-8728694,"White Beach, East Bay, FL",29.785,-84.8983
-8728711,"Apalachicola River, FL",29.7632999420166,-85.0333023071289
-8728728,"Little St George Island, FL",29.603599548339844,-85.04280090332031
-8728757,"Huckleberry Landing, Jackson River, FL",29.770000457763672,-85.08499908447266
-8728786,"Eleven Mile, St. Vincent Sound, FL",29.70669937133789,-85.1532974243164
-8728819,"Lake Wimico, FL",29.821399688720703,-85.17330169677734
-8728852,"Indian Pass, FL",29.685100555419922,-85.22129821777344
-8728853,"White City, Icww, FL",29.880699157714844,-85.22139739990234
-8728886,"White City, Gulf County Canal, FL",29.86680030822754,-85.27059936523438
-8728912,"Port St. Joe, FL",29.815,-85.3133
-8728957,"Overstreet, FL",29.996700286865234,-85.37000274658203
-8728958,"St. Joseph Point, St. Joseph Bay, FL",29.873300552368164,-85.38999938964844
-8728973,"Wetappo Creek, East Bay, FL",30.038299560546875,-85.39330291748047
-8728978,"Cape San Blas, Western Cape, FL",29.764400482177734,-85.40249633789062
-8729015,"Allanton, East Bay, FL",30.030000686645508,-85.46499633789062
-8729017,"Farmdale, East Bay, St. Andrew Bay, FL",30.016700744628906,-85.47000122070312
-8729026,"East Bay, Goose Point, FL",30.061199188232422,-85.48860168457031
-8729045,"Laird Bayou, East Bay, FL",30.1217,-85.5283
-8729082,"Deer Point Lake, FL",30.26959991455078,-85.60790252685547
-8729084,"Parker, East Bay, FL",30.1267,-85.6117
-8729102,"Lynn Haven, North Bay, FL",30.255,-85.6483
-8729108,"Panama City, FL",30.1497222,-85.6644444
-8729132,"Courtney Point, St Andrew Bay, FL",30.15169906616211,-85.66670227050781
-8729136,"New Entrance Channel, St. Andrew Bay, FL",30.125,-85.73
-8729142,"Sulphur Point, Port Of Panama City, FL",30.183000564575195,-85.73280334472656
-8729152,"Alligator Bayou, Panama City, FL",30.17,-85.755
-8729197,"West Bay Creek West Bay, FL",30.29330062866211,-85.8582992553711
-8729210,"Panama City Beach, FL",30.21375,-85.87858333333334
-8729376,"Santa Rosa Hogtown Bayou, FL",30.399999618530273,-86.22830200195312
-8729425,"Driftwood Point, Choctawhatcheee Bay, FL",30.389400482177734,-86.32879638671875
-8729479,"Rocky Bayou, FL",30.50670051574707,-86.44670104980469
-8729501,"Valparaiso, FL",30.503299713134766,-86.49330139160156
-8729511,"Destin, East Pass, FL",30.395,-86.5133
-8729538,"Garnier Bayou, Shalimar, FL",30.435,-86.5867
-8729547,"Okaloosa Island, FL",30.391399383544922,-86.59320068359375
-8729572,"Mary Esther, FL",30.4064998626709,-86.65049743652344
-8729613,"Harris, Santa Rosa Sound, FL",30.4083,-86.7317
-8729678,"Navarre Beach, FL",30.3767,-86.865
-8729702,"East Bay, Holley, FL",30.450000762939453,-86.91829681396484
-8729717,"Navarre, North Side, FL",30.443099975585938,-86.95140075683594
-8729736,"Woodlawn Beach, FL",30.386699676513672,-86.99169921875
-8729747,"Shield Point, Blackwater River, FL",30.58169937133789,-87.01499938964844
-8729753,"Blackwater River, FL",30.636699676513672,-87.0282974243164
-8729791,"Hernandez Point North, FL",30.454999923706055,-87.0999984741211
-8729806,"Fishing Bend, Santa Rosa Sound, FL",30.336700439453125,-87.13999938964844
-8729807,"Pensacola Beach Pier, FL",30.3275,-87.141944
-8729816,"Lora Point, Escambia Bay, FL",30.514999389648438,-87.16169738769531
-8729824,"Floridatown, Escambia Bay, FL",30.58169937133789,-87.18000030517578
-8729840,"Pensacola, FL",30.404399871826172,-87.21119689941406
-8729868,"Pensacola, Naval Air Station, FL",30.345,-87.2733
-8729905,"Millview, Perdido Bay, FL",30.4183,-87.3567
-8729909,"Big Lagoon, FL",30.32670021057129,-87.35669708251953
-8729941,"Blue Angels Park, FL",30.38694444444445,-87.42880555555556
-8729962,"Nix Point, Perdido Bay, FL",30.3933,-87.425
-8730561,"Arnica Bay, Mill Point, AL",30.310199737548828,-87.51930236816406
-8730667,"Alabama Point, AL",30.27861111111111,-87.55500030517578
-8730849,"Wolf Bay, AL",30.354999542236328,-87.5999984741211
-8731269,"Gulf State Park Pier, AL",30.248300552368164,-87.66829681396484
-8731439,"Gulf Shores, Icww, AL",30.27988888888889,-87.68427777777778
-8731952,"Bon Secour, AL",30.3033,-87.735
-8732828,"Weeks Bay, Mobile Bay, AL",30.416900634765625,-87.82540130615234
-8733502,"Fly Creek, Mobile Bay, AL",30.542800903320312,-87.9010009765625
-8733821,"Point Clear, Mobile Bay, AL",30.48663888888889,-87.93452777777777
-8733839,"Meaher State Park, Mobile Bay, AL",30.66716666666667,-87.93644444444445
-8735180,"Dauphin Island, AL",30.25,-88.07499694824219
-8735181,"Dauphin Island Hydro, AL",30.25131944444444,-88.07948611111111
-8735391,"Dog River Bridge, AL",30.565200805664062,-88.08799743652344
-8735523,"East Fowl River Bridge, AL",30.443700790405273,-88.11389923095703
-8736897,"Coast Guard Sector Mobile, AL",30.6495,-88.05811111111112
-8737048,"Mobile State Docks, AL",30.70461111111111,-88.03961111111111
-8737138,"Chickasaw Creek, AL",30.78190040588379,-88.07360076904297
-8737373,"Lower Bryant Landing, AL",30.9783,-87.8733
-8738043,"West Fowl River Bridge, AL",30.37660026550293,-88.15859985351562
-8739803,"Bayou La Batre Bridge, AL",30.40570068359375,-88.2477035522461
-8740166,"Grand Bay Nerr, Mississippi Sound, MS",30.41319444444444,-88.4028888888889
-8740405,"Petit Bois Island, Miss. Sound, MS",30.2033,-88.4417
-8740448,"Point Of Pines, Bayou Cumbest, MS",30.3867,-88.44
-8740993,"Pascagoula, South Side, MS",30.322200775146484,-88.50800323486328
-8741041,"Dock E, Port Of Pascagoula, MS",30.3477778,-88.5058333
-8741196,"Pascagoula Point, MS",30.34,-88.5333
-8741533,"Pascagoula Noaa Lab, MS",30.36777777777778,-88.56305555555555
-8742205,"Graveline Bayou Entrance, MS",30.3617,-88.6633
-8742221,"Horn Island, MS",30.2383,-88.6667
-8743081,"Hollingsworth Point, Davis Bayou, MS",30.3867,-88.7733
-8743281,"Ocean Springs, MS",30.3917,-88.7983
-8743735,"Biloxi (Cadet Point), MS",30.39,-88.8567
-8744117,"Biloxi, MS",30.4117,-88.9033
-8744756,"Ship Island, Mississippi Sound, MS",30.2133,-88.9717
-8745101,"Handsboro Bridge, Bernard Bayou, MS",30.4067,-89.0267
-8745375,"Turkey Creek, Bernard Bayou, MS",30.4267,-89.0533
-8745557,"Gulfport Harbor, MS",30.36,-89.0817
-8745799,"Cat Island, Mississippi Sound, MS",30.2317,-89.1167
-8746819,"Pass Christian Yacht Club, Miss. Sound, MS",30.31,-89.245
-8747437,"Bay Waveland Yacht Club, MS",30.32634166666667,-89.3258
-8747766,"Waveland, MS",30.2817,-89.3667
-8749704,"Pearlington, Pearl River, MS",30.24,-89.615
-8760412,"North Pass, LA",29.205,-89.0367
-8760417,"Devon Energy Facility, LA",29.20075,-89.04446666666666
-8760551,"South Pass, LA",28.99,-89.14
-8760595,"Breton Island, LA",29.4933,-89.1733
-8760668,"Grand Pass, LA",30.126699447631836,-89.2217025756836
-8760721,"Pilottown, LA",29.17930555555556,-89.25883333333333
-8760742,"Comfort Island, LA",29.8233,-89.27
-8760889,"Olga Compressor Station, Grand Bay, LA",29.38655555555556,-89.3801388888889
-8760922,"Pilots Station East, S.W. Pass, LA",28.9322,-89.4075
-8760943,"Sw Pass, LA",28.925,-89.4183
-8761108,"Bay Gardene, LA",29.5983,-89.6183
-8761115,"Bay Pomme D'Or, LA",29.35059928894043,-89.53990173339844
-8761305,"Shell Beach, LA",29.86811111111111,-89.67325
-8761402,"The Rigolets, LA",30.1667,-89.7367
-8761431,"Rat Bayou, LA",29.56669444444444,-89.76336111111111
-8761432,"Bayou Chene, LA",29.512699127197266,-89.7645034790039
-8761473,"Rt. 433, Bayou Bonfouca, LA",30.2717,-89.7933
-8761487,"Chef Menteur, Chef Menteur Pass, LA",30.065,-89.8
-8761529,"Martello Castle, Lake Borgne, LA",29.945,-89.835
-8761678,"Michoud Substation, Icww, LA",30.0067,-89.9367
-8761724,"Grand Isle, LA",29.26333333333333,-89.95666666666666
-8761742,"Mendicant Island, Barataria Bay, LA",29.318300247192383,-89.9800033569336
-8761819,"Texaco Dock, Hackberry Bay, LA",29.4017,-90.0383
-8761826,"Cheniere Caminada, Caminada Pass, LA",29.209999084472656,-90.04000091552734
-8761899,"Lafitte, Barataria Waterway, LA",29.6667,-90.1117
-8761927,"New Canal Station, LA",30.02722222222222,-90.11333333333333
-8761993,"Tchefuncta River, Lake Pont, LA",30.3783,-90.16
-8762075,"Port Fourchon, Belle Pass, LA",29.114200592041016,-90.19930267333984
-8762084,"Leeville, Bayou Lafourche, LA",29.2483,-90.2117
-8762184,"Golden Meadow, Plaisance Canal, LA",29.373300552368164,-90.26499938964844
-8762223,"East Timbalier Island, Timbalier Bay, LA",29.0767,-90.285
-8762329,"Bayou Faleau, LA",29.47038888888889,-90.34222222222222
-8762372,"East Bank 1, Norco, B. Labranche, LA",30.05033333333333,-90.368
-8762525,"Pointe Au Chien, Cut Off Canal, LA",29.41670036315918,-90.44670104980469
-8762888,"E. Isle Dernieres, Lake Pelto, LA",29.0717,-90.64
-8762928,"Cocodrie, LA",29.245,-90.6617
-8763506,"Raccoon Point, Isle Dernieres, LA",29.0633,-90.9617
-8763535,"Texas Gas Platform, Caillou Bay, LA",29.17477777777778,-90.97644444444444
-8763843,"Fourleague Bay, LA",29.341800689697266,-91.135498046875
-8764025,"Stouts Pass At Six Mile Lake, LA",29.7433,-91.23
-8764044,"Berwick, Atchafalaya River, LA",29.6675,-91.23761111111111
-8764165,"Shell Island,Atchafalaya Bay, LA",29.4733,-91.305
-8764227,"Lawma, Amerada Pass, LA",29.449600219726562,-91.33809661865234
-8764256,"Point Au Fer, LA",29.3333,-91.3533
-8764314,"Eugene Island, North Of, Atchafalaya Bay, LA",29.36750030517578,-91.38390350341797
-8765026,"Marsh Is., Atchafalaya Bay, LA",29.485,-91.7633
-8765148,"Weeks Bay, LA",29.83722222222222,-91.8375
-8765251,"Cypremort Point, LA",29.71336111111111,-91.88
-8765746,"Bayou Fearman, Vermillion Bay, LA",29.674400329589844,-92.13520050048828
-8765785,"Intracoastal City, LA",29.783000946044922,-92.15560150146484
-8765969,"Freshwater Bayou, LA",29.655399322509766,-92.25070190429688
-8765994,"Schooner Bayou, LA",29.758100509643555,-92.26380157470703
-8766072,"Freshwater Canal Locks, LA",29.55169444444444,-92.30519444444444
-8766941,"Joseph Harbor, LA",29.637500762939453,-92.76719665527344
-8767095,"Catfish Point, LA",29.862899780273438,-92.8488998413086
-8767403,"Mermentau River, Grand Chenier, LA",29.774999618530273,-93.00830078125
-8767816,"Lake Charles, LA",30.2236111,-93.2216667
-8767911,"East Calcasieu Lake, LA",29.993900299072266,-93.27050018310547
-8767961,"Bulk Terminal, LA",30.19029998779297,-93.30069732666016
-8768094,"Calcasieu Pass, LA",29.76816666666667,-93.3428888888889
-8768772,"Gum Cove, Icww, LA",30.058700561523438,-93.52259826660156
-8769858,"East Sabine Lake, LA",29.812700271606445,-93.86209869384766
-8770475,"Port Arthur, TX",29.86669921875,-93.93000030517578
-8770520,"Rainbow Bridge, TX",29.979999542236328,-93.88169860839844
-8770542,"Buffalo Bayou, TX",29.761899948120117,-95.34429931640625
-8770570,"Sabine Pass North, TX",29.7284,-93.8701
-8770613,"Morgans Point, Barbours Cut, TX",29.6816667,-94.985
-8770625,"Umbrella Point, Trinity Bay, TX",29.68,-94.8683
-8770653,"Cypress, San Jacinto River, TX",29.84670066833496,-95.08830261230469
-8770733,"Lynchburg Landing (Tcoon), TX",29.765,-95.0783
-8770743,"Battleship Texas State Park, TX",29.75670051574707,-95.08999633789062
-8770752,"Cox Wc-53 Platform, TX",29.62400054931641,-93.75
-8770777,"Manchester, TX",29.726299285888672,-95.26580047607422
-8770808,"High Island, TX",29.59469985961914,-94.39029693603516
-8770822,"Texas Point, Sabine Pass, TX",29.689300537109375,-93.841796875
-8770931,"Smith Point, Galveston Bay, TX",29.535,-94.7817
-8770933,"Clear Lake, TX",29.5633,-95.0667
-8770971,"Rollover Pass, TX",29.514999389648438,-94.51329803466797
-8771013,"Eagle Point, Galveston Bay, TX",29.48130555555555,-94.91725277777778
-8771050,"Renaissance Sa-13 Platform, TX",29.47900009155273,-93.63999938964844
-8771074,"Fieldwood Wc-289 Platform, TX",29.34700012207031,-93.63500213623047
-8771165,"Goat Island, TX",29.431100845336914,-94.71040344238281
-8771262,"Texas City, TX",29.390600204467773,-94.88490295410156
-8771328,"Port Bolivar, TX",29.365,-94.78
-8771341,"Galveston Bay Entrance, North Jetty, TX",29.35746111111111,-94.724725
-8771367,"Sabine Offshore Light, TX",29.4689998626709,-93.72000122070312
-8771416,"Galveston Bay Entrance, South Jetty, TX",29.32670021057129,-94.69329833984375
-8771450,"Galveston Pier 21, TX",29.31,-94.79330555555556
-8771486,"Galveston Railroad Bridge, TX",29.302600860595703,-94.89710235595703
-8771510,"Galveston Pleasure Pier, TX",29.2853,-94.7894
-8771722,"Jamaica Beach, TX",29.19860076904297,-94.98829650878906
-8771801,"Alligator Point, West Bay, TX",29.1667,-95.125
-8771972,"San Luis Pass, TX",29.094999313354492,-95.11329650878906
-8772132,"Christmas Bay, TX",29.0417,-95.175
-8772391,"Old Brazos River Freeport, TX",28.96109962463379,-95.36740112304688
-8772440,"Freeport, TX",28.9483,-95.3083
-8772447,"Freeport, TX",28.94330555555555,-95.3025
-8772471,"Freeport Harbor, TX",28.935699462890625,-95.29419708251953
-8772479,"Freeport Entrance Jetty, TX",28.930299758911133,-95.30590057373047
-8772985,"Sargent, TX",28.77163888888889,-95.61683333333333
-8773037,"Seadrift, TX",28.40690040588379,-96.71240234375
-8773146,"Matagorda City, TX",28.709999084472656,-95.91390228271484
-8773259,"Port Lavaca, TX",28.640600204467773,-96.60980224609375
-8773701,"Port O'Connor, TX",28.45170021057129,-96.38829803466797
-8773767,"Matagorda Bay Entrance Channel, TX",28.42690086364746,-96.3301010131836
-8773808,"Barroom Bay, TX",28.402999877929688,-96.48079681396484
-8773896,"Shoalwater Flats, TX",28.364500045776367,-96.5802993774414
-8774230,"Aransas Wildlife Refuge, TX",28.228300094604492,-96.79499816894531
-8774513,"Copano Bay, TX",28.118305206298828,-97.02169799804688
-8774652,"Bayside, Copano Bay, TX",28.068300247192383,-97.19560241699219
-8774770,"Rockport, TX",28.0216667,-97.0466667
-8775083,"Aransas Pass, Redfish Bay, TX",27.908100128173828,-97.13529968261719
-8775131,"Portland, TX",27.88279914855957,-97.34310150146484
-8775132,"La Quinta Channel North, TX",27.880399703979492,-97.27349853515625
-8775222,"Viola Turning Basin, TX",27.846099853515625,-97.52069854736328
-8775237,"Port Aransas, TX",27.83970069885254,-97.07250213623047
-8775241,"Aransas, Aransas Pass, TX",27.836599349975586,-97.03910064697266
-8775244,"Nueces Bay, TX",27.832799911499023,-97.48590087890625
-8775270,"Port Aransas, H. Caldwell Pier, TX",27.82670021057129,-97.05000305175781
-8775283,"Enbridge, Ingleside, TX",27.81861111111111,-97.20894444444444
-8775296,"Uss Lexington, Corpus Christi Bay, TX",27.814899444580078,-97.38919830322266
-8775421,"Naval Air Station, TX",27.704999923706055,-97.27999877929688
-8775792,"Packery Channel, TX",27.63330078125,-97.23670196533203
-8775870,"Bob Hall Pier, Corpus Christi, TX",27.579999923706055,-97.2166976928711
-8778485,"Padre Island, Port Mansfield Channel Ent, TX",26.564199447631836,-97.27649688720703
-8779280,"Realitos Peninsula, TX",26.262399673461914,-97.2853012084961
-8779724,"Queen Isabella Causeway, TX",26.0783,-97.17
-8779739,"W Queen Isabella Causeway, Port Isabel, TX",26.0717,-97.1917
-8779748,"South Padre Island Cg Station, TX",26.07309913635254,-97.1675033569336
-8779749,"Spi Brazos Santiago, TX",26.0674991607666,-97.15480041503906
-8779750,"South Padre Island, Brazos Santiago Pass, TX",26.0683,-97.1567
-8779768,"South Bay, TX",26.0517,-97.1817
-8779770,"Port Isabel, TX",26.06116666666667,-97.21552777777778
-8779911,"San Martin Lake Channel, TX",26.001800537109375,-97.29859924316406
-9410032,"Wilson Cove, San Clemente Is., CA",33.005001068115234,-118.55699920654297
-9410079,"Avalon, Santa Catalina Island, CA",33.345001220703125,-118.32499694824219
-9410120,"Imperial Beach, Pacific Ocean, CA",32.5783,-117.135
-9410135,"South San Diego Bay, CA",32.62910079956055,-117.10780334472656
-9410170,"San Diego, CA",32.71555555555555,-117.1766666666667
-9410196,"Mission Bay, CA",32.793701171875,-117.22380065917969
-9410230,"La Jolla, CA",32.86688888888889,-117.2571388888889
-9410580,"Newport Beach, Newport Bay Entrance, CA",33.6033,-117.883
-9410650,"Cabrillo Beach, CA",33.7067,-118.273
-9410660,"Los Angeles, CA",33.72,-118.272
-9410680,"Long Beach, Terminal Island, CA",33.7517,-118.227
-9410738,"King Harbor, Santa Monica Bay, CA",33.8467,-118.398
-9410840,"Santa Monica, CA",34.0083,-118.5
-9410962,"Bechers Bay, Santa Rosa Island, CA",34.0083,-120.047
-9410971,"Prisoners Harbor, Santa Cruz Is., CA",34.02,-119.683
-9411270,"Rincon Island, Pacific Ocean, CA",34.3483,-119.443
-9411340,"Santa Barbara, CA",34.40458888888889,-119.6924944444445
-9411399,"Gaviota State Park, Pacific Ocean, CA",34.46938888888889,-120.2283055555556
-9411406,"Oil Platform Harvest, CA",34.46916666666667,-120.6819444444444
-9412110,"Port San Luis, CA",35.16888888888889,-120.7541666666667
-9412553,"San Simeon, CA",35.6417,-121.188
-9412802,"Mansfield Cone, CA",35.94952777777777,-121.4819444444445
-9413450,"Monterey, CA",36.6088889,-121.8913889
-9413616,"Moss Landing, CA",36.8017,-121.79
-9413623,"Elkhorn Slough, Entrance Bridge, CA",36.81,-121.785
-9413631,"Elkhorn Slough At Elkhorn, CA",36.81829833984375,-121.74700164794922
-9413643,"Tidal Creek, Elkhorn Slough, CA",36.83330154418945,-121.74500274658203
-9413651,"Kirby Park, Elkhorn Slough, CA",36.84130096435547,-121.74530029296875
-9413663,"Elkhorn Slough Railroad Bridge, CA",36.85667,-121.755
-9414131,"Pillar Point Harbor, CA",37.5025,-122.4821666666667
-9414290,"San Francisco, CA",37.80630555555555,-122.4658888888889
-9414305,"North Point, Pier 41, S.F.Bay, CA",37.81,-122.413
-9414317,"Pier 22 1/2, San Francisco, CA",37.79,-122.387
-9414358,"Hunters Point, S.F. Bay, CA",37.73,-122.357
-9414392,"Oyster Point Marina, San Francisco Bay, CA",37.665,-122.377
-9414458,"San Mateo Bridge, CA",37.58,-122.253
-9414501,"Redwood Creek,C.M. No. 8,S.F.Bay, CA",37.5333,-122.193
-9414506,"Newark Slough,S.F.Bay, CA",37.5133,-122.08
-9414509,"Dumbarton Bridge, CA",37.5067,-122.115
-9414519,"Mowry Slough, San Francisco Bay, CA",37.4933,-122.042
-9414523,"Redwood City, CA",37.50681388888889,-122.2119055555556
-9414525,"Palo Alto Yacht Harbor, S. F. Bay, CA",37.4583,-122.105
-9414551,"Gold Street Bridge, Alviso Slough, CA",37.4233,-121.975
-9414561,"Coyote Creek, Tributary #1, S. F. Bay, CA",37.4467,-121.963
-9414575,"Coyote Creek, CA",37.465,-122.023
-9414609,"South Bay Wreck,S.F.Bay, CA",37.5517,-122.162
-9414621,"Coyote Hills Slough,S.F.Bay, CA",37.5633,-122.128
-9414632,"Alameda Creek, San Francisco Bay, CA",37.595,-122.145
-9414637,"San Mateo Bridge,East End, CA",37.6083,-122.182
-9414688,"San Leandro Marina, CA",37.695,-122.192
-9414711,"Oakland Airport, San Francisco Bay, CA",37.7317,-122.208
-9414746,"Park Street Bridge, CA",37.7717,-122.235
-9414750,"Alameda, CA",37.77195277777778,-122.3002611111111
-9414764,"Oakland Inner Harbor, CA",37.79499816894531,-122.28199768066406
-9414767,"Alameda Nas, Navy Fuel Pier, CA",37.7933,-122.315
-9414777,"Oakland Middle Harbor, Pier 40, CA",37.805,-122.338
-9414779,"Oakland,Matson Wharf,S.F.Bay, CA",37.81,-122.327
-9414782,"Yerba Buena Island, San Francisco Bay, CA",37.81,-122.36
-9414785,"Grant Line Canal Brdg.,Old River, CA",37.82,-121.447
-9414806,"Sausalito, San Francisco Bay, CA",37.8467,-122.477
-9414811,"Bradmoor Island, CA",38.1833,-121.923
-9414816,"Berkeley,S.F.Bay, CA",37.8650016784668,-122.30699920654297
-9414818,"Angel Island, East Garrison, S.F. Bay, CA",37.8633,-122.42
-9414819,"Sausalito, Coe Dock, S.F. Bay, CA",37.865,-122.493
-9414835,"Borden Highway Bridge, Middle River, CA",37.8917,-121.488
-9414836,"Borden Hwy Bridge,Old River, CA",37.8833,-121.577
-9414837,"Point Chauncey, Richardson Bay, CA",37.8917,-122.443
-9414849,"Richmond Inner Harbor, San Francisco Bay, CA",37.91,-122.358
-9414863,"Richmond, CA",37.92829895019531,-122.4000015258789
-9414866,"Holt, Whiskey Slough, CA",37.935,-121.435
-9414868,"Orwood,Old River, CA",37.9383,-121.56
-9414873,"Point San Quentin, San Francisco Bay, CA",37.945,-122.475
-9414874,"Corte Madera Creek, CA",37.94329833984375,-122.51300048828125
-9414881,"Point Orient, CA",37.9583,-122.425
-9414883,"Stockton,San Joaquin River, CA",37.9583,-121.29
-9414958,"Bolinas, Bolinas Lagoon, CA",37.90800094604492,-122.67849731445312
-9415009,"Point San Pedro, San Francisco Bay, CA",37.9933,-122.447
-9415020,"Point Reyes, CA",37.9941667,-122.9736111
-9415021,"Blackslough Landing, San Joaquin River, CA",37.994998931884766,-121.41999816894531
-9415052,"Gallinas, Gallinas Creek, CA",38.015,-122.503
-9415053,"Dutch Slough, CA",38.0117,-121.638
-9415056,"Pinole Point, San Pablo Bay, CA",38.015,-122.363
-9415064,"Antioch, San Joaquin River, CA",38.02,-121.815
-9415074,"Hercules Wharf, CA",38.0233,-122.292
-9415096,"Pittsburg, New York Slough, Suisun Bay, CA",38.0367,-121.88
-9415102,"Martinez-Amorco Pier, CA",38.03463888888889,-122.1251944444445
-9415105,"Wards Island, San Joaquin River, CA",38.04999923706055,-121.49700164794922
-9415111,"Benicia, Carquinez Strait, CA",38.0433,-122.13
-9415112,"Mallard Island, Suisun Bay, CA",38.0433,-121.918
-9415117,"Bishop Cut, Dissapointment Slough, CA",38.045,-121.42
-9415143,"Crockett, Carquinez Strait, CA",38.0583,-122.223
-9415144,"Port Chicago, CA",38.056,-122.0395
-9415145,"Jersey Island, False River, CA",38.055,-121.657
-9415149,"Prisoners Point, San Joaquin River, CA",38.0617,-121.555
-9415165,"Mare Island Strait, CA",38.1117,-122.273
-9415176,"Collinsville,Sacramento River, CA",38.0733,-121.848
-9415193,"Three Mile Slough,San Joaquin R., CA",38.086700439453125,-121.68499755859375
-9415205,"Montezuma Slough, Suisun Bay, CA",38.0767,-121.885
-9415218,"Mare Island, CA",38.07,-122.25
-9415228,"Inverness, Tomales Bay, CA",38.1133,-122.868
-9415229,"Korths Hbr, San Joaquin River, CA",38.097599029541016,-121.56839752197266
-9415236,"Three Mile Slough,Sacramento R., CA",38.1067,-121.7
-9415252,"Petaluma River Entrance, CA",38.11530555555556,-122.5056666666667
-9415257,"Terminous,Mokelumne River, CA",38.11,-121.498
-9415265,"Suisun Slough Entrance, CA",38.1283,-122.073
-9415266,"Pierce Harbor,Goodyear Slough, CA",38.1267,-122.1
-9415287,"Georgiana Slough, Mokelumne River, CA",38.125,-121.578
-9415307,"Meins Landing, Montezuma Slough, CA",38.1367,-121.907
-9415316,"Rio Vista, CA",38.145,-121.692
-9415338,"Sonoma Creek Entrance, CA",38.1567,-122.407
-9415344,"Hog Is.,San Antonio Creek, CA",38.1617,-122.55
-9415379,"Joice Island, Suisun Slough, CA",38.18,-122.045
-9415396,"Blake Landing,Tomales Bay, CA",38.19,-122.917
-9415402,"Montezuma Slough Bridge, CA",38.1867,-121.98
-9415414,"Steamboat Slough, CA",38.1833,-121.655
-9415415,"Edgerley Island, Napa River, CA",38.1917,-122.312
-9415446,"Brazos Drawbridge,Napa River, CA",38.21,-122.307
-9415447,"Wingo, Sonoma Creek, CA",38.21,-122.427
-9415478,"New Hope Bridge, Mokelumne River, CA",38.2267,-121.49
-9415498,"Suisun City, Suisun Slough, CA",38.2367,-122.03
-9415565,"Snodgrass Slough, CA",38.2767,-121.495
-9415584,"Petaluma River, Upper Drawbridge, CA",38.2283,-122.613
-9415623,"Napa, Napa River, CA",38.2983,-122.28
-9415846,"Clarksburg,Sacramento River, CA",38.4167,-121.523
-9416131,"Port Of West Sacramento, Washington Lake, CA",38.56224822998047,-121.54630279541016
-9416174,"Sacramento, Sacramento River, CA",38.58,-121.507
-9416409,"Green Cove, CA",38.70433333333333,-123.4493888888889
-9416841,"Arena Cove, CA",38.91455555555556,-123.7110833333333
-9417426,"Noyo Harbor, CA",39.42577777777778,-123.8051111111111
-9418024,"Shelter Cove, CA",40.025001525878906,-124.05799865722656
-9418637,"Cockrobin Island Bridge, CA",40.63719940185547,-124.2822036743164
-9418686,"Hookton Slough,Humboldt Bay, CA",40.6867,-124.222
-9418723,"Fields Landing, Humboldt Bay, CA",40.7233,-124.222
-9418767,"North Spit, CA",40.76690555555555,-124.2173444444445
-9418778,"Bucksport, Humboldt Bay, CA",40.7783,-124.197
-9418801,"Eureka, CA",40.8067,-124.167
-9418802,"Eureka Slough, Humboldt Bay, CA",40.8067,-124.142
-9418817,"Samoa, Humboldt Bay, CA",40.8267,-124.18
-9418865,"Mad River Slough, Arcata Bay, CA",40.865,-124.148
-9419059,"Trinidad Harbor, CA",41.0567,-124.147
-9419750,"Crescent City, CA",41.74561111111111,-124.1843888888889
-9419945,"Pyramid Point, CA",41.94525,-124.2009166666667
-9431011,"Gold Beach, OR",42.42163888888889,-124.4187222222222
-9431647,"Port Orford, OR",42.73899841308594,-124.49829864501953
-9432373,"Bandon, Coquille River, OR",43.12,-124.413
-9432436,"Coquille River, OR",43.157901763916016,-124.18180084228516
-9432780,"Charleston, OR",43.345001220703125,-124.3219985961914
-9432879,"Sitka Dock, Coos Bay, OR",43.3767,-124.297
-9433445,"Half Moon Bay, OR",43.675,-124.192
-9433501,"Reedsport, OR",43.70830154418945,-124.0979995727539
-9434068,"Cushman, OR",43.98500061035156,-124.04499816894531
-9434098,"Florence Uscg Pier, Siuslaw River, OR",44.00210189819336,-124.12300109863281
-9434938,"Drift Creek, Alsea River, OR",44.4133,-123.99
-9434939,"Waldport, OR",44.43436111111111,-124.0580833333333
-9435308,"Weiser Point, Yaquina River, OR",44.5933,-124.008
-9435362,"Toledo, OR",44.6167,-123.937
-9435380,"South Beach, OR",44.62544444444445,-124.0449444444444
-9435385,"Yaquina Uscg Sta, Newport, OR",44.6267,-124.055
-9435992,"Chinook Bend, OR",44.880001068115234,-123.9636001586914
-9436031,"Kernville, Siletz River, OR",44.8967,-124.0
-9436381,"Cascade Head, Salmon River, OR",45.04794444444445,-124.0073055555556
-9437262,"Netarts, Netarts Bay, OR",45.43,-123.945
-9437381,"Dick Point, OR",45.4817,-123.902
-9437540,"Garibaldi, OR",45.55453,-123.9189444443915
-9437585,"North Jetty, Tillamook Bay, OR",45.56999969482422,-123.96499633789062
-9437954,"North Fork, OR",45.73379898071289,-123.87640380859375
-9438772,"Cathcart Landing, OR",46.12425,-123.8043333333333
-9439011,"Hammond, OR",46.2017,-123.945
-9439026,"Astoria, Youngs Bay, OR",46.1717,-123.842
-9439040,"Astoria, OR",46.207305908203125,-123.76830291748047
-9439069,"Knappa, OR",46.1867,-123.588
-9439099,"Wauna, OR",46.15999984741211,-123.40499877929688
-9439189,"Rocky Point, OR",45.6967,-122.868
-9439201,"St Helens, OR",45.8650016784668,-122.7969970703125
-9439221,"Portland Morrison Street Bridge, OR",45.51,-122.673
-9440047,"Washougal, Columbia River, WA",45.57830047607422,-122.38200378417969
-9440079,"Beacon Rock State Park, WA",45.62030029296875,-122.02030181884766
-9440083,"Vancouver, WA",45.63117222222222,-122.6957722222222
-9440171,"Knapp(Thornes)Lndg, Willow Bar, WA",45.74169921875,-122.75499725341797
-9440357,"Temco Kalama Terminal, WA",45.986698150634766,-122.83670043945312
-9440422,"Longview, WA",46.10609817504883,-122.9542007446289
-9440482,"Cape Horn, Columbia River, WA",46.15169906616211,-123.29000091552734
-9440483,"Barlow Point, WA",46.152198791503906,-123.03919982910156
-9440569,"Skamokawa, WA",46.27030555555555,-123.4565
-9440572,"Jetty A, Columbia River, WA",46.2683,-124.037
-9440574,"North Jetty, WA",46.2733,-124.072
-9440581,"Cape Disappointment, WA",46.28102777777778,-124.0462777777778
-9440650,"Greenhead Slough, WA",46.37220001220703,-123.95030212402344
-9440846,"Bay Center, Palix River, Willapa Bay, WA",46.6233,-123.945
-9440875,"South Bend, WA",46.6633,-123.798
-9440910,"Toke Point, WA",46.7075,-123.9669444
-9441102,"Westport, WA",46.90431,-124.1050833331214
-9441156,"Point Brown, WA",46.95,-124.128
-9441187,"Aberdeen, WA",46.9683,-123.853
-9442396,"La Push, Quillayute River, WA",47.91283611111111,-124.6357388888889
-9442705,"Tskawahyah Island, Cape Alava, WA",48.17110061645508,-124.73690032958984
-9442861,"Makah Bay, WA",48.2967,-124.672
-9443090,"Neah Bay, WA",48.37072222222222,-124.6015888888889
-9443361,"Sekiu, Clallam Bay, WA",48.2633,-124.297
-9443551,"Jim Creek, WA",48.187198638916016,-124.0625
-9443826,"Crescent Bay, WA",48.1617,-123.725
-9444090,"Port Angeles, WA",48.125,-123.44000244140625
-9444122,"Ediz Hook, WA",48.14,-123.413
-9444900,"Port Townsend, WA",48.11122222222222,-122.7596777777778
-9445016,"Foulweather Bluff, WA",47.9267,-122.617
-9445088,"Lofall, WA",47.815,-122.657
-9445133,"Bangor, WA",47.7483,-122.727
-9445246,"Whitney Point, WA",47.7617,-122.85
-9445272,"Quilcene, Dabob Bay, Hood Canal, WA",47.8,-122.858
-9445441,"Lynch Cove Dock, WA",47.4183,-122.9
-9445478,"Union, Hood Canal, WA",47.3583,-123.098
-9445526,"Hansville, WA",47.9183,-122.545
-9445719,"Poulsbo, WA",47.725,-122.638
-9445832,"Brownsville, WA",47.6517,-122.615
-9445938,"Clam Bay, WA",47.5733,-122.543
-9445958,"Bremerton, WA",47.56169891357422,-122.62300109863281
-9446281,"Allyn, WA",47.3833,-122.823
-9446291,"Wauna, WA",47.378299713134766,-122.63400268554688
-9446451,"Green Point, WA",47.3017,-122.682
-9446484,"Tacoma, WA",47.266700744628906,-122.41329956054688
-9446500,"Home, Puget Sound, WA",47.275,-122.758
-9446705,"Yoman Point, Anderson Island, WA",47.18,-122.675
-9446742,"Barron Point, Little Skookum Inlet Ent, WA",47.156700134277344,-123.00800323486328
-9446804,"Sandy Point Anderson Island, Puget Sound, WA",47.15299987792969,-122.67510223388672
-9446807,"Budd Inlet, South Of Gull Harbor, WA",47.0983,-122.895
-9446969,"Olympia, Bud Inlet, Puget Sound, WA",47.06,-122.903
-9447110,"Lockheed Shipyard, WA",47.585,-122.362
-9447130,"Seattle, WA",47.60263888888889,-122.3393055555556
-9447427,"Edmonds, WA",47.8133,-122.383
-9447659,"Everett, WA",47.98,-122.223
-9447717,"Priest Point, WA",48.03494444444444,-122.2271944444445
-9447773,"Tulalip, Tulalip Bay, WA",48.065,-122.288
-9447855,"Holly Harbor Farms, WA",48.0267,-122.535
-9447883,"Green Bank, WA",48.105,-122.57
-9447973,"Nas Whidbey Island, WA",48.34280014038086,-122.68579864501953
-9448009,"Spee-Bi-Dah, WA",48.08825,-122.3223333333333
-9448043,"Tulare Beach, Port Susan, WA",48.10680555555555,-122.3472777777778
-9448094,"Kayak Pt, Port Susan, WA",48.1367,-122.367
-9448558,"La Conner, Swinomish Slough, WA",48.3917,-122.497
-9448576,"Sneeoosh Point, WA",48.4,-122.548
-9448601,"Yokeko Point, WA",48.4133,-122.615
-9448614,"Bowman Bay, Fidalgo Island, WA",48.415000915527344,-122.6520004272461
-9448657,"Turner Bay, WA",48.445,-122.555
-9448682,"Swinomish, WA",48.45830154418945,-122.51300048828125
-9448794,"Anacortes, Fidalgo Island, WA",48.5183,-122.62
-9449161,"Village Point, Lummi Island, WA",48.7167,-122.708
-9449211,"Bellingham, WA",48.745,-122.495
-9449292,"Sandy Point, Lummi Bay, WA",48.79,-122.708
-9449424,"Cherry Point, WA",48.86271666666666,-122.7585833333333
-9449639,"Point Roberts, WA",48.974998474121094,-123.08300018310547
-9449679,"Blaine, Drayton Harbor, WA",48.9917,-122.765
-9449712,"Echo Bay, Sucia Islands, WA",48.7567,-122.897
-9449746,"Waldron Island, WA",48.686798095703125,-123.03759765625
-9449771,"Rosario, Orcas Island, WA",48.64670181274414,-122.87000274658203
-9449828,"Hanbury Point, San Juan Island, WA",48.5817,-123.17
-9449856,"Kanaka Bay, San Juan Island, WA",48.48500061035156,-123.08300018310547
-9449880,"Friday Harbor, WA",48.54527777777778,-123.0125
-9449911,"Upright Head, WA",48.57170104980469,-122.88500213623047
-9449932,"Armitage Island, WA",48.535,-122.797
-9449982,"Richardson, WA",48.4467,-122.9
-9449988,"Telegraph Bay, WA",48.44329833984375,-122.80500030517578
-9450296,"Custom House Cove, Mary Island, AK",55.1,-131.217
-9450314,"Metlakatla, Port Chester, Ak, AK",55.1283,-131.567
-9450364,"Hydaburg, Sukkwan Strait, AK",55.201698303222656,-132.822998046875
-9450460,"Ketchikan, AK",55.3319444,-131.6261111
-9450463,"Trocadero Bay, AK",55.35166666666667,-132.9380555555556
-9450495,"Saltery Cove, AK",55.4017,-132.328
-9450544,"Hollis Anchorage, Kasaan Bay, AK",55.48,-132.645
-9450551,"Craig, AK",55.4883,-133.142
-9450578,"Steamboat Bay, AK",55.5333,-133.637
-9450581,"Kasaan Bay, AK",55.535,-132.397
-9450625,"Lindeman Cove, AK",55.6017,-132.512
-9450651,"Rudyerd Bay, AK",55.6417,-130.645
-9450711,"Nossuk Bay, AK",55.72166666666666,-133.35
-9450753,"Magnetic Point, Union Bay, Earnest Sound, AK",55.78828333333333,-132.1908833333334
-9450815,"Ratz Harbor, AK",55.88,-132.595
-9450831,"Hyder, AK",55.90449905395508,-130.01080322265625
-9450906,"Beck Island, Clarence Strait, AK",56.0467,-132.862
-9450913,"Kuiu Island, Affleck Canal, AK",56.0369,-134.115
-9450914,"Burrough Bay, Behm Canal, AK",56.0383,-131.095
-9450938,"Thorne Island, AK",56.0583,-132.968
-9450970,"Thoms Point, AK",56.1183,-132.078
-9450973,"Blashke Island, AK",56.1267,-132.895
-9450982,"Shakan Bay Entrance, AK",56.14,-133.61
-9450987,"Shakan Strait (Northeast End), AK",56.1483,-133.46
-9450997,"El Capitan Passage, AK",56.1633,-133.33
-9450998,"Dry Pass, El Capitan Passage, AK",56.1633,-133.413
-9451005,"Point Harrington, Clarence Strait, AK",56.1783,-132.697
-9451012,"Bradfield Canal, AK",56.195526123046875,-131.5574188232422
-9451037,"Village Rock, AK",56.22,-132.297
-9451054,"Port Alexander, AK",56.2467,-134.647
-9451074,"Bushy Island, Snow Passage, AK",56.2767,-132.985
-9451124,"Reef Point, Stikine Strait, AK",56.3533,-132.553
-9451152,"Madan Bay, AK",56.3922,-132.169
-9451204,"Wrangell, AK",56.47,-132.387
-9451247,"Monte Carlo Island, AK",56.535,-133.767
-9451263,"Point Lockwood, AK",56.5583,-132.963
-9451281,"Blaquiere Point, AK",56.584693908691406,-132.5421905517578
-9451287,"Beecher Pass, AK",56.595,-132.987
-9451317,"Anchor Point, AK",56.6383,-132.927
-9451321,"Castle Islands, Duncan Canal, AK",56.643306732177734,-133.15199279785156
-9451335,"Cosmos Point, AK",56.6633,-132.617
-9451346,"Papke'S Landing, AK",56.6767,-132.933
-9451349,"The Summit, AK",56.68242222222222,-133.7369083333333
-9451376,"Dorothy Cove, AK",56.7217,-135.075
-9451421,"Golf Island, AK",56.7867,-135.393
-9451422,"Leconte Bay, AK",56.7883,-132.502
-9451434,"Turn Point, AK",56.8,-132.98
-9451438,"Entrance Island, AK",56.8117,-133.787
-9451467,"Red Bluff Bay, Baranof Island, AK",56.8567,-134.723
-9451497,"Saginaw Bay, Kuiu Island, AK",56.90333333333334,-134.3030555555556
-9451528,"Kake Harbor, Keku Strait, AK",56.94830555555556,-133.8947222222222
-9451561,"Thomas Bay, AK",56.9966926574707,-132.78500366210938
-9451600,"Sitka, AK",57.05169444444444,-135.342
-9451625,"Baranof, Warm Spring Bay, AK",57.08833333333333,-134.825
-9451634,"Herring Bay, Frederick Sound, AK",57.1133,-134.38
-9451706,"Eliza Harbor, Frederick Sound, AK",57.1883,-134.287
-9451741,"Whitestone Narrows, Neva Strait, AK",57.25,-135.567
-9451781,"Cannery Cove, Pybus Bay, AK",57.3067,-134.133
-9451785,"The Brothers, Stephens Passage, AK",57.295,-133.797
-9451798,"Port Houghton (Inside), Stephens Passage, AK",57.32500076293945,-133.18299865722656
-9451805,"Scraggy Island, AK",57.34,-135.707
-9451853,"Sergius Narrows, AK",57.41,-135.627
-9451936,"Provorotni Island, AK",57.515,-135.555
-9451953,"Target Island, Mitchell Bay, AK",57.5333,-134.417
-9452005,"North Shore Upper Endicott Arm, AK",57.52169418334961,-133.05499267578125
-9452022,"Sawyer Island, Tracy Arm, Holkham Bay, AK",57.8783,-133.19
-9452067,"Holkham Bay, Stephens Passage, AK",57.76,-133.603
-9452081,"Port Snettisham, Speel River Arm, AK",58.116695404052734,-133.69000244140625
-9452082,"Crib Point, Port Snettisham, Stephens Pa, AK",58.0967,-133.742
-9452089,"Sharp Point, Speel Arm, AK",58.022335052490234,-133.80728149414062
-9452123,"Taku Harbor, AK",58.0683,-134.012
-9452124,"Taku Point, AK",58.408668518066406,-134.00613403320312
-9452210,"Juneau, AK",58.2988,-134.4106
-9452249,"Young Bay, AK",58.1833,-134.587
-9452294,"Hawk Inlet, AK",58.085,-134.777
-9452318,"Barlow Cove, AK",58.3217,-134.878
-9452321,"Funter, Mansfield Peninsula, AK",58.255,-134.895
-9452328,"False Bay, Chatham Strait, AK",57.9667,-134.935
-9452336,"Lincoln Island, Favorite Channel, AK",58.4983,-134.965
-9452346,"Cove Point, AK",58.7517,-135.028
-9452368,"Swanson Harbor, AK",58.215,-135.127
-9452386,"Tenakee, AK",57.77930555555555,-135.2194722222222
-9452391,"William Henry Bay, AK",58.7133,-135.232
-9452400,"Skagway, Taiya Inlet, AK",59.4508,-135.328
-9452421,"Chilkat Inlet, AK",59.17,-135.4
-9452434,"Taiyasanka Harbor, AK",59.3017,-135.428
-9452437,"Excursion Inlet (South End), AK",58.4167,-135.447
-9452438,"Hoonah, Port Fredrick, AK",58.10755555555556,-135.4441944444444
-9452516,"Point Adolphus, AK",58.2867,-135.803
-9452534,"Bartlett Cove, Glacier Bay, AK",58.45669937133789,-135.88299560546875
-9452584,"Muir Inlet, Glacier Bay, AK",58.9133,-136.108
-9452611,"Pelican Harbor, Lisianski Inlet, Ak, AK",57.95777777777778,-136.2267777777778
-9452632,"Wachusett Inlet, Glacier Bay, AK",58.9467,-136.333
-9452634,"Elfin Cove, AK",58.19472222222223,-136.3469444444444
-9452682,"Composite Island, Glacier Bay, AK",58.8883,-136.573
-9452749,"Tarr Inlet, Glacier Bay, AK",58.96477777777778,-136.8775833333333
-9453208,"Redfield Cove, Yakutat Bay, AK",59.6117,-139.58
-9453210,"Point Latouche, Yakutat Bay, AK",59.9033,-139.627
-9453215,"Johnstone Passage, AK",59.5817,-139.702
-9453220,"Yakutat, Yakutat Bay, AK",59.548500061035156,-139.7333984375
-9453431,"Tyndall Glacier, Icy Bay, AK",60.07830047607422,-141.27499389648438
-9453443,"Moraine Bay, AK",59.93000030517578,-141.36300659179688
-9453456,"Riou Bay, AK",59.885,-141.457
-9454050,"Cordova, AK",60.55830001831055,-145.7530059814453
-9454124,"Sheep Bay, AK",60.67189025878906,-145.99217224121094
-9454153,"Gravina River, AK",60.766700744628906,-146.0845947265625
-9454240,"Valdez, AK",61.125,-146.36199951171875
-9454329,"Cape Hichinbrook, AK",60.23830032348633,-146.6479949951172
-9454363,"Rocky Pt, T-17, AK",60.94670104980469,-146.7550048828125
-9454374,"Busby Island, AK",60.8983,-146.782
-9454511,"Port Chalmers, AK",60.2418,-147.249
-9454561,"Perch Point, AK",60.1267,-147.395
-9454562,"Wooded Island, AK",59.875,-147.403
-9454564,"Seal Island, AK",60.425,-147.41
-9454616,"Montague Island, AK",60.025,-147.592
-9454642,"Louis Bay, AK",60.4617,-147.672
-9454652,"South Arm, Knight Island, Bay Of Isles, AK",60.3667,-147.7
-9454662,"Snug Harbor, AK",60.25,-147.717
-9454671,"Point Helen, Knight Island, AK",60.1533,-147.767
-9454672,"College Fiord, AK",61.2057991027832,-147.7613983154297
-9454673,"Port Audrey, AK",60.3433,-147.768
-9454674,"Macleod Harbor, AK",59.88999938964844,-147.7949981689453
-9454691,"Herring Point, Knight Island, Pr Wil Snd, AK",60.475,-147.792
-9454713,"Latouche, AK",60.0533,-147.907
-9454721,"Perry Island (South Bay), AK",60.6717,-147.932
-9454751,"Guguak, AK",60.1,-148.038
-9454755,"Bainbridge Point, AK",60.19670104980469,-148.04200744628906
-9454757,"Eshamy Lagoon, Knight Island Passage, AK",60.4617,-148.045
-9454777,"Chenega Island (S.W. End), AK",60.2833,-148.113
-9454794,"Applegate Island, AK",60.6233,-148.165
-9454814,"Point Erlington, Erlington Island, AK",59.9383,-148.227
-9454825,"Long Bay Entr, Culross Passage, AK",60.6917,-148.263
-9454949,"Whittier, AK",60.7783,-148.665
-9455090,"Seward, AK",60.1193,-149.4281083333333
-9455120,"Agnes Cove, AK",59.7733,-149.588
-9455128,"Bear Cove, Aialik Peninsula, Kenai Penin, AK",59.8017,-149.615
-9455145,"Aialik Bay, North End, AK",59.9533,-149.715
-9455146,"Aialik Sill, Aialik Bay, AK",59.885,-149.718
-9455151,"Camp Cove, Harris Penninsula, AK",59.6933,-149.748
-9455159,"Crater Bay, Harris Bay, AK",59.7133,-149.787
-9455204,"Upper Northwestern Fiord, AK",59.79,-150.032
-9455258,"Mccarty Fiord, AK",59.511600494384766,-150.35519409179688
-9455428,"Port Chatham, AK",59.2133,-151.728
-9455437,"Port Graham, AK",59.35,-151.8266666666667
-9455500,"Seldovia, AK",59.44049835205078,-151.7198944091797
-9455517,"Kasitsna Bay, Kachemak Bay, AK",59.46830555555555,-151.565
-9455558,"Coal Point, AK",59.60139846801758,-151.4105987548828
-9455595,"Bear Cove, Kachemak Bay, AK",59.725,-151.023
-9455606,"Anchor Point, Cook Inlet, AK",59.77197222222223,-151.8670277777778
-9455653,"Ninilchik, Cook Inlet, AK",60.055,-151.682
-9455711,"Cape Kasilof, AK",60.3367,-151.38
-9455732,"Kaligan Island (North End), Cook Inlet, AK",60.51169967651367,-151.95199584960938
-9455735,"Chinulna Point, Cook Inlet, AK",60.5033,-151.283
-9455760,"Nikiski, AK",60.68330001831055,-151.3979949951172
-9455866,"Point Possession, AK",61.0367,-150.413
-9455869,"North Foreland, AK",61.04330555555556,-151.163
-9455912,"Fire Island, Cook Inlet, AK",61.1733,-150.213
-9455920,"Anchorage, AK",61.2375,-149.8903888888889
-9455934,"Port Mackenzie, AK",61.2682991027832,-149.91700744628906
-9455963,"Goose Creek, Cook Inlet, AK",61.3933,-149.847
-9456173,"Snug Harbor, AK",60.10749816894531,-152.58169555664062
-9456525,"Sw Iniskin Bay, AK",59.65169906616211,-153.4680938720703
-9456717,"Nukshak Island, Shelikof Strait, AK",58.3917,-153.958
-9456901,"Aguchik Island, Kukak Bay, AK",58.29,-154.27
-9456992,"Takli Island, Shelikof Strait, AK",58.0633,-154.477
-9457152,"Tonki Bay, Afognak Island, AK",58.31669998168945,-152.06700134277344
-9457261,"Port Of Kodiak, AK",57.7833,-152.428
-9457283,"Kodiak, St Pauls Harbor, AK",57.745,-152.483
-9457287,"Ouzinkie, Spruce Island, AK",57.9217,-152.498
-9457292,"Kodiak Island, AK",57.7317,-152.512
-9457313,"Port William, Shuyak Island, AK",58.4902229309082,-152.58377075195312
-9457376,"Uzkosti Point, AK",57.9283,-152.812
-9457391,"Port Lions, Ak, AK",57.87347222222222,-152.8671111111111
-9457407,"Nachalni Island, AK",57.9783,-152.925
-9457493,"Sw Terror Bay, AK",57.74402777777778,-153.1954722222222
-9457527,"Old Harbor, Kodiak Island, AK",57.20277777777778,-153.3038888888889
-9457535,"West Raspberry Island, AK",58.10716666666666,-153.3401111111111
-9457634,"Japanese Bay, Kodiak Island, AK",56.96,-153.687
-9457724,"Larsen Bay, Kodiak Island, Ak, AK",57.5333,-153.99
-9457804,"Alitak, AK",56.89738888888889,-154.248
-9458209,"Puale Bay, AK",57.7067,-155.393
-9458293,"Chirikof Island, AK",55.8083,-155.74
-9458365,"Kanatak Lagoon, Portage Bay, AK",57.52000045776367,-156.052001953125
-9458519,"Chowiet Island, AK",56.0517,-156.698
-9458762,"Unavikshak Island, AK",56.4917,-157.74
-9458779,"Nakchamik Island, Chignik Bay, AK",56.3517,-157.812
-9458819,"Kujulik Bay (North Shore), AK",56.6133,-157.983
-9458849,"Chankliut Island, AK",56.1467,-158.107
-9458907,"Castle Bay, AK",56.2317,-158.347
-9458917,"Chignik, Anchorage Bay, AK",56.2967,-158.4
-9458964,"Hump Island, Kuiukta Bay, AK",56.1133,-158.598
-9459016,"Mitrofania Island, AK",55.89,-158.82
-9459163,"Herendeen Island, Shumagin Islands, AK",55.06555555555556,-159.4186666666667
-9459181,"Ivanof Bay, AK",55.90011215209961,-159.4912567138672
-9459251,"Bird Island, Shumagin Bank, AK",54.83522222222222,-159.7595555555556
-9459450,"Sand Point, AK",55.33172222222223,-160.5043333333333
-9459465,"Zachary Bay, Unga Is (N. Side), AK",55.334999084472656,-160.61700439453125
-9459758,"Dolgoi Harbor, Dolgoi Island, AK",55.121700286865234,-161.79200744628906
-9459881,"King Cove, AK",55.05988888888889,-162.3261111111111
-9459949,"Cold Bay, AK",55.2083,-162.698
-9461380,"Adak Island, AK",51.86063888888889,-176.6375833333333
-9461710,"Atka, AK",52.23194444444444,-174.1725
-9462450,"Nikolski, AK",52.94061,-168.8713055557675
-9462620,"Unalaska, AK",53.87919444444444,-166.5403055555556
-9462645,"Biorka Village, Biverly Inlet, AK",53.82891666666667,-166.21625
-9462662,"Reef Bight, AK",54.13072222222223,-166.0993333333333
-9462676,"Broad Bight, AK",54.06458333333333,-165.9370555555556
-9462694,"Akutan, Alaska, AK",54.13327777777778,-165.7773055555556
-9462705,"Green Bight, AK",54.11027777777778,-165.6613888888889
-9462711,"Surf Bay, Akutan Bay, AK",54.15083333333333,-165.615
-9462719,"Akun Cove, Akun Island, AK",54.2333,-165.533
-9462721,"Trident Bay, Akun Island, AK",54.14,-165.527
-9462723,"Rootok Island, AK",54.05222222222222,-165.5141666666667
-9462782,"Tigalda Bay, Tigalda Island, AK",54.12,-164.977
-9462786,"Se Tigalda Island, Pacific Ocean, AK",54.10180555555556,-164.9415833333333
-9462787,"Cape Sarichef, Unimak Island, AK",54.6,-164.928
-9462808,"Scotch Cap, Unimak Island, Ak, AK",54.39363888888889,-164.7457222222222
-9462941,"Cape Chunak, Ak, AK",55.06427777777778,-163.5341666666667
-9462948,"Neumans Cove, AK",54.9667,-163.44
-9462955,"False Pass, Unimak Island, AK",54.8583,-163.407
-9462961,"Isanotski Strait Entrance, AK",54.77844444444445,-163.3642777777778
-9463502,"Port Moller, AK",55.9858333,-160.5736111
-9463885,"Zapadni Bay, St. George Island, AK",56.56669998168945,-169.6667022705078
-9463888,"St. George, St. George Island, AK",56.60327777777778,-169.5495555555555
-9464075,"Meshik, Port Heiden, AK",56.90829849243164,-158.68490600585938
-9464212,"Village Cove, St Paul Island, AK",57.125301361083984,-170.2852020263672
-9464512,"Dago Creek Mouth, Ugashik Bay, AK",57.61479949951172,-157.60069274902344
-9464874,"Egegik, Egegik R, Bristol Bay, AK",58.21670150756836,-157.375
-9464961,"Cape Constantine, Nushagak Peninsula, AK",58.52170181274414,-159.15199279785156
-9465056,"Protection Point, Nushagak Bay, AK",58.5,-158.712
-9465137,"Cape Peirce, West Side, AK",58.62670135498047,-161.83700561523438
-9465149,"King Salmon Air Base, Naknek River, AK",58.671695709228516,-156.65699768066406
-9465182,"Black Rock, Walrus Is Bristol B, AK",58.70830154418945,-160.18800354003906
-9465203,"Naknek, AK",58.73210144042969,-156.98330688476562
-9465261,"Clarks Point, Nushagak Bay, AK",58.8483,-158.552
-9465265,"Kulukak Point, AK",58.84000015258789,-159.64700317382812
-9465374,"Snag Point, Dillingham, AK",59.04,-158.447
-9465396,"Platinum, AK",59.0467,-161.818
-9465419,"Levelock, Kvichak River, AK",59.11330032348633,-156.83200073242188
-9465438,"Goodnews Bay, AK",59.11439895629883,-161.5843963623047
-9465601,"Carter Bay, Kuskokwim Bay, AK",59.37801666666667,-162.0293333333333
-9465831,"Quinhagak (Kwinak), Kushkokwin River, AK",59.75055277777778,-161.9154361111111
-9465951,"Kipnuk, Kugkaktlik River, AK",59.943199157714844,-164.04339599609375
-9466057,"Popokamute (Kokokamute), Kuskokwim River, AK",60.12327777777778,-162.5003611111111
-9466084,"Chefornak, AK",60.159400939941406,-164.27259826660156
-9466153,"Helmick Point, AK",60.270301818847656,-162.4102020263672
-9466197,"Tuntutuliak, AK",60.34149932861328,-162.68600463867188
-9466217,"Mekoryuk, Mekoryuk River Entrance, AK",60.4167,-166.167
-9466298,"Nelson Island, Tooksook Bay, AK",60.5167,-165.133
-9466328,"Lomavik, AK",60.554298400878906,-162.29710388183594
-9466477,"Bethel, Kuskokwim River, Ak, AK",60.8,-161.75
-9466563,"Newtok, AK",60.93450164794922,-164.63870239257812
-9466931,"Dall Point, AK",61.5317,-166.148
-9467124,"Kun River, AK",61.84170150756836,-165.56700134277344
-9467551,"Nunam Iqua (Sheldon Point), AK",62.53294444444445,-164.8452777777778
-9467645,"Alakanuk, Yukon River, AK",62.687198638916016,-164.66690063476562
-9467701,"Emmonak, AK",62.77750015258789,-164.54690551757812
-9467861,"Kotlik, Ak, AK",63.037899017333984,-163.52650451660156
-9468039,"Northeast Cape, St. Lawrence Island, AK",63.3167,-168.967
-9468151,"Stebbins, Norton Sound, East, AK",63.525001525878906,-162.29299926757812
-9468258,"Savoonga, AK",63.67908333333333,-170.5371111111111
-9468333,"Unalakleet, AK",63.875,-160.78799438476562
-9468691,"Shaktoolik, AK",64.38022222222222,-161.2351388888889
-9468756,"Nome, Norton Sound, AK",64.49461111111111,-165.4396388888889
-9468793,"Golovin, Golovnin Lagoon Entrance, AK",64.54630279541016,-163.0316925048828
-9468841,"Upper Golovnin Lagoon, AK",64.62079620361328,-163.1490020751953
-9468877,"White Mountain, Ak, AK",64.68113708496094,-163.4119110107422
-9469031,"Koyuk, AK",64.93119812011719,-161.1508026123047
-9469146,"Imuruk Basin, AK",65.11840057373047,-165.47210693359375
-9469237,"Point Spencer, Port Clarence, AK",65.2567,-166.847
-9469239,"Teller, Port Clarence, AK",65.2667,-166.353
-9469338,"Lost River, Seward Peninsula, AK",65.39,-167.145
-9469439,"Tin City, Bering Sea, AK",65.55833333333334,-167.975
-9469677,"Buckland, AK",65.97550201416016,-161.125
-9469751,"Deering, AK",66.09716666666667,-162.7404722222222
-9469833,"Goodhope Bay, AK",66.23030090332031,-163.9040985107422
-9469854,"Shishmaref Inlet 2, AK",66.2633,-166.02
-9490096,"Cape Espenberg, Kotzebue Sound, AK",66.58569444444444,-164.2508333333333
-9490424,"Kotzebue, AK",66.9017,-162.582
-9490571,"Cape Krusenstern, AK",67.05419444444445,-163.3212777777778
-9491094,"Red Dog Dock, AK",67.57580555555556,-164.0643888888889
-9491253,"Kivalina, AK",67.7267,-164.592
-9491873,"Point Hope, AK",68.3417,-166.808
-9494212,"Wainwright, AK",70.643798828125,-160.06509399414062
-9494935,"Barrow Offshore, AK",71.36011111111111,-156.7298611111111
-9497645,"Prudhoe Bay, AK",70.4113889,-148.5316667
-9499176,"Barter Island, AK",70.12855555555555,-143.6110277777778
-9500966,"Madero, Tampico Harbor, Mexico, Mexico",22.261699676513672,-97.79499816894531
-9710441,"Settlement Point, Bahamas",26.71,-78.9967
-9751082,"Grapetree Bay, PR",17.740699768066406,-64.60579681396484
-9751084,"Teague Bay, PR",17.7549991607666,-64.60240173339844
-9751219,"Fareham Bay, PR",17.709999084472656,-64.68280029296875
-9751274,"Johns Folly Bay, PR",18.316999435424805,-64.70210266113281
-9751309,"Leinster Point, Leinster Bay, St. John'S, Vi",18.36761111111111,-64.72072222222222
-9751364,"Christiansted Harbor, St Croix, Vi",17.74769444444445,-64.69838888888889
-9751373,"St John'S Island, Coral Harbor, Vi",18.34830093383789,-64.7166976928711
-9751381,"Lameshur Bay, St John, Vi",18.31825,-64.72422222222222
-9751389,"Salt River Bay, PR",17.775299072265625,-64.76229858398438
-9751401,"Limetree Bay, Vi",17.694700241088867,-64.75379943847656
-9751417,"Hawksnest Beach, PR",18.348899841308594,-64.77739715576172
-9751419,"Haulover Bay, St. Johns, PR",18.349700927734375,-64.67960357666016
-9751467,"Lovango Cay, St. John, Vi",18.36066666666667,-64.80352777777777
-9751472,"Cruz Bay, PR",18.33289909362793,-64.79409790039062
-9751494,"Dog Island, St. Thomas, Vi",18.29713888888889,-64.81775
-9751540,"Redhook Bay, St Thomas, Usvi, Vi",18.3267,-64.8517
-9751561,"Pavillion Point, PR",18.33989906311035,-64.85240173339844
-9751574,"Jersey Bay, PR",18.318099975585938,-64.8594970703125
-9751583,"Water Bay, Vi",18.34894444444445,-64.86416666666666
-9751584,"Fredericksted, St. Croix, Vi",17.7133,-64.8833
-9751639,"Charlotte Amalie, Vi",18.3305833,-64.9258056
-9751693,"Magens Bay, PR",18.366300582885742,-64.9220962524414
-9751749,"Crown Bay, PR",18.33289909362793,-64.95169830322266
-9751768,"Dorothea Bay, Saint Thomas, Vi",18.37125,-64.96347222222222
-9751774,"Botany Bay, St. Thomas, Vi",18.3633,-65.035
-9752062,"Culebrita, PR",18.319400787353516,-65.23809814453125
-9752235,"Culebra, PR",18.30086111111111,-65.30247222222222
-9752426,"Playa La Plata, PR",18.116600036621094,-65.3729019165039
-9752619,"Isabel Segunda, Vieques Island, PR",18.15252777777778,-65.44380555555556
-9752695,"Esperanza, Vieques Island, PR",18.09386111111111,-65.47136111111111
-9752813,"Mosquito Pier, PR",18.14889907836914,-65.51490020751953
-9752962,"Isla Palominos, PR",18.34497222222222,-65.5695
-9752998,"Punta Arenas, Vieques Island, PR",18.11240005493164,-65.57589721679688
-9753182,"Ceiba, Roosevelt Road, PR",18.228099822998047,-65.61969757080078
-9753216,"Fajardo, PR",18.3352778,-65.6311111
-9753641,"Naguabo, PR",18.18705555555556,-65.71138888888889
-9753766,"Luquillo, Pr, PR",18.38170051574707,-65.73650360107422
-9754057,"Palmas Del Mar, PR",18.078100204467773,-65.79560089111328
-9754228,"Yabucoa Harbor, PR",18.05508333333333,-65.833
-9754487,"Puerto Maunabo, PR",17.99139976501465,-65.88880157470703
-9754986,"Boca De Cangrejos, PR",18.456600189208984,-65.99150085449219
-9755371,"San Juan, La Puntilla, San Juan Bay, PR",18.45894444444445,-66.11641666666667
-9755679,"Las Mareas, PR",17.9283,-66.1583
-9755971,"Central Aguirre, PR",17.950000762939453,-66.22640228271484
-9756567,"Boca Del Cibuco, PR",18.485200881958008,-66.3843994140625
-9756639,"Santa Isabel, PR",17.955,-66.4067
-9757487,"Ponce, PR",17.969600677490234,-66.61990356445312
-9757809,"Arecibo, PR",18.48052777777778,-66.70236111111112
-9758053,"Penuelas (Punta Guayanilla), PR",17.97252777777778,-66.76177777777778
-9758627,"Guanica, PR",17.95800018310547,-66.90679931640625
-9759110,"Magueyes Island, PR",17.97011111111111,-67.04638888888888
-9759173,"Boqueron, PR",18.02400016784668,-67.17310333251953
-9759183,"Joyuda, PR",18.115800857543945,-67.18319702148438
-9759189,"Puerto Real, PR",18.07480555555556,-67.18877777777777
-9759197,"Bahia Salinas, PR",17.95144444444444,-67.19658333333334
-9759394,"Mayaguez, PR",18.21883333333333,-67.16244444444445
-9759412,"Aguadilla, Crashboat Beach, PR",18.45663888888889,-67.16458333333334
-9759421,"Punta Guanajibo, Mayagues, PR",18.165000915527344,-67.18170166015625
-9759866,"Southeast Mona Island, PR",18.06529998779297,-67.86609649658203
-9759938,"Mona Island, PR",18.08928888888889,-67.93820833333334
-9761115,"Barbuda, Antigua And Barbuda",17.59083366394043,-61.820556640625
+station_id,place_name,latitude,longitude,timezone
+1611347,"Port Allen, Hanapepe Bay, Kauai Island, HI",21.9033,-159.592,Pacific/Honolulu
+1611400,"Nawiliwili, HI",21.9544,-159.3561,Pacific/Honolulu
+1612340,"Honolulu, HI",21.30333333333334,-157.8645277777778,Pacific/Honolulu
+1612366,"Fort Kamehameha, Bishop Point, Pearl Hbr, HI",21.33,-157.967,Pacific/Honolulu
+1612401,"Pearl Harbor, HI",21.36750030517578,-157.96389770507812,Pacific/Honolulu
+1612404,"Ford Island, Ferry Dock, Pearl Harbor, HI",21.3683,-157.94,Pacific/Honolulu
+1612480,"Mokuoloe, HI",21.43305555555556,-157.79,Pacific/Honolulu
+1613198,"Kaunakakai Harbor, HI",21.085,-157.032,Pacific/Honolulu
+1614465,"Kaumalapau Harbor, Lanai Island, HI",20.79,-156.995,Pacific/Honolulu
+1615680,"Kahului, Kahului Harbor, HI",20.89494444444445,-156.469,Pacific/Honolulu
+1617433,"Kawaihae, HI",20.0366,-155.8294,Pacific/Honolulu
+1617760,"Hilo, Hilo Bay, Kuhio Bay, HI",19.73027777777778,-155.0555555555555,Pacific/Honolulu
+1619000,"Johnston Atoll, United States Of America",16.7383,-169.53,Pacific/Honolulu
+1619910,"Sand Island, Midway Islands, United States Of America",28.2116667,-177.36,Pacific/Midway
+1630000,"Apra Harbor, Guam, United States Of America",13.44338888888889,144.6563611111111,Pacific/Guam
+1631428,"Pago Bay, Guam, United States Of America",13.4283333,144.7988888888889,Pacific/Guam
+1633227,"Saipan, Gu",15.2267,145.737,Pacific/Saipan
+1732417,Fare Ute Point,-17.535,-149.572,Pacific/Tahiti
+1770000,"Pago Pago, American Samoa, American Samoa",-14.279999732971191,-170.69000244140625,Pacific/Pago_Pago
+1820000,"Kwajalein, Marshall Islands, United States Of America",8.731666564941406,167.7361145019531,Pacific/Kwajalein
+1840000,"Chuuk, Moen Island, E. Caroline Islands, Fm",7.44667,151.847,Pacific/Chuuk
+1890000,"Wake Island, Pacific Ocean, United States Of America",19.2905556,166.6175,Pacific/Wake
+1910000,"Suva, Suva Harbor, Fiji",-18.1333,178.425,Pacific/Fiji
+2431000,"Diego Garcia, United Kingdom",-7.29,72.3933,Indian/Chagos
+2695535,"Bermuda Biological Station, Bermuda",32.37022399902344,-64.69572448730469,Atlantic/Bermuda
+2695540,"Bermuda, St. Georges Island, Bermuda",32.3734016418457,-64.70330047607422,Atlantic/Bermuda
+8410140,"Eastport, ME",44.90460968017578,-66.9828872680664,America/New_York
+8410714,"Coffin Point, Coffin Neck, ME",44.87,-67.1083,America/New_York
+8410715,"Garnet Point, Hersey Neck, ME",44.9233,-67.13,America/New_York
+8410834,"Pettegrove Point, Dochet Island, ME",45.12844444444445,-67.14466666666667,America/New_York
+8410864,"Gravelly Point, Whiting Bay, ME",44.823299407958984,-67.15170288085938,America/New_York
+8411060,"Cutler Farris Wharf, ME",44.656700134277344,-67.20999908447266,America/New_York
+8411250,"Cutler Naval Base, ME",44.6417,-67.2967,America/New_York
+8412581,"Milbridge, ME",44.54,-67.875,America/New_York
+8413320,"Bar Harbor, ME",44.39219444444444,-68.20427777777778,America/New_York
+8413801,"Ellsworth, ME",44.535,-68.4217,America/New_York
+8413825,"Mackerel Cove, Swans Island, ME",44.16999816894531,-68.43499755859375,America/New_York
+8414249,"Oceanville, Deer Isle, ME",44.19230555555556,-68.62093055555556,America/New_York
+8414612,"Bangor, ME",44.785,-68.7667,America/New_York
+8414684,"Bucksport, ME",44.5717,-68.8017,America/New_York
+8414692,"Sandy Point, ME",44.505,-68.805,America/New_York
+8414721,"Fort Point, ME",44.4717,-68.8133,America/New_York
+8414781,"Winterport, Penobscot River, ME",44.63669967651367,-68.8416976928711,America/New_York
+8414856,"North Haven, ME",44.1267,-68.8733,America/New_York
+8414888,"Pulpit Harbor, Penobscot Bay, ME",44.1567,-68.8867,America/New_York
+8415191,"Belfast, Penobscot Bay, ME",44.4267,-69.005,America/New_York
+8415490,"Rockland, ME",44.105,-69.1017,America/New_York
+8415709,"Thomaston, ME",44.0717,-69.1817,America/New_York
+8416731,"Walpole, Damariscotta River, ME",43.9333,-69.58,America/New_York
+8416921,"Wiscasset, ME",44.0,-69.6667,America/New_York
+8417134,"Gardiner, ME",44.2333,-69.7667,America/New_York
+8417177,"Hunniwell Point, ME",43.755,-69.785,America/New_York
+8417208,"Richmond, ME",44.0883,-69.7983,America/New_York
+8417227,"Bath, ME",43.925,-69.815,America/New_York
+8417821,"Cliff Island, Luckse Sound, ME",43.695,-70.11,America/New_York
+8417874,"Doyle Point, Casco Bay, ME",43.7517,-70.14,America/New_York
+8417881,"Great Chebeague Island, ME",43.7217,-70.1417,America/New_York
+8417941,"Long Island, Casco Bay, ME",43.69,-70.17,America/New_York
+8417948,"Prince Point, Yarmouth, ME",43.7617,-70.1733,America/New_York
+8417988,"Great Diamond Is., Casco Bay, ME",43.67,-70.2,America/New_York
+8417997,"Cushing Island, Casco Bay, ME",43.645,-70.1983,America/New_York
+8418009,"Cow Island, Casco Bay, ME",43.69,-70.19,America/New_York
+8418015,"Falmouth Foreside, ME",43.7317,-70.205,America/New_York
+8418031,"Portland Head Light Station, ME",43.6233,-70.2067,America/New_York
+8418150,"Portland, ME",43.65805555555556,-70.24416666666667,America/New_York
+8418268,"Fore River, Portland, ME",43.6417,-70.285,America/New_York
+8418445,"Pine Point, ME",43.545,-70.3333,America/New_York
+8418606,"Camp Ellis, Saco River, ME",43.4617,-70.3817,America/New_York
+8418828,"Biddeford, Saco River, ME",43.4917,-70.4467,America/New_York
+8418911,"Kennebunkport, Kennebunk River, ME",43.3583,-70.4767,America/New_York
+8419317,"Wells, ME",43.31999969482422,-70.56330108642578,America/New_York
+8419399,"Cape Neddick, ME",43.1667,-70.5933,America/New_York
+8419528,"Fort Point, York Harbor, ME",43.13,-70.6383,America/New_York
+8419688,"Gerrish Island, Kittery, ME",43.0667,-70.6967,America/New_York
+8419870,"Seavey Island, ME",43.0797222,-70.74111111111111,America/New_York
+8420411,"Dover, Cocheco River, NH",43.1983,-70.8683,America/New_York
+8423635,"Atlantic Heights, NH",43.09,-70.7633,America/New_York
+8423898,"Fort Point, NH",43.07170104980469,-70.71170043945312,America/New_York
+8440273,"Salisbury Point, Merrimack River, MA",42.8383,-70.9083,America/New_York
+8440369,"Merrimacport, Merrimack River, MA",42.825,-70.9883,America/New_York
+8440452,"Plum Island, Merrimack River Entrance, MA",42.8167,-70.82,America/New_York
+8440466,"Newburyport, Merrimack River, MA",42.815,-70.8733,America/New_York
+8440889,"Riverside, Merrimack River, MA",42.763889,-71.034028,America/New_York
+8441241,"Plum Island South, MA",42.71013888888889,-70.78861111111111,America/New_York
+8441551,"Rockport Harbor, MA",42.6583,-70.615,America/New_York
+8441571,"Lobster Cove, Annisquam River, MA",42.654998779296875,-70.67669677734375,America/New_York
+8441771,"Essex, Essex River, MA",42.6317,-70.7767,America/New_York
+8441841,"Gloucester Harbor, MA",42.61000061035156,-70.66000366210938,America/New_York
+8442417,"Beverly, Beverly Harbor, MA",42.540000915527344,-70.88670349121094,America/New_York
+8442645,"Salem, Salem Harbor, MA",42.5233,-70.8767,America/New_York
+8443187,"Lynn, Lynn Harbor, MA",42.4583,-70.9433,America/New_York
+8443662,"Amelia Earhart Dam, Mystic River, MA",42.395,-71.0767,America/New_York
+8443725,"Chelsea, MA",42.3867,-71.0233,America/New_York
+8443970,"Boston, MA",42.35388888888889,-71.05027777777778,America/New_York
+8444162,"Boston Light, MA",42.3283,-70.8917,America/New_York
+8444525,"Nut Island, MA",42.28,-70.9533,America/New_York
+8444788,"Weymouth Fore River, MA",42.2483,-70.9667,America/New_York
+8445138,"Scituate, Scituate Harbor, MA",42.2017,-70.7267,America/New_York
+8446009,"Brant Rock, Green Harbor River, MA",42.0833,-70.6467,America/New_York
+8446121,"Provincetown, MA",42.04959166666666,-70.18215833333333,America/New_York
+8446166,"Duxbury, Duxbury Harbor, MA",42.0383,-70.67,America/New_York
+8446493,"Plymouth, Plymouth Harbor, MA",41.96,-70.6617,America/New_York
+8447173,"Sagamore, Cape Cod Canal (Sta. 115), MA",41.775,-70.535,America/New_York
+8447180,"Sandwich, MA",41.7717,-70.5067,America/New_York
+8447191,"Bournedale, Cape Cod Canal (Sta. 200), MA",41.77,-70.5617,America/New_York
+8447241,"Sesuit Harbor, East Dennis, MA",41.7517,-70.155,America/New_York
+8447259,"Bourne Bridge, Cape Cod Canal (Sta. 320), MA",41.745,-70.5933,America/New_York
+8447270,"Buzzards Bay, MA",41.7417,-70.6167,America/New_York
+8447277,"Onset Beach T-12, MA",41.7417,-70.6583,America/New_York
+8447281,"Steepbrook, MA",41.74,-71.1317,America/New_York
+8447295,"Gray Gables, MA",41.735,-70.6233,America/New_York
+8447355,"Monument Beach T-8, MA",41.715,-70.6167,America/New_York
+8447368,"Great Hill, MA",41.711700439453125,-70.71499633789062,America/New_York
+8447385,"Marion, Buzzard'S Bay, MA",41.705,-70.7617,America/New_York
+8447386,"Fall River, MA",41.70429992675781,-71.16410064697266,America/New_York
+8447416,"Piney Point, MA",41.695,-70.72,America/New_York
+8447435,"Chatham, MA",41.688499450683594,-69.95110321044922,America/New_York
+8447495,"Saquatucket Harbor, MA",41.6683,-70.0567,America/New_York
+8447504,"South Yarmouth, Bass River, MA",41.665,-70.1833,America/New_York
+8447505,"Chatham, Stage Harbor, MA",41.6667,-69.9667,America/New_York
+8447506,"Wychmere Hbr., Harwichport, MA",41.665000915527344,-70.06500244140625,America/New_York
+8447531,"Mattapoisett, MA",41.6567,-70.8133,America/New_York
+8447605,"Hyannisport, MA",41.6317,-70.3,America/New_York
+8447636,"New Bedford Harbor, MA",41.62120056152344,-70.9136962890625,America/New_York
+8447685,"Chappaquoit Point, MA",41.605,-70.6517,America/New_York
+8447712,"New Bedford, Clarks Point, MA",41.5933,-70.9,America/New_York
+8447842,"Round Hill Point, MA",41.5383,-70.9283,America/New_York
+8447930,"Woods Hole, MA",41.52361297607422,-70.67111206054688,America/New_York
+8448157,"Vineyard Haven, Vineyard Hvn Hbr, MA",41.4583,-70.6,America/New_York
+8448208,"Oak Bluffs, Martha'S Vineyard, MA",41.4583,-70.555,America/New_York
+8448248,"Penikese Island, MA",41.45,-70.9217,America/New_York
+8448251,"Quick'S Hole, MA",41.4483,-70.8567,America/New_York
+8448376,"Cuttyhunk, MA",41.42499923706055,-70.91670227050781,America/New_York
+8448558,"Edgartown, MA",41.3883,-70.5117,America/New_York
+8448725,"Menemsha Harbor, Ma, MA",41.35444444444445,-70.76783333333333,America/New_York
+8448875,"Martha'S Vineyard Gps Buoy, MA",41.32622222222222,-70.59033333333333,America/New_York
+8449130,"Nantucket Island, MA",41.28499984741211,-70.0967025756836,America/New_York
+8450768,"Sakonnet, RI",41.465,-71.1933,America/New_York
+8450898,"Sakonnet River, North End, Bay Oil Pier, RI",41.6517,-71.21,America/New_York
+8450948,"Anthony Point, RI",41.6383,-71.2117,America/New_York
+8450954,"Nannaquaket, RI",41.6183,-71.2033,America/New_York
+8451301,"The Glen,Sakonnet River, RI",41.5583,-71.2367,America/New_York
+8451351,"Sachuest, Flint Point, RI",41.4867,-71.2383,America/New_York
+8451552,"Bristol Ferry, RI",41.6367,-71.255,America/New_York
+8452154,"Bristol Highlands, RI",41.69670104980469,-71.29329681396484,America/New_York
+8452555,"Navy Pier, Prudence Island, RI",41.58,-71.3217,America/New_York
+8452660,"Newport, RI",41.5043333,-71.3261389,America/New_York
+8452944,"Conimicut Light, RI",41.71670150756836,-71.34329986572266,America/New_York
+8453033,"Bay Spring, Bullock Cove, RI",41.75170135498047,-71.35169982910156,America/New_York
+8453201,"Castle Hill, RI",41.4633,-71.3617,America/New_York
+8453433,"Rumford, Seekonk River, RI",41.84000015258789,-71.37329864501953,America/New_York
+8453465,"Conanicut Point, RI",41.5733,-71.3717,America/New_York
+8453742,"West Jamestown, RI",41.4967,-71.3867,America/New_York
+8453767,"Pawtuxet Cove, Providence River, RI",41.76169967651367,-71.38829803466797,America/New_York
+8453999,"Beavertail Point, RI",41.4517,-71.4017,America/New_York
+8454000,"Providence, RI",41.80716666666667,-71.40066666666667,America/New_York
+8454049,"Quonset Point, RI",41.58679962158203,-71.41100311279297,America/New_York
+8454341,"Boston Neck, RI",41.46,-71.4283,America/New_York
+8454538,"Wickford, Narragansett Bay, RI",41.5717,-71.445,America/New_York
+8454578,"East Greenwich, RI",41.665000915527344,-71.44499969482422,America/New_York
+8454658,"Narragansett Pier, RI",41.4217,-71.455,America/New_York
+8455083,"Point Judith, Harbor Of Refuge, RI",41.3633,-71.49,America/New_York
+8455137,"Kickamuit River, RI",41.707801818847656,-71.24169921875,America/New_York
+8455189,"Westerly Pawcatuck, RI",41.3817,-71.8317,America/New_York
+8458022,"Weekapaug Point, Block Island Sound, RI",41.3283,-71.7617,America/New_York
+8458694,"Watch Hill Point, RI",41.305,-71.86,America/New_York
+8459338,"Block Island, RI",41.1733,-71.5567,America/New_York
+8459681,"Block Island, RI",41.1633,-71.61,America/New_York
+8460751,"West Mystic River, CT",41.343299865722656,-71.9749984741211,America/New_York
+8461392,"Norwich, Thames River, CT",41.5233,-72.0783,America/New_York
+8461467,"Yale Boathouse, Thames River, CT",41.43,-72.0933,America/New_York
+8461490,"New London, CT",41.371667,-72.095556,America/New_York
+8461925,"Niantic, Niantic River, CT",41.325,-72.1867,America/New_York
+8463348,"Tylerville, Connecticut R., CT",41.4517,-72.465,America/New_York
+8463701,"Clinton Harbor, CT",41.2683,-72.5317,America/New_York
+8463827,"Maromas, Connecticut River, CT",41.5417,-72.5517,America/New_York
+8463836,"Higganum Creek, Connecticut R., CT",41.5033,-72.5533,America/New_York
+8464255,"Rocky Hill,Connecticut River, CT",41.6633,-72.63,America/New_York
+8464336,"Middletown, Connecticut River, CT",41.56,-72.645,America/New_York
+8464445,"Guilford, Guilford Harbor, CT",41.2717,-72.6667,America/New_York
+8465692,"Lighthouse Point, New Haven Harbor, CT",41.2517,-72.905,America/New_York
+8465705,"New Haven, CT",41.28329849243164,-72.9083023071289,America/New_York
+8466375,"Gulf Beach, CT",41.205,-73.0417,America/New_York
+8466442,"Milford Harbor, CT",41.2183,-73.055,America/New_York
+8466573,"Shelton, Housatonic River, CT",41.3017,-73.0717,America/New_York
+8466664,"Murphy'S Boat Yard, Housatonic River, CT",41.275,-73.0883,America/New_York
+8466791,"Sniffens Point, Housatonic River, CT",41.1867,-73.1133,America/New_York
+8466797,"I-95 Bridge, Housatonic River, CT",41.2033,-73.1117,America/New_York
+8467150,"Bridgeport, CT",41.17581944444444,-73.18396944444444,America/New_York
+8467373,"Black Rock Harbor, CT",41.1567,-73.2133,America/New_York
+8467726,"Southport, Southport Harbor, CT",41.1333,-73.2833,America/New_York
+8468191,"Saugatuck River, CT",41.119998931884766,-73.36830139160156,America/New_York
+8468448,"South Norwalk, CT",41.0967,-73.415,America/New_York
+8468609,"Rowayton, Fivemile River, CT",41.065,-73.445,America/New_York
+8468799,"Long Neck Point, Long Island Sound, CT",41.0383,-73.48,America/New_York
+8469198,"Stamford Harbor, CT",41.0383,-73.5467,America/New_York
+8510448,"Lake Montauk, NY",41.0733,-71.935,America/New_York
+8510560,"Montauk, NY",41.0483333,-71.9594444,America/New_York
+8510719,"Silver Eel Pond, NY",41.2567,-72.03,America/New_York
+8511171,"Threemile Harbor Entrance, NY",41.035,-72.19,America/New_York
+8511236,"Plum Island Plum Gut Harbor, NY",41.1717,-72.205,America/New_York
+8511629,"Sag Harbor, NY",41.0033,-72.2967,America/New_York
+8511671,"Orient Harbor, NY",41.1367,-72.3067,America/New_York
+8511907,"Greenport, NY",41.101,-72.36116666666666,America/New_York
+8512354,"Shinnecock Inlet Open Coast, NY",40.8367,-72.48,America/New_York
+8512451,"Ponquogue Point, NY",40.85,-72.5033,America/New_York
+8512668,"Mattituck Inlet, Long Island, NY",41.01499938964844,-72.56169891357422,America/New_York
+8512671,"Shinnecock Bay, NY",40.82,-72.5617,America/New_York
+8512735,"South Jamesport, NY",40.935,-72.5817,America/New_York
+8512769,"Shinnecock Yacht Club, Penniman Creek, NY",40.81855555555556,-72.58661111111111,America/New_York
+8512987,"Northville, NY",40.9817,-72.645,America/New_York
+8513388,"Moriches Cgs, Moriches Bay, NY",40.7867,-72.75,America/New_York
+8513398,"Moriches Inlet, NY",40.76441666666667,-72.75597222222223,America/New_York
+8513825,"Smith Point Bridge, Narrow Bay, NY",40.7383,-72.8683,America/New_York
+8514322,"Patchogue, Patchogue River, NY",40.75,-73.0,America/New_York
+8514422,"Cedar Beach, NY",40.965,-73.0433,America/New_York
+8514560,"Port Jefferson, NY",40.95000076293945,-73.07669830322266,America/New_York
+8514779,"Seaview Ferry Dock, NY",40.64925,-73.15061111111112,America/New_York
+8515102,"Bayshore, Long Island, NY",40.7167,-73.24,America/New_York
+8515186,"Fire Island, NY",40.6267,-73.26,America/New_York
+8515586,"Northport, Northport Bay, NY",40.9,-73.3533,America/New_York
+8515786,"Eatons Neck, NY",40.9533,-73.4,America/New_York
+8515921,"Lloyd Harbor Lighthouse, NY",40.91,-73.4317,America/New_York
+8516061,"Cold Spring Harbor, NY",40.87329864501953,-73.47000122070312,America/New_York
+8516155,"Green Island, NY",40.6233,-73.5017,America/New_York
+8516299,"Bayville Bridge, Oyster Bay, NY",40.9033,-73.55,America/New_York
+8516402,"Point Lookout, NY",40.59388888888889,-73.58397222222223,America/New_York
+8516501,"Parsonnage Cove, NY",40.6333,-73.6167,America/New_York
+8516607,"Harry Tappen Marina, NY",40.83461111111111,-73.65241666666667,America/New_York
+8516614,"Glen Cove Yacht Club, Long Island, NY",40.8633,-73.655,America/New_York
+8516661,"Bay Park, Ny, NY",40.63,-73.67,America/New_York
+8516663,"Long Beach, New York, NY",40.59633333333333,-73.65508333333334,America/New_York
+8516761,"Port Washington, Manhassset Bay, NY",40.8317,-73.7033,America/New_York
+8516881,"Atlantic Beach, NY",40.595,-73.7433,America/New_York
+8516891,"Norton Point, Hook Creek, New York, NY",40.635,-73.7467,America/New_York
+8516945,"Kings Point, NY",40.810298919677734,-73.76490020751953,America/New_York
+8516990,"Willets Point, NY",40.7933,-73.7817,America/New_York
+8517125,"Whitestone, NY",40.7983,-73.8133,America/New_York
+8517137,"Beach Channel (Bridge), NY",40.5883,-73.82,America/New_York
+8517201,"North Channel, NY",40.645,-73.8367,America/New_York
+8517251,"Worlds Fair Marina, NY",40.761,-73.85036111111111,America/New_York
+8517276,"College Pt, Ft. Of 110Th St, Li, NY",40.7833,-73.8567,America/New_York
+8517401,"Wards Is., NY",40.7867,-73.9217,America/New_York
+8517732,"Wallabout Bay, Bkln Navy Yard, NY",40.7067,-73.975,America/New_York
+8517756,"Kingsborough Cc, NY",40.581199645996094,-73.93379974365234,America/New_York
+8517811,"Gravesend Bay, Norton Pt. Bkln, NY",40.59,-73.9983,America/New_York
+8517847,"Brooklyn Bridge, NY",40.7033,-73.995,America/New_York
+8517921,"Gowanus Bay, NY",40.665,-74.0133,America/New_York
+8518091,"Rye Beach, Amusement Park, NY",40.9617,-73.6717,America/New_York
+8518490,"New Rochelle, NY",40.8933,-73.7817,America/New_York
+8518526,"Throgs Neck, NY",40.805,-73.795,America/New_York
+8518621,"Hunts Pt., NY",40.8,-73.8733,America/New_York
+8518639,"Port Morris, NY",40.8017,-73.9067,America/New_York
+8518643,"Randalls Island, NY",40.8,-73.9283,America/New_York
+8518668,"Horns Hook, NY",40.7767,-73.9417,America/New_York
+8518687,"Queensboro Bridge, NY",40.7583,-73.9583,America/New_York
+8518695,"East 41St Street Pier, NY",40.7467,-73.9683,America/New_York
+8518699,"Williamsburg Bridge, NY",40.7117,-73.9683,America/New_York
+8518750,"The Battery, NY",40.70055389404297,-74.01416778564453,America/New_York
+8518902,"Dyckman Street, NY",40.8683,-73.9333,America/New_York
+8518903,"Spuyten Duyvil Ck, Ent., Hudson R,, NY",40.8783,-73.925,America/New_York
+8518905,"Riverdale, Hudson River, NY",40.9033,-73.9167,America/New_York
+8518924,"Haverstraw Bay, NY",41.2183,-73.9633,America/New_York
+8518934,"Beacon, Hudson River, NY",41.5,-73.9833,America/New_York
+8518951,"Hyde Park, NY",41.7833,-73.95,America/New_York
+8518962,"Turkey Point Hudson River Nerrs, NY",42.01390075683594,-73.93920135498047,America/New_York
+8518979,"Coxsackie, Hudson River, NY",42.352638244628906,-73.79486083984375,America/New_York
+8518995,"Albany, Hudson River, NY",42.65,-73.7467,America/New_York
+8519050,"Uscg Station Ny, NY",40.612,-74.0598611111111,America/New_York
+8519200,"Port Ivory, Arthur Kill, NY",40.645,-74.18,America/New_York
+8519436,"Great Kills Harbor, NY",40.5433,-74.14,America/New_York
+8519483,"Bergen Point West Reach, NY",40.63911111111111,-74.14630555555556,America/New_York
+8519789,"Rossville, Staten Island, NY",40.5567,-74.2233,America/New_York
+8530095,"Alpine, Hudson River, NJ",40.945,-73.9183,America/New_York
+8530186,"New Milford, Hackensack River, NJ",40.935,-74.03,America/New_York
+8530278,"Hackensack, Hackensack River, NJ",40.88,-74.04,America/New_York
+8530398,"Ridgefield Park Hackensack River, NJ",40.85,-74.03,America/New_York
+8530403,"East Rutherford, Passaic River, NJ",40.8467,-74.12,America/New_York
+8530528,"Carlstadt, Hackensack River, NJ",40.8067,-74.06,America/New_York
+8530531,"North Secaucus, Hack. River, NJ",40.805,-74.0533,America/New_York
+8530586,"Berrys Creek, Fish Creek, NJ",40.7933,-74.0917,America/New_York
+8530591,"Belleville, Passaic River, NJ",40.7867,-74.1467,America/New_York
+8530645,"Union City Hudson River, NJ",40.765,-74.0183,America/New_York
+8530696,"Amtrack Rr Swingbridge, Hackensack River, NJ",40.7517,-74.0967,America/New_York
+8530743,"Point No Point, Passaic River, NJ",40.7317,-74.1167,America/New_York
+8530772,"Kearny Point, Hackensack River, NJ",40.7283,-74.1033,America/New_York
+8530882,"Port Elizabeth, Newark Bay, NJ",40.673301696777344,-74.13999938964844,America/New_York
+8530985,"Constable Hook Upper Bay, NJ",40.655,-74.085,America/New_York
+8531077,"Rahway River #1, NJ",40.5983,-74.2317,America/New_York
+8531142,"Port Reading, NJ",40.55500030517578,-74.24500274658203,America/New_York
+8531156,"Woodbridge Creek #1, NJ",40.545,-74.265,America/New_York
+8531223,"Cheesequake Creek, NJ",40.4533,-74.2733,America/New_York
+8531232,"South Amboy Raritan River, NJ",40.4917,-74.2817,America/New_York
+8531262,"Keasbey, Raritan River, NJ",40.50830078125,-74.31169891357422,America/New_York
+8531369,"North Old Bridge, South River, NJ",40.41669845581055,-74.36329650878906,America/New_York
+8531390,"Sayreville, Raritan River, NJ",40.47829818725586,-74.35669708251953,America/New_York
+8531463,"New Brunswick Raritan River, NJ",40.48830032348633,-74.43499755859375,America/New_York
+8531526,"Matawan Creek Raritan Bay, NJ",40.4333,-74.2183,America/New_York
+8531545,"Keyport, Raritan Bay, NJ",40.44,-74.1983,America/New_York
+8531592,"Waackaack Ck, Raritan Bay, NJ",40.4483,-74.1433,America/New_York
+8531662,"Atlantic Highlands, Sandy Hook, NJ",40.4183,-74.035,America/New_York
+8531680,"Sandy Hook, NJ",40.46689987182617,-74.0093994140625,America/New_York
+8531712,"Highlands Bridge, Shrewsbury River, NJ",40.3967,-73.9817,America/New_York
+8531753,"Oceanic, Navesink River, NJ",40.3767,-74.015,America/New_York
+8531804,"Sea Bright, NJ",40.365,-73.975,America/New_York
+8531833,"Red Bank, Navesink River, NJ",40.355,-74.065,America/New_York
+8531925,"Gooseneck Bridge, Shrewsbury R, NJ",40.3267,-74.0167,America/New_York
+8531942,"Long Branch, Inside, NJ",40.325,-73.9967,America/New_York
+8531991,"Long Branch,Fishing Pier, NJ",40.3033,-73.9767,America/New_York
+8532322,"Shark River Hills, NJ",40.1917,-74.0383,America/New_York
+8532337,"Belmar Outside, NJ",40.185,-74.0083,America/New_York
+8532339,"Avon Shark River, NJ",40.1867,-74.0267,America/New_York
+8532371,"Wall Township, Shark River, NJ",40.1783,-74.0467,America/New_York
+8532585,"Point Pleasant Beach, Manasquan River, NJ",40.105,-74.055,America/New_York
+8532591,"Manasquan Inlet, NJ",40.1017,-74.035,America/New_York
+8532611,"Riviera Beach, Manasquan River, NJ",40.0967,-74.0867,America/New_York
+8532703,"Forge Pond, Metedeconk River, NJ",40.065,-74.135,America/New_York
+8532715,"Beaver Dam Creek, NJ",40.0617,-74.0617,America/New_York
+8532716,"Beaver Dam Creek (Inside), NJ",40.0617,-74.0733,America/New_York
+8532721,"Tall Pines Camp, Metedeconk R., NJ",40.0583,-74.1167,America/New_York
+8532786,"Mantoloking, Barnegat Bay, NJ",40.0367,-74.0533,America/New_York
+8532835,"Kettle Creek, NJ",40.0133,-74.1133,America/New_York
+8532885,"Ocean Beach, Barnegat Bay, NJ",39.9883,-74.0683,America/New_York
+8532921,"Silver Bay, NJ",39.9967,-74.1483,America/New_York
+8533005,"Goose Creek Barnegat Bay, NJ",39.9633,-74.115,America/New_York
+8533051,"Toms River, NJ",39.95000076293945,-74.19830322265625,America/New_York
+8533055,"Coates Point, Barnegat Bay, NJ",39.9483,-74.115,America/New_York
+8533071,"Seaside Heights, NJ",39.9433,-74.035,America/New_York
+8533135,"Seaside Park, NJ",39.9217,-74.0833,America/New_York
+8533141,"Barnegat Pier, Barnegat Bay, NJ",39.9183,-74.11,America/New_York
+8533185,"Sloop Creek, NJ",39.905,-74.1333,America/New_York
+8533295,"Cedar Creek, NJ",39.87,-74.155,America/New_York
+8533345,"Island Beach Barnegat Bay, NJ",39.8517,-74.0883,America/New_York
+8533365,"Stouts Creek, NJ",39.845001220703125,-74.15170288085938,America/New_York
+8533391,"Forked River, NJ",39.825,-74.1733,America/New_York
+8533465,"Oyster Creek, NJ",39.8083,-74.1883,America/New_York
+8533535,"Island Beach, Sedge Islands, NJ",39.7883,-74.0983,America/New_York
+8533541,"Waretown Barnegat Bay, NJ",39.7917,-74.1817,America/New_York
+8533615,"Barnegat Inlet (Inside), NJ",39.7617,-74.1117,America/New_York
+8533631,"High Bar, Barnegat Bay, NJ",39.7567,-74.1283,America/New_York
+8533665,"Double Creek, NJ",39.745,-74.2017,America/New_York
+8533738,"Loveladies, NJ",39.725,-74.1367,America/New_York
+8533780,"Flat Creek, NJ",39.7067,-74.1917,America/New_York
+8533862,"North Beach, Manahawkin Bay, NJ",39.675,-74.16,America/New_York
+8533905,"Mill Creek, Manahawkin Bay, NJ",39.665,-74.2317,America/New_York
+8533909,"Manahawkin Creek, NJ",39.6667,-74.215,America/New_York
+8533935,"Manahawkin Drawbridge, NJ",39.6533,-74.185,America/New_York
+8533941,"Cedar Rkun, Li Egg Harbor, NJ",39.6533,-74.2567,America/New_York
+8533982,"Dinner Point Creek, NJ",39.6567,-74.27,America/New_York
+8533987,"West Creek, Westecunk Creek, NJ",39.6317,-74.2967,America/New_York
+8534002,"Upper Mullica River, NJ",39.625,-74.6417,America/New_York
+8534043,"Wading River, NJ",39.6183,-74.4967,America/New_York
+8534044,"Long Point, Little Egg Harbor, NJ",39.6133,-74.2633,America/New_York
+8534048,"Beach Haven Crest (Inside), NJ",39.6133,-74.21,America/New_York
+8534049,"Parker Run, Little Egg Harbor, NJ",39.6167,-74.31,America/New_York
+8534080,"Tuckerton, Tuckertoncreek, NJ",39.6017,-74.3417,America/New_York
+8534104,"New Gretna, Bass River, NJ",39.5917,-74.4417,America/New_York
+8534117,"Green Bank, Mullica River, NJ",39.6117,-74.59,America/New_York
+8534139,"Tuckerton, Little Egg Harbor, NJ",39.5767,-74.3317,America/New_York
+8534208,"Beach Haven Cg Station, NJ",39.5483,-74.2567,America/New_York
+8534212,"Cramers Boatyard, Mullica River, NJ",39.5483,-74.4617,America/New_York
+8534244,"Graveling Point, NJ",39.540000915527344,-74.38670349121094,America/New_York
+8534256,"Nancote Creek, NJ",39.535,-74.4633,America/New_York
+8534287,"Little Sheepshead Creek, NJ",39.5217,-74.32,America/New_York
+8534319,"Great Bay, Shooting Thorofare, NJ",39.50830078125,-74.32499694824219,America/New_York
+8534393,"Main Marsh Thorofare, NJ",39.4783,-74.3833,America/New_York
+8534468,"Mays Landing, Great Egg Harbor River, NJ",39.4483,-74.7283,America/New_York
+8534496,"Brigantine Channel, NJ",39.435,-74.3633,America/New_York
+8534540,"Absecon, Absecon Creek, NJ",39.4233,-74.5,America/New_York
+8534638,"Absecon Channal, NJ",39.385,-74.425,America/New_York
+8534657,"Pleasantville, Lakes Bay, NJ",39.3817,-74.5183,America/New_York
+8534691,"Great Egg Harbor River, NJ",39.3683,-74.7167,America/New_York
+8534720,"Atlantic City, NJ",39.356666564941406,-74.41805267333984,America/New_York
+8534739,"Dock Thorofare, NJ",39.3517,-74.54,America/New_York
+8534770,"Ventnor City, Fishing Pier, NJ",39.335,-74.4767,America/New_York
+8534778,"Steelmanville, Patcong River, NJ",39.334999084472656,-74.5967025756836,America/New_York
+8534836,"Longport, Risely Channel, NJ",39.3083,-74.5333,America/New_York
+8534883,"Tuckahoe,Tuckahoe River, NJ",39.295,-74.7483,America/New_York
+8534975,"Great Egg Harbor Bay, NJ",39.2883,-74.6283,America/New_York
+8535001,"Cedar Swamp, Tuckahoe River, NJ",39.2467,-74.7183,America/New_York
+8535055,"Bivalve, Maurice River, NJ",39.23249816894531,-75.03279876708984,America/New_York
+8535101,"Corson Inlet, NJ",39.215,-74.6483,America/New_York
+8535163,"Strathmere, Strathmere Bay, NJ",39.2,-74.6567,America/New_York
+8535221,"Ludlam Bay, NJ",39.1767,-74.71,America/New_York
+8535309,"Townsend Sound, NJ",39.1467,-74.75,America/New_York
+8535357,"Stites Sound, NJ",39.12,-74.755,America/New_York
+8535375,"Townsend Inlet, NJ",39.1217,-74.7167,America/New_York
+8535419,"Ingram Thorofare, NJ",39.11,-74.7383,America/New_York
+8535451,"Longreach, NJ",39.1017,-74.755,America/New_York
+8535581,"Stone Harbor, Great Channel, NJ",39.05670166015625,-74.76499938964844,America/New_York
+8535661,"Nummy Is.,Grassy Snd.Ch., NJ",39.0283,-74.8017,America/New_York
+8535695,"Old Turtle, Richardson Sound, NJ",39.0183,-74.8417,America/New_York
+8535726,"West Wildwood, Grassy Sound, NJ",39.005,-74.8267,America/New_York
+8535805,"Swain Channel, NJ",38.98,-74.8633,America/New_York
+8535835,"Wildwood Crest, NJ",38.975,-74.8233,America/New_York
+8535838,"Sunset Lake, NJ",38.9783,-74.8367,America/New_York
+8535901,"Cape May Harbor, NJ",38.9483,-74.8917,America/New_York
+8535902,"Cape Island Creek, NJ",38.9467,-74.9133,America/New_York
+8535962,"Cape May, Atlantic Ocean, NJ",38.93,-74.935,America/New_York
+8536021,"Cape May Point, NJ",38.9467,-74.9717,America/New_York
+8536110,"Cape May, NJ",38.968299865722656,-74.95999908447266,America/New_York
+8536271,"Villas-Jackson Pier, NJ",39.0183,-74.9533,America/New_York
+8536449,"Dias Creek, NJ",39.0833,-74.8867,America/New_York
+8536551,"Upper Bidwell Creek, NJ",39.1183,-74.8683,America/New_York
+8536581,"Bidwell Creek Entrance, Delaware Bay, NJ",39.1283,-74.8917,America/New_York
+8536687,"Sluice Creek, NJ",39.1617,-74.8317,America/New_York
+8536736,"Dennis Creek, Delaware Bay, NJ",39.1783,-74.8517,America/New_York
+8536752,"Upper Dennis Creek, NJ",39.1833,-74.8217,America/New_York
+8536764,"West Creek, Delaware Bay, NJ",39.1883,-74.915,America/New_York
+8536780,"East Point, NJ",39.2,-75.02,America/New_York
+8536801,"Riggins Ditch, NJ",39.2,-74.97,America/New_York
+8536823,"East Creek, NJ",39.2083,-74.9017,America/New_York
+8536848,"Fishing Creek, NJ",39.2167,-75.1583,America/New_York
+8536849,"Lower Dividing Creek, NJ",39.2167,-75.1033,America/New_York
+8536851,"West Creek, NJ",39.2167,-74.925,America/New_York
+8536855,"Riggins Ditch, Heislarville, NJ",39.2183,-74.98,America/New_York
+8536931,"Fortescue Creek, NJ",39.2383,-75.175,America/New_York
+8536935,"Weir Creek, Delaware Bay, NJ",39.25,-75.1283,America/New_York
+8537026,"Hollywood Beach, NJ",39.275,-75.1417,America/New_York
+8537052,"Money Island, NJ",39.285,-75.2383,America/New_York
+8537059,"Mauricetown, Maurice River, NJ",39.285,-74.9917,America/New_York
+8537079,"Newport Ldg., Nantuxent Creek, NJ",39.2917,-75.1983,America/New_York
+8537101,"Cedar Creek, NJ",39.2983,-75.2467,America/New_York
+8537116,"Back Creek, Del. Bay, NJ",39.305,-75.2783,America/New_York
+8537121,"Ship John Shoal, NJ",39.30538888888889,-75.37667777777777,America/New_York
+8537147,"Manumuskin River, NJ",39.3133,-74.985,America/New_York
+8537242,"Manantico Creek, NJ",39.3433,-75.0083,America/New_York
+8537353,"Tyndalls Wharf, NJ",39.3783,-75.235,America/New_York
+8537359,"Millville, NJ",39.3917,-75.0417,America/New_York
+8537374,"Greenwich, Cohansey River, NJ",39.3833,-75.35,America/New_York
+8537416,"Stathems Neck, Stow Ck., NJ",39.4067,-75.405,America/New_York
+8537488,"Pine Island, NJ",39.4217,-75.4283,America/New_York
+8537489,"Raccoon Ditch, NJ",39.4217,-75.3817,America/New_York
+8537535,"Mad Horse Creek, Delaware Bay, NJ",39.4317,-75.4467,America/New_York
+8537562,"Stow Creek,Delaware Bay, NJ",39.4617,-75.4033,America/New_York
+8537614,"Artificial Is., NJ",39.46,-75.5317,America/New_York
+8537667,"Hope Creek, Delaware Bay, NJ",39.4583,-75.495,America/New_York
+8537731,"Lower Alloway Creek, Del.Bay, NJ",39.4967,-75.5167,America/New_York
+8537753,"Hancocks Bridge, Alloway Creek, NJ",39.505,-75.4833,America/New_York
+8537774,"Abbots Meadow, NJ",39.5117,-75.4933,America/New_York
+8537779,"Cooper Creek, NJ",39.5133,-75.4467,America/New_York
+8537889,"Quinton, Alloway Creek, NJ",39.5483,-75.415,America/New_York
+8537961,"Sinnickson Landing, Salem R., NJ",39.57,-75.4983,America/New_York
+8537979,"Salem, NJ",39.5767,-75.4767,America/New_York
+8538231,"Deepwater, Delaware River, NJ",39.6833,-75.51,America/New_York
+8538274,"Auburn, Oldmans Creek, NJ",39.715,-75.36,America/New_York
+8538369,"Pedricktown, Oldmans Creek, NJ",39.7617,-75.4033,America/New_York
+8538438,"Mantua, NJ",39.795,-75.1767,America/New_York
+8538449,"Bridgeport, Racoon Creek, NJ",39.8067,-75.355,America/New_York
+8538512,"Paulsboro, Mantua Creek, NJ",39.835,-75.2383,America/New_York
+8538548,"Woodbury Creek, NJ",39.86,-75.1867,America/New_York
+8538552,"Billingsport, NJ",39.85,-75.25,America/New_York
+8538601,"Westville, Big Timber Creek, NJ",39.8733,-75.1233,America/New_York
+8538848,"North Branch,Rancocas Ck, Del B, NJ",39.9983,-74.8183,America/New_York
+8538853,"Palmyra, Pennsauken Creek, NJ",39.9933,-75.0283,America/New_York
+8538875,"Pompeston Creek, Delaware River, NJ",40.0133,-75.0083,America/New_York
+8538886,"Tacony-Palmyra Bridge, NJ",40.01190185546875,-75.04299926757812,America/New_York
+8538921,"Bridgeboro, Rancocas Creek, NJ",40.0283,-74.9317,America/New_York
+8539094,"Burlington, Delaware River, NJ",40.08169937133789,-74.86969757080078,America/New_York
+8539487,"Fieldsboro, Delaware River, NJ",40.1367,-74.7367,America/New_York
+8539993,"Trenton Marine Terminal, NJ",40.1883,-74.755,America/New_York
+8540433,"Marcus Hook, PA",39.81180555555556,-75.4095,America/New_York
+8542699,"Norwood, Darby Creek, PA",39.88,-75.29,America/New_York
+8542885,"Tinicum 4, Darby Creek, PA",39.8783,-75.2767,America/New_York
+8543024,"Tinicum 3, Darby Creek, PA",39.8867,-75.265,America/New_York
+8545240,"Philadelphia, PA",39.93305555555556,-75.14198055555556,America/New_York
+8545530,"Philadelphia (Pier 11 North), Del. River, PA",39.9533,-75.1383,America/New_York
+8546252,"Bridesburg, PA",39.97968333333333,-75.07931666666667,America/New_York
+8548989,"Newbold, PA",40.13733333333333,-74.75183333333334,America/New_York
+8549424,"Meenan, PA",40.1283,-74.8233,America/New_York
+8550438,"Edgemoor, DE",39.75,-75.4933,America/New_York
+8550714,"Wilmington, Christina R. Ent., DE",39.7183,-75.52,America/New_York
+8551201,"New Castle, DE",39.6567,-75.5617,America/New_York
+8551702,"Pea Patch Island, DE",39.5833,-75.5733,America/New_York
+8551762,"Delaware City, DE",39.58219444444445,-75.58897222222222,America/New_York
+8551851,"Delaware City Bridge, DE",39.57,-75.59,America/New_York
+8551910,"Reedy Point, DE",39.5583333,-75.5719444,America/New_York
+8554399,"Mahon River Entrance, DE",39.185,-75.4,America/New_York
+8555388,"Murderkill River Entrance, DE",39.0583,-75.3967,America/New_York
+8555889,"Brandywine Shoal Light, DE",38.98666666666667,-75.11333333333333,America/New_York
+8556198,"Mispillion River Entrance, DE",38.945,-75.3133,America/New_York
+8557380,"Lewes, DE",38.78283333333334,-75.11927777777778,America/New_York
+8557863,"Rehoboth Beach, DE",38.72,-75.0833,America/New_York
+8558690,"Indian River Inlet, DE",38.61,-75.07,America/New_York
+8558814,"Rosedale Beach, Indian River, DE",38.59149932861328,-75.21160125732422,America/New_York
+8559957,"Little Assawoman Bay, DE",38.45500183105469,-75.05829620361328,America/New_York
+8570255,"Keydash, Isle Of Wight Bay, MD",38.3417,-75.085,America/New_York
+8570280,"Ocean City, Fishing Pier, MD",38.3267,-75.0833,America/New_York
+8570282,"Ocean City, MD",38.3317,-75.09,America/New_York
+8570283,"Ocean City Inlet, MD",38.32833,-75.09166666666667,America/New_York
+8570536,"South Point, Sinepuxent Neck, Chinc. Bay, MD",38.215,-75.1917,America/New_York
+8570649,"Public Landing, Chincoteague Bay, MD",38.1483,-75.285,America/New_York
+8570691,"Buntings Bridge, MD",38.13894444444445,-75.18352777777778,America/New_York
+8571091,"Crisfield, MD",37.9767,-75.8633,America/New_York
+8571117,"Ewell, Smith Island, MD",37.995,-76.0317,America/New_York
+8571181,"Colbourn Creek, Big Annemessex R, MD",38.0483,-75.8033,America/New_York
+8571214,"Holland Bar Light, MD",38.0683,-76.0967,America/New_York
+8571351,"Chance, Nanticoke River, MD",38.1717,-75.945,America/New_York
+8571359,"Snow Hill, MD",38.17833,-75.39666666666666,America/New_York
+8571402,"Hooper Strait Lighthouse, MD",38.2267,-76.0767,America/New_York
+8571421,"Bishops Head, MD",38.22,-76.0383,America/New_York
+8571485,"Whitehaven, Wicomico River, MD",38.2683,-75.7883,America/New_York
+8571519,"Middle Hoopers Island, MD",38.2967,-76.205,America/New_York
+8571559,"Mccready'S Creek, MD",38.29999923706055,-76.00499725341797,America/New_York
+8571579,"Barren Island, MD",38.3417,-76.265,America/New_York
+8571616,"Salisbury, Wicomico River, MD",38.3650016784668,-75.60669708251953,America/New_York
+8571702,"Beaverdam Creek, MD",38.42833,-76.23666666666666,America/New_York
+8571773,"Vienna, MD",38.48333,-75.81833333333333,America/New_York
+8571858,"Sharpstown, Nanticoke River, MD",38.54499816894531,-75.72329711914062,America/New_York
+8571892,"Cambridge, MD",38.5725,-76.0616667,America/New_York
+8571901,"Avalon, Tilganan Island, MD",38.71,-76.335,America/New_York
+8571979,"Tilghman Island, Ferry Cove, MD",38.765,-76.3283,America/New_York
+8572271,"Poplar Island, MD",38.75833333333333,-76.375,America/New_York
+8572342,"St. Michaels, Miles River, MD",38.7867,-76.2217,America/New_York
+8572467,"Kent Point, MD",38.8367,-76.3733,America/New_York
+8572669,"Hillsboro, MD",38.9167,-75.945,America/New_York
+8572770,"Matapeake, MD",38.9567,-76.355,America/New_York
+8572955,"Love Point Pier, MD",39.0317,-76.3017,America/New_York
+8573137,"Cliff'S Wharf, MD",39.11,-76.1383,America/New_York
+8573211,"Deep Landing, Swan Creek, MD",39.145,-76.26,America/New_York
+8573349,"Crumpton, MD",39.245,-75.925,America/New_York
+8573364,"Tolchester Beach, MD",39.21344444444444,-76.24455555555555,America/New_York
+8573704,"Betterton, MD",39.3717,-76.0633,America/New_York
+8573903,"Town Point Wharf, MD",39.5033,-75.9167,America/New_York
+8573927,"Chesapeake City, MD",39.5266667,-75.81,America/New_York
+8574008,"Port Deposit, MD",39.6033,-76.1133,America/New_York
+8574070,"Havre De Grace, MD",39.5367,-76.09,America/New_York
+8574459,"Pond Point (Aberdeen P.G.), Bush River, MD",39.3883,-76.255,America/New_York
+8574680,"Baltimore, MD",39.266693115234375,-76.57830810546875,America/New_York
+8574683,"Fort Mchenry Marsh, MD",39.2617,-76.585,America/New_York
+8574821,"Hawkins Point, Patapsco River, MD",39.2083,-76.5333,America/New_York
+8574857,"North Point, MD",39.1967,-76.445,America/New_York
+8574931,"Stony Creek, MD",39.1633,-76.5267,America/New_York
+8575109,"Cornfield Creek, Magothy River, MD",39.1,-76.445,America/New_York
+8575512,"Annapolis, MD",38.983882904052734,-76.48003387451172,America/New_York
+8575550,"Gingerville Creek, South River, MD",38.9583,-76.555,America/New_York
+8575787,"Rhode River, MD",38.8867,-76.54,America/New_York
+8576363,"Chesapeake Beach, MD",38.7,-76.5333,America/New_York
+8577004,"Long Beach, MD",38.465,-76.4733,America/New_York
+8577188,"Cove Point, MD",38.3917,-76.3983,America/New_York
+8577330,"Solomons Island, MD",38.31669998168945,-76.45169830322266,America/New_York
+8578002,"Point Lookout, Potomac River, MD",38.04,-76.3233,America/New_York
+8578240,"Piney Point, MD",38.1333333,-76.5333333,America/New_York
+8579542,"Lower Marlboro, MD",38.655,-76.68333333333334,America/New_York
+8579997,"Bladensburg, Anacostia River, MD",38.9333,-76.9383,America/New_York
+8593005,"Washington Navy Yard,D.C., DC",38.8717,-76.995,America/New_York
+8593545,"Kingman Lake, Anacostia River, DC",38.895,-76.9683,America/New_York
+8593909,"East Lake, Anacostia River, DC",38.91,-76.955,America/New_York
+8594900,"Washington, DC",38.87333333333334,-77.02166666666666,America/New_York
+8630111,"Jesters Island, Chincoteague Bay, VA",37.9817008972168,-75.30169677734375,America/New_York
+8630249,"Chincoteague, Uscg Station, VA",37.93170166015625,-75.38330078125,America/New_York
+8630308,"Chincoteague Channel, South End, VA",37.9067,-75.405,America/New_York
+8630315,"Southern Chincoteague Island, VA",37.902400970458984,-75.40789794921875,America/New_York
+8631044,"Wachapreague, VA",37.60777777777778,-75.68583333333333,America/New_York
+8631542,"Sand Shoal Inlet, Cobb Island, VA",37.3017,-75.7783,America/New_York
+8631591,"Oyster Harbor, VA",37.2883,-75.925,America/New_York
+8632200,"Kiptopeke, VA",37.165199279785156,-75.9884033203125,America/New_York
+8632366,"Cape Charles Hbr (U.S. G. Wharf), VA",37.2633,-76.02,America/New_York
+8632837,"Rappahannock Light, VA",37.538299560546875,-76.01499938964844,America/New_York
+8632869,"Gaskins Pt., Occohannock Creek, VA",37.5567,-75.9167,America/New_York
+8633091,"Harborton, Pungoteague Creek, VA",37.6667,-75.8333,America/New_York
+8633362,"Schooner Bay, VA",37.7633,-75.7733,America/New_York
+8633532,"Tangier Island, VA",37.8283,-75.9933,America/New_York
+8633777,"Saxis, Starling Creek, VA",37.92169952392578,-75.72830200195312,America/New_York
+8635027,"Dahlgren, VA",38.31975277777778,-77.03659722222223,America/New_York
+8635150,"Colonial Beach, Potomac River, VA",38.2517,-76.96,America/New_York
+8635257,"Rappahannock Bend, VA",38.2133,-77.2433,America/New_York
+8635750,"Lewisetta, VA",37.99610137939453,-76.46440124511719,America/New_York
+8635985,"Wares Wharf, VA",37.8733,-76.7833,America/New_York
+8636128,"Fleet Pt, Great Wicomico River, VA",37.8133,-76.275,America/New_York
+8636580,"Windmill Point, VA",37.6155,-76.28977777777777,America/New_York
+8636653,"Lester Manor, VA",37.5833,-76.99,America/New_York
+8636654,"New Mill Creek, (Greys Point), VA",37.5833,-76.4183,America/New_York
+8636941,"Richmond Deepwater Terminal, James River, VA",37.45955555555555,-77.42077777777777,America/New_York
+8637624,"Gloucester Point, VA",37.2467,-76.5,America/New_York
+8637689,"Yorktown Uscg Training Center, VA",37.2265,-76.47880555555555,America/New_York
+8637712,"Jamestown, VA",37.22010040283203,-76.79139709472656,America/New_York
+8638017,"Fort Eustis (Marad), James River, VA",37.13822222222223,-76.62275,America/New_York
+8638339,"Western Branch, VA",36.82322222222222,-76.39911111111111,America/New_York
+8638421,"Burwell Bay, James River, VA",37.0567,-76.6683,America/New_York
+8638424,"Kingsmill, VA",37.22,-76.6633,America/New_York
+8638433,"Scotland, VA",37.185,-76.7833,America/New_York
+8638445,"Lanexa, Chickahominy River, VA",37.4033,-76.9117,America/New_York
+8638449,"Claremont, James River, VA",37.2317,-76.9483,America/New_York
+8638450,"Tettington, James River, VA",37.24,-76.9433,America/New_York
+8638464,"Wilcox Wharf, VA",37.315,-77.0983,America/New_York
+8638476,"Jordan Point, James River, VA",37.3133,-77.2233,America/New_York
+8638481,"Hopewell, VA",37.3133,-77.27,America/New_York
+8638489,"Puddledock, VA",37.2667,-77.3717,America/New_York
+8638491,"Chester, James River, VA",37.3833,-77.3783,America/New_York
+8638495,"Richmond River Locks, James River, VA",37.525,-77.42,America/New_York
+8638610,"Sewells Point, VA",36.9427778,-76.3286111,America/New_York
+8638660,"Portsmouth, Norfolk Naval Shipyard, VA",36.8217,-76.2933,America/New_York
+8638671,"Lafayette River, VA",36.88422222222222,-76.27585833333333,America/New_York
+8638863,"Chesapeake Bay Bridge Tunnel, VA",36.96670150756836,-76.11329650878906,America/New_York
+8638888,"Va. Pilots Dock, Lynnhaven Inlet, VA",36.9067,-76.09,America/New_York
+8638901,"Cbbt, Chesapeake Channel, VA",37.032901763916016,-76.08329772949219,America/New_York
+8638916,"Long Creek, Lynnhaven Bay, VA",36.9033,-76.07,America/New_York
+8638923,"Broad Bay Canal East, VA",36.9017,-76.0617,America/New_York
+8638999,"Cape Henry, VA",36.93000030517578,-76.00666809082031,America/New_York
+8639207,"Rudee Inlet, VA",36.8317,-75.9733,America/New_York
+8639214,"Rudee Heights, Lake Wesley, VA",36.825,-75.975,America/New_York
+8639219,"South End, Lake Rudee, VA",36.825,-75.9817,America/New_York
+8639348,"Money Point, VA",36.77819444444445,-76.30186111111111,America/New_York
+8639414,"Deep Creek Entrance, VA",36.755,-76.2933,America/New_York
+8639428,"Sandbridge, VA",36.6917,-75.92,America/New_York
+8651370,"Duck, NC",36.18330001831055,-75.74669647216797,America/New_York
+8652226,"Jennette'S Pier, NC",35.91,-75.59169444444444,America/New_York
+8652247,"Manns Harbor, NC",35.9033,-75.77,America/New_York
+8652437,"Oyster Creek, NC",35.845,-75.655,America/New_York
+8652547,"Roanoke Marshes Light, NC",35.8117,-75.7,America/New_York
+8652587,"Oregon Inlet Marina, NC",35.79569444444444,-75.54819444444445,America/New_York
+8652648,"Old House Channel, NC",35.77669906616211,-75.58499908447266,America/New_York
+8652678,"Uscg Lifeboat Station, Oregon Inlet, NC",35.7683,-75.5267,America/New_York
+8653215,"Rodanthe, Pamlico Sound, NC",35.595001220703125,-75.4717025756836,America/New_York
+8653244,"Pungo River Nc 45, NC",35.585201263427734,-76.48560333251953,America/New_York
+8653471,"Engelhard, NC",35.5093994140625,-75.98889923095703,America/New_York
+8653951,"Peter'S Ditch, NC",35.35013888888889,-75.51202777777777,America/New_York
+8654400,"Cape Hatteras Fishing Pier, NC",35.2233,-75.635,America/New_York
+8654467,"Uscg Station Hatteras, NC",35.20861111111111,-75.70419444444444,America/New_York
+8654769,"Ocracoke, Pamlico Sound, NC",35.115501403808594,-75.98690032958984,America/New_York
+8655133,"Oriental, Neuse River, NC",35.024600982666016,-76.69180297851562,America/New_York
+8655151,"Cedar Island, NC",35.01890182495117,-76.31430053710938,America/New_York
+8656084,"Core Creek Bridge, NC",34.82500076293945,-76.69000244140625,America/New_York
+8656201,"Davis, Core Sound, NC",34.79679870605469,-76.45549774169922,America/New_York
+8656225,"North River Bridge, Bettie, NC",34.7917,-76.6083,America/New_York
+8656306,"Morehead-Beaufort Y.C., Newport River, NC",34.7683,-76.6717,America/New_York
+8656451,"Gallant Channel, NC",34.7283,-76.6683,America/New_York
+8656467,"Spooners Creek, NC",34.725,-76.8033,America/New_York
+8656483,"Beaufort, Duke Marine Lab, NC",34.71733055555556,-76.67065833333334,America/New_York
+8656502,"Morehead City Harbor, Harbor Channel, NC",34.720001220703125,-76.71080017089844,America/New_York
+8656503,"Harkers Island Bridge, NC",34.715,-76.5783,America/New_York
+8656518,"Beaufort, Taylor Creek, NC",34.7117,-76.645,America/New_York
+8656539,"Lenoxville Point, North River Channel, NC",34.7083,-76.62,America/New_York
+8656566,"Coral Bay, Atlantic Beach, NC",34.7,-76.7683,America/New_York
+8656571,"Fort Macon, NC",34.6983,-76.6817,America/New_York
+8656590,"Atlantic Beach Triple S Pier, NC",34.6933,-76.7117,America/New_York
+8656613,"Swansboro, East Corbett Ave Bridge, NC",34.68659973144531,-77.11810302734375,America/New_York
+8656841,"Cape Lookout, Lookout Bight, NC",34.6133,-76.5383,America/New_York
+8656937,"Cape Lookout, Atlantic Ocean, NC",34.6083,-76.5283,America/New_York
+8657002,"Sneads Ferry, New River, NC",34.57630157470703,-77.39540100097656,America/New_York
+8657419,"Ocean City, Fishing Pier, NC",34.4517,-77.495,America/New_York
+8657813,"Hampstead, NC",34.33940124511719,-77.70600128173828,America/New_York
+8658120,"Wilmington, NC",34.22669982910156,-77.95330047607422,America/New_York
+8658145,"Shinn Point, NC",34.217899322509766,-77.81230163574219,America/New_York
+8658163,"Wrightsville Beach, NC",34.21330555555556,-77.78669444444445,America/New_York
+8658501,"Orton Point, Cape Fear River, NC",34.0567,-77.94,America/New_York
+8658559,"Wilmington Beach, NC",34.0317,-77.8933,America/New_York
+8658579,"Sunny Point, Motsu North Wharf, NC",34.0233,-77.9467,America/New_York
+8658622,"Reaves Point, Motsu Center, NC",34.0033,-77.955,America/New_York
+8658654,"Motsu South Wharf #1, Cape Fear River, NC",33.99,-77.9567,America/New_York
+8658715,"Federal Point, Cape Fear River, NC",33.9617,-77.94,America/New_York
+8658741,"Zekes Island, Cape Fear River, NC",33.95,-77.9517,America/New_York
+8658901,"Bald Head Island, Cape Fear River, NC",33.88,-78.0017,America/New_York
+8659084,"Southport, NC",33.915,-78.0183,America/New_York
+8659182,"Oak Island, Atlantic Ocean, NC",33.9017,-78.0817,America/New_York
+8659414,"Varnamtown, Lockwoods Folly River, NC",33.933101654052734,-78.21890258789062,America/New_York
+8659665,"Bowen Point, Shallotte Inlet, NC",33.915000915527344,-78.37329864501953,America/New_York
+8659897,"Sunset Beach, NC",33.865,-78.5067,America/New_York
+8660098,"Little River Neck, SC",33.87,-78.5733,America/New_York
+8660121,"Little River Town, Little R., SC",33.87,-78.6083,America/New_York
+8660147,"Dunn Sound, North, Little River, SC",33.86,-78.58,America/New_York
+8660148,"Dunn Sound, Little River, SC",33.8583,-78.57,America/New_York
+8660166,"Nixon Crossroads, Little River, SC",33.855,-78.6483,America/New_York
+8660195,"Dunn Sound, West End, SC",33.8517,-78.5883,America/New_York
+8660265,"Cherry Grove, Inside, SC",33.835,-78.6333,America/New_York
+8660266,"Hog Inlet Pier, SC",33.8367,-78.6067,America/New_York
+8660401,"Myrtle Beach Airport, SC",33.82,-78.7183,America/New_York
+8660642,"North Myrtle Beach, SC",33.766700744628906,-78.81500244140625,America/New_York
+8660854,"Combination Bridge, SC",33.7133,-78.9217,America/New_York
+8660983,"Socastee Bridge, SC",33.6867,-79.005,America/New_York
+8661070,"Springmaid Pier, SC",33.654998779296875,-78.91829681396484,America/New_York
+8661093,"Yauhannah Bridge, Pee Dee River, SC",33.66,-79.155,America/New_York
+8661119,"Sandy Island North, Bull Cr., SC",33.6017,-79.1183,America/New_York
+8661139,"Bucksport, Waccamaw River, SC",33.6467,-79.095,America/New_York
+8661299,"Lower Topsaw Landing, Pee Dee River, SC",33.6083,-79.1517,America/New_York
+8661347,"Waccamaw River, S. Of Bull Cr., SC",33.5967,-79.0983,America/New_York
+8661419,"Garden City Bridge, Murrells Inlet, SC",33.5783,-79.0033,America/New_York
+8661437,"Garden City Pier, Murrells Inlet, SC",33.575,-78.9967,America/New_York
+8661493,"Wachesaw Landing, Waccamaw R., SC",33.560001373291016,-79.08499908447266,America/New_York
+8661529,"Capt. Alex'S Marina, Murrells, SC",33.5517,-79.0367,America/New_York
+8661559,"Smith'S Dock, Murrells Inlet, SC",33.545,-79.045,America/New_York
+8661582,"Divine'S Dock, Murrells Inlet, SC",33.5417,-79.0283,America/New_York
+8661593,"Winea Plantation, Black River, SC",33.535,-79.3883,America/New_York
+8661608,"Allston Creek, Murrells Inlet, SC",33.5317,-79.0533,America/New_York
+8661609,"Oaks Cr. Inlet, Murrells Inlet, SC",33.53,-79.0433,America/New_York
+8661684,"Oaks Creek, Upper End, Murrells Inlet, SC",33.5117,-79.0683,America/New_York
+8661703,"Sandy Island, Thoroughfare Creek, SC",33.5067,-79.145,America/New_York
+8661734,"Mt. Pleasant Plant., Black R., SC",33.495,-79.4617,America/New_York
+8661989,"Bennett'S Dock, SC",33.435,-79.1267,America/New_York
+8661991,"Hagley, Waccamaw River, SC",33.435,-79.1817,America/New_York
+8662006,"Pawleys Island Pier, Atlantic Ocean, SC",33.4317,-79.1167,America/New_York
+8662071,"Pawleys Inlet, Wards Dock, SC",33.4117,-79.135,America/New_York
+8662216,"Cumberland, Sampit River, SC",33.37,-79.4333,America/New_York
+8662245,"Oyster Landing (N Inlet Estuary), SC",33.35169982910156,-79.18669891357422,America/New_York
+8662299,"Clambank Creek Dock, Goat Island, SC",33.3333,-79.1933,America/New_York
+8662405,"Jamestown Bridge, Santee River, SC",33.305,-79.6783,America/New_York
+8662549,"South Island Ferry, Winyah Bay, SC",33.2517,-79.2683,America/New_York
+8662670,"Pleasant Hill Landing, Santee River, SC",33.245,-79.5217,America/New_York
+8662746,"Winyah Bay, South Island Plantation, SC",33.235,-79.2033,America/New_York
+8662747,"Georgetown Lt.House, Winyah Bay, SC",33.2233,-79.185,America/New_York
+8662793,"N. Santee Bridge, N. Santee R., SC",33.21,-79.385,America/New_York
+8662796,"Minim Creek, SC",33.195,-79.275,America/New_York
+8662799,"Us Highway 17, South Santee River, SC",33.185,-79.4067,America/New_York
+8662926,"Georgetown, Sampit River Ent., SC",33.361698150634766,-79.27999877929688,America/New_York
+8662931,"Waccamaw River Entrance, SC",33.36669921875,-79.25499725341797,America/New_York
+8662953,"Windsor Plantation, Black River, SC",33.415,-79.25,America/New_York
+8663101,"Cape Romain, SC",33.025,-79.3483,America/New_York
+8663219,"S. Santee R.,Iww(4 Mi. Canal Cr), SC",33.15420150756836,-79.35440063476562,America/New_York
+8663381,"Cedar Island Pt, South Santee R, SC",33.12,-79.27,America/New_York
+8663461,"Casino Creek, SC",33.1083,-79.3933,America/New_York
+8663535,"Quinby Bridge, Quinby Creek, SC",33.095,-79.8083,America/New_York
+8663539,"Pimlico, West Branch Cooper River, SC",33.095,-79.9533,America/New_York
+8663618,"Mc Clellanville, Jeremy Creek, SC",33.0783,-79.46,America/New_York
+8663665,"Richmond Plantation, E. Br. Cooper River, SC",33.0767,-79.855,America/New_York
+8663757,"Dupont, Dean Hall, Cooper R., SC",33.0583,-79.9367,America/New_York
+8663781,"French Quarter Creek, SC",33.055,-79.88,America/New_York
+8663858,"Buck Hall, Awendaw Creek, SC",33.040000915527344,-79.55999755859375,America/New_York
+8664022,"Gen. Dynamics Pier, Cooper R., SC",33.0083,-79.9233,America/New_York
+8664442,"Moores Landing, Sewee Bay, SC",32.9367,-79.655,America/New_York
+8664515,"Snow Point, 0.4 Mile N Of, Cooper River, SC",32.9483,-79.9317,America/New_York
+8664531,"Bacon Bridge, Ashley River, SC",32.9583,-80.2033,America/New_York
+8664541,"Yeamans Hall, Goose Creek, SC",32.925,-79.9867,America/New_York
+8664545,"Cainhoy, Wando River, SC",32.9267,-79.83,America/New_York
+8664589,"Hanahan, Turkey Creek, SC",32.9183,-80.0117,America/New_York
+8664611,"Big Paradise Island, Wando River, SC",32.915,-79.7467,America/New_York
+8664621,"Bull Island, Summerhouse Creek, SC",32.9133,-79.6167,America/New_York
+8664662,"Army Depot, SC",32.91,-79.9517,America/New_York
+8664688,"Clouter Creek, North, SC",32.9067,-79.935,America/New_York
+8664699,"North Charleston, Ashley River, SC",32.900299072265625,-80.11750030517578,America/New_York
+8664701,"Nowell Creek, SC",32.9,-79.9,America/New_York
+8664782,"Horlbeck Creek, Wando River, SC",32.885,-79.845,America/New_York
+8664801,"Price Creek, North Capers Island, SC",32.8817,-79.6583,America/New_York
+8664878,"Old Capers Landing, Capers Island, SC",32.87,-79.6867,America/New_York
+8664941,"South Capers Island, SC",32.8567,-79.7067,America/New_York
+8664945,"Clouter Creek, South, SC",32.86,-79.9383,America/New_York
+8664992,"North Dewee'S Island, SC",32.85,-79.7033,America/New_York
+8665002,"Drayton, Bees Ferry, Ashley River, SC",32.8483,-80.0517,America/New_York
+8665099,"I-526 Bridge, Ashley River, SC",32.8367,-80.0217,America/New_York
+8665101,"Cosgrove Bridge, Ashley River, SC",32.835,-79.9867,America/New_York
+8665111,"South Dewees Island, Dewees Inlet, SC",32.8333,-79.7267,America/New_York
+8665167,"Hamlin Sound, SC",32.8267,-79.7867,America/New_York
+8665192,"Wando River Entrance, Hobcaw Point, SC",32.8217,-79.9,America/New_York
+8665257,"Edisto River, South Of Canaday Landing, SC",32.8133,-80.4067,America/New_York
+8665387,"Hamlin Creek, Isle Of Palms, SC",32.7867,-79.7917,America/New_York
+8665424,"Highway 171 Bridge, Folly Creek, SC",32.675,-79.9517,America/New_York
+8665426,"Shem Creek At 17, SC",32.7933,-79.8817,America/New_York
+8665475,"Limehouse Bridge, Stono River, SC",32.7867,-80.105,America/New_York
+8665494,"Isle Of Palms Pier, SC",32.7833,-79.785,America/New_York
+8665495,"South Ashley Bridge, Ashley River, SC",32.7833,-79.9567,America/New_York
+8665530,"Charleston, SC",32.7808333,-79.9236111,America/New_York
+8665552,"Breach Inlet, SC",32.7767,-79.8117,America/New_York
+8665567,"Ben Sawyer Bridge, Iww, SC",32.7733,-79.8417,America/New_York
+8665589,"Sandblasters, Penny'S Creek, SC",32.77,-80.0633,America/New_York
+8665599,"Penneys Creek W Entrance, Stono River, SC",32.7683,-80.07,America/New_York
+8665637,"The Cove, Ft Moultrie, Charleston Harbor, SC",32.7633,-79.8567,America/New_York
+8665641,"Elliott Cut Entrance, Stono River, SC",32.7633,-80.0017,America/New_York
+8665728,"Fort Sumter, Charleston Harbor, SC",32.7533,-79.8767,America/New_York
+8665737,"Jacksonboro Camp, South Edisto River, SC",32.7533,-80.45,America/New_York
+8665763,"Hollywood, Wadmalaw River, SC",32.746700286865234,-80.16500091552734,America/New_York
+8666017,"Edisto River, South Of Penny Creek, SC",32.715,-80.4367,America/New_York
+8666101,"Johns Island, Church Creek, SC",32.7067,-80.1567,America/New_York
+8666131,"Lower Toogoodoo Creek, SC",32.7033,-80.2783,America/New_York
+8666167,"Hope Creek, SC",32.7,-80.4267,America/New_York
+8666217,"Yonges Island, Wadmalaw River, SC",32.695,-80.2233,America/New_York
+8666282,"Oak Branch, Bohicket Creek, SC",32.6833,-80.0967,America/New_York
+8666283,"Mc Dermids Pier, Stono River, SC",32.6767,-80.0067,America/New_York
+8666359,"Bluff Plantation, Combahee River, SC",32.6833,-80.7383,America/New_York
+8666367,"Willtown Bluff, SC",32.6817,-80.4167,America/New_York
+8666433,"Toogoodoo Creek, SC",32.6683,-80.2933,America/New_York
+8666467,"Folly River, North, SC",32.67,-79.9167,America/New_York
+8666616,"South Edisto River At Dawhoo River, SC",32.6567,-80.3917,America/New_York
+8666652,"Folly River Bridge, Folly River, SC",32.6617,-79.945,America/New_York
+8666659,"Combahee River At Us Hwy. 17, SC",32.6517,-80.6833,America/New_York
+8666699,"Bluff Point, Wadmalaw River, SC",32.6467,-80.2567,America/New_York
+8666749,"Airy Hall, Ashepoo River, SC",32.6317,-80.4717,America/New_York
+8666767,"Snake Island, Stono River, SC",32.64,-80.015,America/New_York
+8666775,"Leadenwah Creek, SC",32.6367,-80.2017,America/New_York
+8666799,"Dawhoo Bridge, Dawhoo River, SC",32.6367,-80.3417,America/New_York
+8666918,"Ho-Non-Wah Boyscout Camp, Bohicket Cr, SC",32.625,-80.1667,America/New_York
+8667062,"Kiawah Bridge, Kiawah River, SC",32.6033,-80.1317,America/New_York
+8667067,"Pine Landing, South Edisto R., SC",32.6033,-80.3883,America/New_York
+8667074,"Wiggins, Chehaw River, SC",32.6017,-80.5417,America/New_York
+8667075,"Steamboat Creek Landing, SC",32.6033,-80.2867,America/New_York
+8667172,"Sheldon, Huspa Creek, SC",32.5833,-80.7833,America/New_York
+8667178,"Point Of Pines, N. Edisto R., SC",32.585,-80.2283,America/New_York
+8667199,"Wimbee Creek, SC",32.5783,-80.67,America/New_York
+8667209,"Musselboro Island, Mosquito Creek, SC",32.5783,-80.4483,America/New_York
+8667259,"Fields Point, Combahee R., SC",32.5683,-80.5533,America/New_York
+8667281,"Ocella Creek, SC",32.5617,-80.2383,America/New_York
+8667295,"White House Woods, Mosquito Creek, SC",32.55870056152344,-80.45439910888672,America/New_York
+8667309,"Fenwick Island, South Edisto River, SC",32.56,-80.4183,America/New_York
+8667411,"Lobeco, Whale Branch, Coosaw River, SC",32.5733,-80.745,America/New_York
+8667425,"Peters Point, St. Pierre Creek, SC",32.54,-80.34,America/New_York
+8667524,"Seabrook, Ashepoo River, SC",32.5233,-80.4067,America/New_York
+8667612,"Air Station Beaufort, Mccalleys Creek, SC",32.50189971923828,-80.68489837646484,America/New_York
+8667630,"Edisto Beach, Edisto Island, SC",32.5017,-80.2967,America/New_York
+8667633,"Clarendon Plantation, SC",32.5025,-80.7841,America/New_York
+8667676,"Edisto Marina, Big Bay Creek, SC",32.4933,-80.34,America/New_York
+8667679,"Carter'S Dock, Big Bay Creek, SC",32.4933,-80.3267,America/New_York
+8667733,"Sams Point, Lucy Point Creek, SC",32.4833,-80.6,America/New_York
+8667783,"Otter Island, St. Helena Sound, SC",32.4767,-80.42,America/New_York
+8667909,"Salt Creek At Rt. 21, SC",32.45,-80.7317,America/New_York
+8667972,"Eddings Point Creek, SC",32.4467,-80.5333,America/New_York
+8667982,"Jenkins Creek, SC",32.44,-80.5533,America/New_York
+8667999,"Beaufort, SC",32.43,-80.675,America/New_York
+8668092,"Battery Creek, SC",32.4133,-80.7,America/New_York
+8668146,"Harbor River Bridge, St. Helena Sound, SC",32.4033,-80.4533,America/New_York
+8668155,"Distant Island Creek, Upper End, SC",32.4017,-80.6533,America/New_York
+8668223,"Broad River Bridge, SC",32.3867,-80.7767,America/New_York
+8668227,"Johnson'S Creek, Harbor Island, SC",32.3917,-80.4383,America/New_York
+8668301,"Chechessee Bluff, Chechessee R., SC",32.3733,-80.8367,America/New_York
+8668482,"Baileys Landing, Okatee River, SC",32.3467,-80.89,America/New_York
+8668498,"Fripps Inlet, SC",32.34,-80.465,America/New_York
+8668511,"Callawassie Island Bridge, SC",32.3417,-80.8567,America/New_York
+8668601,"Station Creek, SC",32.325,-80.6017,America/New_York
+8668619,"Colleton River Entrance, SC",32.3217,-80.7917,America/New_York
+8668701,"Purrysburg Landing, Savannah River, SC",32.3033,-81.1217,America/New_York
+8668918,"Ribaut Island, Skull Creek, SC",32.2667,-80.7367,America/New_York
+8669103,"Bluffton, May River, SC",32.23,-80.8617,America/New_York
+8669133,"Skull Creek South, SC",32.2233,-80.7717,America/New_York
+8669167,"Port Royal Pltn., Hilton Head, SC",32.22,-80.6683,America/New_York
+8669262,"North Bull Island, May River, SC",32.2,-80.815,America/New_York
+8669338,"Broad Creek, SC",32.185,-80.7533,America/New_York
+8669415,"U.S. Highway 17, Little Back River, SC",32.165,-81.13,America/New_York
+8669601,"Pine Island, Ramshorn Creek, SC",32.1217,-80.8983,America/New_York
+8669691,"Daufuskie Landing, New River, SC",32.1033,-80.895,America/New_York
+8669801,"Bloody Point, New River, SC",32.0817,-80.8783,America/New_York
+8670424,"Port Wentworth, GA",32.14330555555556,-81.14169444444444,America/New_York
+8670870,"Fort Pulaski, GA",32.03469444444445,-80.90302777777778,America/New_York
+8671086,"Skidaway Institute, Skidaway River, GA",31.99,-81.0233,America/New_York
+8671314,"Halfmoon Reef, Halfmoon River, GA",31.963300704956055,-80.94329833984375,America/New_York
+8671315,"Priest Landing, Wilmington River, GA",31.963300704956055,-81.01170349121094,America/New_York
+8671489,"Richmond Hill, Ogeechee River, GA",31.94300079345703,-81.28980255126953,America/New_York
+8671946,"Little Wassaw Island, Green Island Sound, GA",31.889699935913086,-81.06169891357422,America/New_York
+8672667,"Range A Light, Bear River, GA",31.7933,-81.1817,America/New_York
+8672875,"Sunbury, Sunbury Channel, GA",31.7667,-81.2783,America/New_York
+8673171,"South Ossabaw Island, Bear River, GA",31.72302777777778,-81.1417,America/New_York
+8673381,"Halfmoon, Colonels Island, Timmons River, GA",31.695,-81.2717,America/New_York
+8674301,"Daymark #135, South Newport River, GA",31.575,-81.19,America/New_York
+8674975,"Daymark #156, Head Of Mud River, GA",31.4867,-81.32,America/New_York
+8675622,"Old Tower, Sapelo Island, Doboy Sound, GA",31.39,-81.2883,America/New_York
+8675761,"Daymark #185, Rockdedundy River Entrance, GA",31.37386111111111,-81.33394444444444,America/New_York
+8676329,"Mackay River, Icww, Buttermilk Sound, GA",31.285,-81.385,America/New_York
+8676808,"Crispen Island,Turtle River, GA",31.213300704956055,-81.55000305175781,America/New_York
+8677344,"St.Simons Island, GA",31.1317,-81.3967,America/New_York
+8677406,"Howe Street Pier, Brunswick, GA",31.14455555555556,-81.49680555555555,America/New_York
+8678124,"Raccoon Key Spit, GA",31.01480555555555,-81.45597222222223,America/New_York
+8678322,"Bailey Cut, Satilla River, GA",30.985,-81.5917,America/New_York
+8679511,"Kings Bay, GA",30.7967,-81.515,America/New_York
+8679598,"Kings Bay Msf Pier, GA",30.778099060058594,-81.49140167236328,America/New_York
+8679758,"Dungeness, Seacamp Dock, GA",30.7633,-81.4717,America/New_York
+8679945,"Beach Creek, GA",30.7267,-81.4767,America/New_York
+8679964,"St. Marys, St. Marys River, GA",30.72,-81.5483,America/New_York
+8720001,"St. Marys River Headwaters, FL",30.7867,-81.84,America/New_York
+8720004,"Crandall, St. Marys River, FL",30.7217,-81.6217,America/New_York
+8720006,"Little St. Marys River, FL",30.7317,-81.7267,America/New_York
+8720007,"Roses Bluff, FL",30.7033,-81.5767,America/New_York
+8720011,"Cut 1N Front Range, St Marys River Entr, FL",30.7083,-81.465,America/New_York
+8720023,"Chester, Bells River, FL",30.6833,-81.5333,America/New_York
+8720030,"Fernandina Beach, FL",30.67135555555556,-81.46584166666666,America/New_York
+8720051,"Lanceford Creek, Lofton, FL",30.6433,-81.5233,America/New_York
+8720058,"Kingsley Creek, Seaboard R.R., FL",30.6317,-81.4767,America/New_York
+8720059,"Vaughns Landing, FL",30.63,-81.5767,America/New_York
+8720084,"Boggy Creek, Upper Nassau River, FL",30.5883,-81.6633,America/New_York
+8720086,"Amelia City, South Amelia River, FL",30.5867,-81.4633,America/New_York
+8720093,"Halfmoon Island, FL",30.5767,-81.6083,America/New_York
+8720097,"Cuno, Lofton Creek, FL",30.5767,-81.5717,America/New_York
+8720098,"Nassauville, Nassau River East, FL",30.5683,-81.515,America/New_York
+8720119,"Mink Creek Ent., Nassau River, FL",30.5367,-81.5817,America/New_York
+8720135,"Nassau River Entrance, FL",30.518299102783203,-81.45330047607422,America/New_York
+8720137,"Sawpit Creek Entrance, FL",30.5133,-81.4567,America/New_York
+8720143,"Sawpit Creek, FL",30.5033,-81.4717,America/New_York
+8720145,"Edwards Creek, FL",30.5017,-81.5417,America/New_York
+8720148,"Tiger Point, Pumpkin Hills Creek, FL",30.5017,-81.495,America/New_York
+8720168,"Simpson Creek, FL",30.465,-81.4317,America/New_York
+8720186,"Fort George Island, FL",30.44,-81.4383,America/New_York
+8720189,"Cedar Heights, FL",30.4367,-81.6417,America/New_York
+8720196,"Sisters Creek, FL",30.4167,-81.4533,America/New_York
+8720198,"Clapboard Creek, FL",30.4067,-81.51,America/New_York
+8720203,"Blount Island Bridge, FL",30.4133,-81.545,America/New_York
+8720211,"Mayport Naval Sta., St Johns River, FL",30.4,-81.4133,America/New_York
+8720213,"Trout R., Sherwood Forest, FL",30.42,-81.7283,America/New_York
+8720214,"Degaussing Structure, FL",30.3967,-81.395,America/New_York
+8720215,"Navy Fuel Depot, FL",30.4,-81.6267,America/New_York
+8720216,"Ribault River, Lake Forest, FL",30.3983,-81.6983,America/New_York
+8720217,"Moncrief Creek Entrance, FL",30.3917,-81.6617,America/New_York
+8720218,"Mayport (Bar Pilots Dock), FL",30.39816666666667,-81.42788888888889,America/New_York
+8720219,"Dames Point, FL",30.386699676513672,-81.55829620361328,America/New_York
+8720220,"Mayport (Ferry Depot), FL",30.3933,-81.4317,America/New_York
+8720221,"Fulton, St. Johns River, FL",30.39,-81.5067,America/New_York
+8720225,"Phoenix Park, FL",30.3833,-81.6367,America/New_York
+8720226,"Southbank Riverwalk, St Johns River, FL",30.32,-81.6583,America/New_York
+8720232,"Pablo Creek Entrance, FL",30.3767,-81.4483,America/New_York
+8720242,"Long Branch, FL",30.360000610351562,-81.62000274658203,America/New_York
+8720267,"Pablo Creek, FL",30.3233,-81.4383,America/New_York
+8720274,"Little Pottsburg Creek, FL",30.31,-81.61,America/New_York
+8720291,"Jacksonville Beach, FL",30.2833,-81.3867,America/New_York
+8720296,"Ortega River Entrance, FL",30.2783,-81.705,America/New_York
+8720305,"Oak Landing, FL",30.2533,-81.43,America/New_York
+8720333,"Piney Point, St. Johns River, FL",30.2283,-81.6633,America/New_York
+8720357,"I-295 Buckman Bridge, FL",30.19241666666667,-81.68888888888888,America/New_York
+8720374,"Orange Park, St. Johns River, FL",30.16830062866211,-81.69499969482422,America/New_York
+8720398,"Palm Valley Icww, FL",30.1333,-81.3867,America/New_York
+8720406,"Doctors Lake, Peoria Point, FL",30.12,-81.7583,America/New_York
+8720409,"Julington Creek, FL",30.135000228881836,-81.62999725341797,America/New_York
+8720434,"Black Creek, FL",30.079999923706055,-81.76170349121094,America/New_York
+8720494,"Tolomato River, Icww, FL",29.994400024414062,-81.32949829101562,America/New_York
+8720496,"Green Cove Springs, St. Johns R., FL",29.99,-81.6633,America/New_York
+8720503,"Red Bay Point, St Johns River, FL",29.98166666666667,-81.63416666666667,America/New_York
+8720554,"Vilano Beach Icww, FL",29.9167,-81.3,America/New_York
+8720576,"St. Augustine, FL",29.8917,-81.31,America/New_York
+8720582,"State Road 312, Matanzas River, FL",29.8667,-81.3067,America/New_York
+8720587,"St. Augustine Beach, FL",29.8567,-81.2633,America/New_York
+8720596,"East Tocoi, St. Johns River, FL",29.8583,-81.5533,America/New_York
+8720625,"Racy Point, St Johns River, FL",29.8017,-81.5483,America/New_York
+8720651,"Crescent Beach, Matanzas River, FL",29.7683,-81.2583,America/New_York
+8720653,"Palmetto Bluff, St. Johns River, FL",29.7633,-81.5617,America/New_York
+8720686,"Fort Matanzas, FL",29.715,-81.2383,America/New_York
+8720692,"State Road A1A Bridge, FL",29.70453055555556,-81.22785555555555,America/New_York
+8720757,"Bings Landing, Matanzas River, FL",29.615,-81.205,America/New_York
+8720767,"Buffalo Bluff, St Johns River, FL",29.595,-81.6817,America/New_York
+8720774,"Palatka, St Johns River, FL",29.6433,-81.6317,America/New_York
+8720782,"Sutherlands Still, FL",29.5717,-81.6067,America/New_York
+8720793,"Piney Bluff Landing, FL",29.5583,-81.5733,America/New_York
+8720832,"Welaka, FL",29.4767,-81.675,America/New_York
+8720833,"Smith Creek, Flagler Beach, FL",29.4783,-81.1367,America/New_York
+8720954,"Ormond Beach, Halifax River, FL",29.28499984741211,-81.05329895019531,America/New_York
+8721120,"Daytona Beach Shores, FL",29.1467,-80.9633,America/New_York
+8721138,"Halifax River, Ponce Inlet, FL",29.0817,-80.9367,America/New_York
+8721147,"Ponce De Leon Inlet South, FL",29.06333333333333,-80.91583333333334,America/New_York
+8721164,"New Smyrna Beach, FL",29.0233,-80.9183,America/New_York
+8721222,"Packwood Place, FL",28.94,-80.87,America/New_York
+8721223,"Turtle Mound, FL",28.9267,-80.825,America/New_York
+8721604,"Trident Pier, Port Canaveral, FL",28.415800094604492,-80.59310150146484,America/New_York
+8721649,"Cocoa Beach, Atlantic Ocean, FL",28.3683,-80.6,America/New_York
+8721727,"Patrick Air Force Base, FL",28.245,-80.6,America/New_York
+8721804,"Canova, FL",28.1383,-80.5783,America/New_York
+8721843,"Melbourne Causeway, FL",28.08329963684082,-80.5916976928711,America/New_York
+8721994,"Micco, Indian River, FL",27.8733,-80.4967,America/New_York
+8722004,"Sebastian Inlet, FL",27.86,-80.4483,America/New_York
+8722029,"Sebastian, Indian River, FL",27.8117,-80.4633,America/New_York
+8722059,"Wabasso,Indian River, FL",27.755,-80.425,America/New_York
+8722125,"Vero Beach, FL",27.6317,-80.3717,America/New_York
+8722146,"Oslo,Indian River, FL",27.5933,-80.3567,America/New_York
+8722207,"St. Lucie,Indian River, FL",27.48,-80.3333,America/New_York
+8722212,"Fort Pierce, South Jetty, FL",27.47,-80.2883,America/New_York
+8722213,"Binney Dock, FL",27.4683,-80.3,America/New_York
+8722219,"South Beach Causeway, FL",27.4567,-80.3233,America/New_York
+8722274,"Ankona, Indian River, FL",27.355,-80.2733,America/New_York
+8722312,"Nettles Island, Indian River, FL",27.2867,-80.2267,America/New_York
+8722329,"Jensen Beach Causeway Park, FL",27.251699447631836,-80.21829986572266,America/New_York
+8722334,"North Fork, St. Lucie River, FL",27.2433,-80.3133,America/New_York
+8722357,"Stuart, St. Lucie River, FL",27.2,-80.2583,America/New_York
+8722366,"Seminole Shores, FL",27.1833,-80.1583,America/New_York
+8722371,"Sewall Point. St. Lucie River, FL",27.174999237060547,-80.18830108642578,America/New_York
+8722375,"South Point, St Lucie Inlet, FL",27.1583,-80.1567,America/New_York
+8722376,"South Fork,St. Lucie River, FL",27.165,-80.255,America/New_York
+8722383,"Port Salerno, FL",27.1517,-80.195,America/New_York
+8722404,"Peck Lake, St. Lucie Inlet, FL",27.1133,-80.145,America/New_York
+8722414,"Gomez, FL",27.0933,-80.1367,America/New_York
+8722429,"Hobe Sound Bridge, Hobe Sound, FL",27.065,-80.1233,America/New_York
+8722445,"Hobe Sound, State Park, FL",27.0367,-80.1067,America/New_York
+8722472,"North Loxahatchee River, FL",26.9867,-80.1417,America/New_York
+8722478,"North Fork, Loxahatchee River, FL",26.975,-80.1133,America/New_York
+8722481,"Loxahatchee River, FL",26.97,-80.1267,America/New_York
+8722486,"Tequesta, N.Fork,Loxahatchee R., FL",26.96,-80.105,America/New_York
+8722491,"Jupiter Sound, South End, FL",26.9517,-80.08,America/New_York
+8722492,"Jupiter West, FL",26.9467,-80.09,America/New_York
+8722495,"Jupiter Inlet, FL",26.9433,-80.0733,America/New_York
+8722496,"Loxahatchee River Lock, FL",26.935,-80.1433,America/New_York
+8722499,"Jupiter, Intracoastal Waterway, FL",26.935,-80.085,America/New_York
+8722512,"Lake Worth Creek, FL",26.9117,-80.08,America/New_York
+8722528,"Donald Ross Bridge, FL",26.8817,-80.07,America/New_York
+8722548,"Pga Boulevard Bridge, Palm Beach, FL",26.8433,-80.0667,America/New_York
+8722557,"North Palm Beach, FL",26.8267,-80.055,America/New_York
+8722588,"Port Of West Palm Beach, FL",26.77,-80.0517,America/New_York
+8722607,"Palm Beach, FL",26.7333,-80.0417,America/New_York
+8722621,"Palm Beach, FL",26.705,-80.045,America/New_York
+8722654,"West Palm Beach, FL",26.645,-80.045,America/New_York
+8722669,"Lake Worth Icw, FL",26.6133,-80.0467,America/New_York
+8722670,"Lake Worth Pier, Atlantic Ocean, FL",26.6127778,-80.0341667,America/New_York
+8722706,"Boynton Beach, FL",26.54829978942871,-80.05329895019531,America/New_York
+8722718,"Ocean Ridge, FL",26.52669906616211,-80.05329895019531,America/New_York
+8722746,"Delray Beach, FL",26.4733,-80.0617,America/New_York
+8722761,"South Delray Beach, FL",26.4467,-80.065,America/New_York
+8722784,"Yamato, FL",26.4033,-80.07,America/New_York
+8722802,"Lake Wyman, FL",26.37,-80.07,America/New_York
+8722816,"Boca Raton, FL",26.343299865722656,-80.07669830322266,America/New_York
+8722832,"Deerfield Beach, FL",26.31329917907715,-80.08170318603516,America/New_York
+8722859,"Hillsboro, FL",26.260000228881836,-80.08499908447266,America/New_York
+8722861,"Hillsboro Inlet, Inside, FL",26.2583,-80.0817,America/New_York
+8722862,"Hillsboro Inlet Ocean, FL",26.2567,-80.08,America/New_York
+8722899,"Lauderdale-By-The-Sea, FL",26.18829917907715,-80.09329986572266,America/New_York
+8722937,"Ft. Lauderdale, Andrews Avenue Bridge, FL",26.11829948425293,-80.1449966430664,America/New_York
+8722939,"Ft. Lauderdale Bahia Yacht Club, FL",26.1133,-80.1083,America/New_York
+8722951,"Port Everglades, Lake Mabel, FL",26.0917,-80.1233,America/New_York
+8722956,"South Port Everglades, FL",26.0816667,-80.1166667,America/New_York
+8722957,"North Dania Sound, FL",26.08,-80.1117,America/New_York
+8722968,"Port Laudania, FL",26.06,-80.13,America/New_York
+8722971,"Whiskey Creek, South Entrance, FL",26.055,-80.1133,America/New_York
+8722977,"West Lake, North End, FL",26.0433,-80.1267,America/New_York
+8722979,"Hollywood Beach, FL",26.04,-80.115,America/New_York
+8722982,"West Lake, South End, FL",26.0333,-80.1233,America/New_York
+8723026,"Golden Beach, FL",25.9667,-80.125,America/New_York
+8723044,"Dumfoundling Bay, FL",25.9417,-80.125,America/New_York
+8723050,"North Miami Beach, FL",25.93,-80.12,America/New_York
+8723073,"Haulover Inside, FL",25.9033,-80.125,America/New_York
+8723080,"Haulover Pier, N. Miami Beach, FL",25.9033,-80.12,America/New_York
+8723089,"Biscayne Creek, Intracoastal Waterway, FL",25.88,-80.1633,America/New_York
+8723155,"Miami Ship Base, FL",25.77,-80.1683,America/New_York
+8723165,"Miami, Biscayne Bay, FL",25.7783,-80.185,America/New_York
+8723170,"Miami Beach, FL",25.7683,-80.1317,America/New_York
+8723178,"Miami Beach, Government Cut, FL",25.7633,-80.13,America/New_York
+8723205,"Dinner Key Marina,Biscayne Bay, FL",25.7267,-80.2367,America/New_York
+8723214,"Virginia Key, FL",25.731399536132812,-80.16179656982422,America/New_York
+8723232,"Key Biscayne Yacht Club, FL",25.6983,-80.17,America/New_York
+8723251,"Cape Florida, Key Biscayne, FL",25.6517,-80.16,America/New_York
+8723289,"Cutler, Biscayne Bay, FL",25.615,-80.305,America/New_York
+8723350,"Ragged Key #3, FL",25.5333,-80.1717,America/New_York
+8723355,"Ragged Key No. 5, Biscayne Bay, FL",25.5233,-80.175,America/New_York
+8723372,"Sands Key, Elliott Key, FL",25.5067,-80.1883,America/New_York
+8723391,"Coon Point, Elliott Key, FL",25.48,-80.1883,America/New_York
+8723393,"Elliott Key (Outside), FL",25.4767,-80.18,America/New_York
+8723409,"Elliott Key Harbor, Elliott Key, FL",25.4533,-80.1967,America/New_York
+8723423,"Turkey Point, Biscayne Bay, FL",25.4367,-80.33,America/New_York
+8723439,"Billy'S Point, Elliott Key, FL",25.415,-80.21,America/New_York
+8723453,"Adams Key, FL",25.3967,-80.2333,America/New_York
+8723457,"Christmas Point, Elliott Key, FL",25.3917,-80.23,America/New_York
+8723465,"East Arsenicker, Card Sound, FL",25.3733,-80.29,America/New_York
+8723467,"Totten Key, Biscayne Bay, FL",25.3783,-80.2567,America/New_York
+8723506,"Pumpkin Key, Card Sound, FL",25.325,-80.2933,America/New_York
+8723518,"Wednesday Point, Key Largo, FL",25.31,-80.2983,America/New_York
+8723519,"Ocean Reef Harbor, Key Largo, FL",25.3083,-80.2767,America/New_York
+8723534,"Card Sound Bridge, FL",25.2883,-80.37,America/New_York
+8723583,"Carysfort Reef Lighthouse, FL",25.2217,-80.2117,America/New_York
+8723644,"Flamingo Visitors Center, FL",25.1417,-80.9233,America/New_York
+8723689,"Point Charles, Key Largo, FL",25.0817,-80.4467,America/New_York
+8723691,"Pt. Charles, Gage 'C', Key Largo, FL",25.0817,-80.45,America/New_York
+8723746,"Crane Key, FL",25.005,-80.6183,America/New_York
+8723747,"Tavernier Hawk Channel, FL",25.005,-80.5167,America/New_York
+8723752,"East Key, Florida Bay, FL",24.9967,-80.61,America/New_York
+8723769,"Plantation Key, Atlantic Side, FL",24.9733,-80.55,America/New_York
+8723786,"Uscg Sta., Islamorada, Snake Cr, FL",24.9533,-80.5867,America/New_York
+8723795,"Whale Harbor Marina, FL",24.94,-80.6083,America/New_York
+8723797,"Islamorada, Whale Harbor Channel, FL",24.9383,-80.61,America/New_York
+8723807,"Shell Key, N.W.Side, FL",24.9233,-80.6717,America/New_York
+8723808,"Upper Matecumbe Key,Florida Bay, FL",24.925,-80.6317,America/New_York
+8723812,"Shell Key Channel, FL",24.9133,-80.66,America/New_York
+8723814,"Upper Matecumbe Key,Atlan. Side, FL",24.915,-80.6317,America/New_York
+8723824,"Lignumvitae Key East, FL",24.9033,-80.695,America/New_York
+8723825,"Lignumvitae Key West, FL",24.9,-80.705,America/New_York
+8723828,"Upper Matecumbe Key, West End, FL",24.8967,-80.6583,America/New_York
+8723843,"Indian Key, Hawk Channel, FL",24.8767,-80.6767,America/New_York
+8723851,"Lower Matecumbe Key Hawk Channel, FL",24.8683,-80.7033,America/New_York
+8723852,"Lower Matecumbe Key, Fla. Bay, FL",24.865,-80.7167,America/New_York
+8723861,"Alligator Reef Lighthouse, FL",24.85,-80.6183,America/New_York
+8723873,"Long Key, Florida Bay, FL",24.83830555555556,-80.79830555555556,America/New_York
+8723906,"Long Key Channel West, FL",24.7917,-80.8833,America/New_York
+8723912,"Tom'S Harbor Cut, FL",24.7833,-80.9067,America/New_York
+8723918,"Tom'S Harbor Channel, FL",24.7767,-80.9233,America/New_York
+8723921,"Grassy Key North Side, Florida Bay, FL",24.7717,-80.94,America/New_York
+8723927,"Duck Key, FL",24.765,-80.9133,America/New_York
+8723933,"Grassy Key, Atlantic Side, FL",24.755,-80.9583,America/New_York
+8723949,"Fat Deer Key, FL",24.7333,-81.0167,America/New_York
+8723950,"Marthon Shores Key, Vaca Cut, FL",24.73,-81.03,America/New_York
+8723962,"Key Colony Beach, FL",24.7183,-81.0167,America/New_York
+8723970,"Vaca Key, Florida Bay, FL",24.711,-81.1065,America/New_York
+8723971,"Boot Key Harbor, FL",24.7033,-81.105,America/New_York
+8723999,"Sombrero Key Lighthouse, FL",24.6267,-81.1117,America/New_York
+8724008,"Knight Key Channel, FL",24.7067,-81.125,America/New_York
+8724032,"Pigeon Key Atlantic Side, FL",24.7033,-81.155,America/New_York
+8724033,"Pigeon Key (Inside), FL",24.705,-81.1567,America/New_York
+8724062,"Molasses Key, FL",24.6833,-81.1917,America/New_York
+8724082,"Money Key, FL",24.6833,-81.2167,America/New_York
+8724093,"Little Duck Key, FL",24.6817,-81.2283,America/New_York
+8724094,"East Bahia Honda Key, FL",24.775,-81.2267,America/New_York
+8724098,"Cocoanut Key, FL",24.745,-81.2367,America/New_York
+8724099,"Missouri-Little Duck Channel, FL",24.68,-81.235,America/New_York
+8724107,"Missouri-Ohio Channel, FL",24.6733,-81.2433,America/New_York
+8724112,"Ohio-Bahia Honda Channel, FL",24.67,-81.2517,America/New_York
+8724129,"West Bahia Honda Key, FL",24.78,-81.2717,America/New_York
+8724138,"Bahia Honda Key, FL",24.655,-81.2817,America/New_York
+8724139,"Horeshoe Keys, FL",24.7667,-81.2833,America/New_York
+8724153,"Johnson Keys South, FL",24.7433,-81.3,America/New_York
+8724154,"Little Pine Key South, FL",24.7133,-81.3033,America/New_York
+8724168,"No Name Key, FL",24.6983,-81.3183,America/New_York
+8724172,"Johnson Keys North, FL",24.7667,-81.3233,America/New_York
+8724177,"Little Pine Key North, FL",24.75,-81.3283,America/New_York
+8724178,"Spanish Harbor Viaduct, Big Pine Key, FL",24.6483,-81.33,America/New_York
+8724189,"Water Key, Big Spanish Channel, FL",24.74,-81.3417,America/New_York
+8724192,"Big Pine Key, Coupon Bight Inside, FL",24.6517,-81.35,America/New_York
+8724193,"Bogie Channel Landing, Big Pine Key, FL",24.6967,-81.3483,America/New_York
+8724196,"Porpoise Key, FL",24.7183,-81.3517,America/New_York
+8724199,"Crawl Key, Big Spanish Channel, FL",24.7567,-81.3583,America/New_York
+8724201,"Doctors Arm, FL",24.69,-81.3567,America/New_York
+8724205,"Mayo Key, FL",24.7333,-81.3617,America/New_York
+8724209,"Little Spanish Key Island, FL",24.7733,-81.3683,America/New_York
+8724211,"Big Pine Key Viaduct, FL",24.67,-81.3683,America/New_York
+8724215,"Newfound Harbor, FL",24.6517,-81.375,America/New_York
+8724224,"Little Torch Key, FL",24.665,-81.3867,America/New_York
+8724226,"Big Pine Key Ne, FL",24.7283,-81.3867,America/New_York
+8724227,"Big Pine Key, West Side, FL",24.69,-81.3833,America/New_York
+8724229,"Annette Key, FL",24.7583,-81.39,America/New_York
+8724231,"Big Pine Key North End, FL",24.745,-81.395,America/New_York
+8724238,"Munson Key, FL",24.6233,-81.4033,America/New_York
+8724239,"Ramrod Key Southeast, FL",24.65,-81.4033,America/New_York
+8724243,"Howe Key (Off South End), FL",24.725,-81.4067,America/New_York
+8724246,"Big Spanish Key, FL",24.7883,-81.4117,America/New_York
+8724255,"Ramrod Key, FL",24.66,-81.4233,America/New_York
+8724264,"Big Torch Key, West Side, FL",24.705,-81.4333,America/New_York
+8724266,"Summerland Key East, FL",24.6517,-81.435,America/New_York
+8724273,"Water Keys South End, FL",24.7467,-81.45,America/New_York
+8724276,"Summerland Key, West Side, FL",24.65,-81.4467,America/New_York
+8724292,"Kemp Channel Viaduct, FL",24.6617,-81.4683,America/New_York
+8724302,"Knockemdown Key, FL",24.715,-81.4783,America/New_York
+8724306,"Gopher Key, FL",24.6417,-81.485,America/New_York
+8724307,"Content Key, FL",24.79,-81.4833,America/New_York
+8724311,"Racoon Key, FL",24.7417,-81.4833,America/New_York
+8724313,"Cudjoe Bay, FL",24.66,-81.4917,America/New_York
+8724327,"Tarpon Creek (Outside), FL",24.6283,-81.51,America/New_York
+8724328,"Cudjoe Key No. Point, FL",24.7,-81.505,America/New_York
+8724332,"Cudjoe Key Pirates Cove, FL",24.6617,-81.515,America/New_York
+8724334,"Tarpon Creek, Sugarloaf Key, FL",24.63,-81.5167,America/New_York
+8724347,"Sugarloaf Key East Side, FL",24.6717,-81.5333,America/New_York
+8724353,"Perky Lake, Sugerloaf Key, FL",24.655,-81.54,America/New_York
+8724367,"North Harris Channel, FL",24.6533,-81.5533,America/New_York
+8724368,"Sugarloaf Key (North End), FL",24.6933,-81.555,America/New_York
+8724369,"Sawyer Key (Inside), FL",24.7583,-81.5617,America/New_York
+8724373,"Pumpkin Key, Sugarloaf Channel, FL",24.7167,-81.5617,America/New_York
+8724378,"Perky, Sugarloaf Sound, FL",24.6483,-81.57,America/New_York
+8724397,"Johnston Key, FL",24.71,-81.5933,America/New_York
+8724405,"Saddlebunch Channel No. 3, FL",24.6233,-81.6033,America/New_York
+8724409,"Inner Narrows, FL",24.6583,-81.6083,America/New_York
+8724417,"Saddlebunch Channel No. 4, FL",24.615,-81.6167,America/New_York
+8724422,"Similar Sound, FL",24.6,-81.6217,America/New_York
+8724423,"Saddlebunch Channel No. 5, FL",24.6117,-81.6233,America/New_York
+8724427,"Middle Narrows, FL",24.6667,-81.63,America/New_York
+8724436,"Bird Key, FL",24.5883,-81.6383,America/New_York
+8724438,"Shark Key, FL",24.6033,-81.645,America/New_York
+8724441,"O'Hara Key, North Point, FL",24.6167,-81.645,America/New_York
+8724448,"Waltz Key, FL",24.6467,-81.6533,America/New_York
+8724463,"Snipe Point, Snipe Keys, FL",24.6917,-81.6733,America/New_York
+8724474,"Duck Key Point, FL",24.6233,-81.685,America/New_York
+8724485,"Boca Chica,Long Point, FL",24.6033,-81.6983,America/New_York
+8724489,"Big Coppitt Key, FL",24.6017,-81.655,America/New_York
+8724493,"Boca Chica Marina, FL",24.575,-81.7083,America/New_York
+8724499,"Boca Chica, Southwest End, FL",24.5633,-81.7133,America/New_York
+8724503,"Stock Island, FL",24.5767,-81.7217,America/New_York
+8724507,"Channel Key, FL",24.6033,-81.725,America/New_York
+8724517,"Key Haven West, FL",24.58,-81.7383,America/New_York
+8724527,"Cow Key Channel, FL",24.57,-81.75,America/New_York
+8724529,"Riveria Canal, Key West, FL",24.565,-81.7517,America/New_York
+8724542,"Sigsbee Park, Garrison Bight Channel, FL",24.585,-81.775,America/New_York
+8724557,"Key West, White Street Pier, FL",24.545,-81.7833,America/New_York
+8724571,"Fleming Key, FL",24.5917,-81.795,America/New_York
+8724580,"Key West, FL",24.555700302124023,-81.80789947509766,America/New_York
+8724635,"Sand Key Lighthouse, FL",24.4533,-81.8783,America/New_York
+8724671,"Smith Shoal Light, FL",24.71827777777778,-81.92152777777778,America/New_York
+8724697,"Garden Key, Dry Tortugas, FL",24.6267,-82.8717,America/New_York
+8724698,"Loggerhead Key, FL",24.6317,-82.92,America/New_York
+8724919,"Chokoloskee, FL",25.8133,-81.3633,America/New_York
+8724932,Indian Key,25.799999237060547,-81.4666976928711,America/New_York
+8724947,"Cape Romano Island, FL",25.8533,-81.675,America/New_York
+8724948,Everglades City,25.8583,-81.3867,America/New_York
+8724963,"Dismal Key, Pumpkin Bay, FL",25.895,-81.5583,America/New_York
+8724964,"Coon Key Pass, Gullivan Bay, FL",25.8967,-81.6367,America/New_York
+8724967,"Marco Island, Caxambas Pass, FL",25.9083,-81.7283,America/New_York
+8724991,"Marco, Big Marco River, FL",25.9717,-81.7283,America/New_York
+8724996,"Mcilvaine Bay, FL",25.985,-81.7017,America/New_York
+8725019,"Keewaydin Island, Inside, FL",26.025,-81.7683,America/New_York
+8725110,"Naples, FL",26.1316667,-81.8075,America/New_York
+8725114,"Naples Bay, North, FL",26.136699676513672,-81.78829956054688,America/New_York
+8725228,"Cocohatchee River, U.S. 41, FL",26.2817,-81.8017,America/New_York
+8725235,"Wiggins Pass, Inside, FL",26.29,-81.8183,America/New_York
+8725283,"Little Hickory Is., Estero B., FL",26.353300094604492,-81.8550033569336,America/New_York
+8725319,"Coconut Point, Estero Bay, FL",26.4,-81.8433,America/New_York
+8725325,"Carlos Point, Estero Bay, FL",26.405000686645508,-81.88500213623047,America/New_York
+8725346,"Estero River, Estero Bay, FL",26.43,-81.8567,America/New_York
+8725351,"Estero Island, Estero Bay, FL",26.4383,-81.9183,America/New_York
+8725362,"Tarpon Bay, FL",26.4433,-82.0817,America/New_York
+8725377,"Hendry Creek, Estero Bay, FL",26.47,-81.8767,America/New_York
+8725383,"Captiva Island (So. End), FL",26.4783,-82.1833,America/New_York
+8725391,"Punta Rassa, San Carlos Bay, FL",26.488300323486328,-82.01329803466797,America/New_York
+8725393,"St. James City,Pine Island, FL",26.49169921875,-82.08170318603516,America/New_York
+8725411,"Galt Island,Pine Island Sd., FL",26.5133,-82.1067,America/New_York
+8725418,"Iona Shores, Caloosahatchee R., FL",26.5217,-81.965,America/New_York
+8725439,"Tropical Homesites,Matlacha Pass, FL",26.5483,-82.08,America/New_York
+8725441,"Redfish Pass,Captiva Is.(No. End), FL",26.55,-82.1967,America/New_York
+8725451,"Cape Coral Br.,Caloosahatchee R., FL",26.56329917907715,-81.93329620361328,America/New_York
+8725488,"North Captiva Island, FL",26.605,-82.2183,America/New_York
+8725506,"Matlacha Pass (Swing Br.), FL",26.63170051574707,-82.06829833984375,America/New_York
+8725520,"Fort Myers, FL",26.64777777777778,-81.8711111111111,America/New_York
+8725528,"Pine Island, Charlotte Harbor, FL",26.66,-82.155,America/New_York
+8725541,"Bokeelia, Charlotte Harbor, FL",26.70669937133789,-82.16329956054688,America/New_York
+8725577,"Port Boca Grande, Charlotte Hbr., FL",26.719999313354492,-82.25830078125,America/New_York
+8725649,"Turtle Bay, FL",26.7967,-82.1833,America/New_York
+8725667,"Placida, Gasparilla Sound, FL",26.8333,-82.265,America/New_York
+8725685,"Cutoff South, FL",26.855,-82.3033,America/New_York
+8725744,"Punta Gorda, FL",26.9283,-82.065,America/New_York
+8725745,"Locust Point, Hog Island, FL",26.93,-82.1367,America/New_York
+8725747,"Englewood, Lemon Bay, FL",26.9333,-82.3533,America/New_York
+8725769,"El Jobean, Myakka River, FL",26.9617,-82.21,America/New_York
+8725791,"Harbour Heights, Peace River, FL",26.9883,-81.9933,America/New_York
+8725809,"Manasota, FL",27.0117,-82.41,America/New_York
+8725837,"Myakka River, Us 41, FL",27.045,-82.2933,America/New_York
+8725858,"Venice, FL",27.0717,-82.4533,America/New_York
+8725889,"Venice, Roberts Bay, FL",27.1117,-82.4633,America/New_York
+8726034,"Siesta Key, Big Sarasota Pass, FL",27.283899307250977,-82.56500244140625,America/New_York
+8726083,"Sarasota, FL",27.3317,-82.545,America/New_York
+8726217,"Cortez, FL",27.4667,-82.6867,America/New_York
+8726243,"Anna Maria Outside, FL",27.4967,-82.7133,America/New_York
+8726247,"Bradenton, Manatee River, FL",27.5,-82.57330322265625,America/New_York
+8726265,"Ellenton, Manatee River, FL",27.51490020751953,-82.53379821777344,America/New_York
+8726278,"Redfish Point, Manatee River, FL",27.5267,-82.4817,America/New_York
+8726282,"Anna Maria, City Pier, FL",27.5333,-82.73,America/New_York
+8726347,"Egmont Key, Tampa Bay, FL",27.6017,-82.76,America/New_York
+8726364,"Mullet Key, Tampa Bay, FL",27.615,-82.7267,America/New_York
+8726384,"Port Manatee, FL",27.638700485229492,-82.56210327148438,America/New_York
+8726520,"St. Petersburg, FL",27.76059913635254,-82.62689971923828,America/New_York
+8726533,"Johns Pass, FL",27.785,-82.7817,America/New_York
+8726537,"Apollo Beach, Hillsborough Bay, FL",27.786699295043945,-82.42669677734375,America/New_York
+8726539,"Newman Branch, FL",27.7833,-82.4067,America/New_York
+8726574,"Boca Ciega Bay, FL",27.8083,-82.795,America/New_York
+8726607,"Old Port Tampa, FL",27.857799530029297,-82.55280303955078,America/New_York
+8726639,"Tampa, Ballast Point, FL",27.89,-82.48,America/New_York
+8726641,"Gandy Bridge, Old Tampa Bay, FL",27.8933,-82.5383,America/New_York
+8726651,"Pendola Point, Hillsborough Bay, FL",27.8983,-82.4267,America/New_York
+8726657,"Davis Island, Hillsborough Bay, FL",27.9083,-82.4517,America/New_York
+8726667,"Mckay Bay Entrance, FL",27.913299560546875,-82.42500305175781,America/New_York
+8726674,"East Bay, FL",27.923099517822266,-82.42140197753906,America/New_York
+8726689,"Bay Aristocrat Village, Old Tampa Bay, FL",27.9417,-82.72,America/New_York
+8726706,"Clearwater, Clearwater Harbor, FL",27.955,-82.8067,America/New_York
+8726724,"Clearwater Beach, FL",27.9783333,-82.8316667,America/New_York
+8726738,"Safety Harbor, Old Tampa Bay, FL",27.9883,-82.685,America/New_York
+8726761,"Dunedin City Dock, FL",28.0133,-82.7933,America/New_York
+8726769,"Mobbly Bayou, FL",28.0217,-82.655,America/New_York
+8726905,"Tarpon Springs, Anclote River, FL",28.16,-82.7683,America/New_York
+8726917,"Anclote Lighthouse, Anclote Key, FL",28.165,-82.8433,America/New_York
+8726924,"Anclote River, FL",28.1717,-82.785,America/New_York
+8726942,"North Anclote Key, FL",28.21,-82.84,America/New_York
+8727001,"Middle Pithlachascotee River, FL",28.2483,-82.7233,America/New_York
+8727012,"Pithlachascotee River, FL",28.2683,-82.7267,America/New_York
+8727061,"Hudson, Hudson Creek, FL",28.3617,-82.71,America/New_York
+8727097,"Aripeka, FL",28.4333,-82.6683,America/New_York
+8727122,"Rocky Cr.,Little Pine Is. Bay,, FL",28.4867,-82.6617,America/New_York
+8727151,"Bayport, FL",28.5333,-82.65,America/New_York
+8727235,"Johns Island, Chassahowitzka Bay, FL",28.6917,-82.6383,America/New_York
+8727246,"Chassahowitzka River, FL",28.715,-82.5767,America/New_York
+8727274,"Mason Creek, Homosassa Bay, FL",28.7617,-82.6383,America/New_York
+8727277,"Tuckers Island, Homosassa River, FL",28.7717,-82.695,America/New_York
+8727293,"Halls River Bridge, Halls River, FL",28.8,-82.6033,America/New_York
+8727306,"Ozello, FL",28.825,-82.6583,America/New_York
+8727328,"Ozello North, FL",28.8633,-82.6667,America/New_York
+8727333,"Mangrove Point, FL",28.87,-82.7233,America/New_York
+8727336,"Dixie Bay, FL",28.8817,-82.635,America/New_York
+8727343,"Crystal River, Kings Bay, FL",28.8983,-82.5983,America/New_York
+8727348,"Twin Rivers Marina, FL",28.905,-82.6383,America/New_York
+8727359,"Shell Island, Crystal River, FL",28.9233,-82.6917,America/New_York
+8727395,"Port Inglis, Withlacoochee River, FL",29.0017,-82.7583,America/New_York
+8727520,"Cedar Key, FL",29.135000228881836,-83.03170013427734,America/New_York
+8727535,"Shell Mound, FL",29.20639991760254,-83.0697021484375,America/New_York
+8727577,"Suwannee, FL",29.3283,-83.1517,America/New_York
+8727648,"Horseshoe Point, FL",29.4367,-83.2933,America/New_York
+8727695,"Steinhatchee, FL",29.6717,-83.39,America/New_York
+8727792,"Hagens Cove, FL",29.79669952392578,-83.58380126953125,America/New_York
+8727843,"Spring Warrior Creek, FL",29.92,-83.6717,America/New_York
+8727956,"Econfina River, Inside, FL",30.0533,-83.91,America/New_York
+8727976,"Snipe Island, FL",30.061899185180664,-83.95269775390625,America/New_York
+8727989,"Mandalay, Aucilla River, FL",30.1267,-83.975,America/New_York
+8728104,"Port Leon, FL",30.124399185180664,-84.14900207519531,America/New_York
+8728130,"St. Marks Lhtse., Apalachee Bay, FL",30.0783,-84.1783,America/New_York
+8728152,"St Marks, Wakulla River, FL",30.158899307250977,-84.21859741210938,America/New_York
+8728229,"Shell Point, Walker Creek, FL",30.05833333333333,-84.29055555555556,America/New_York
+8728237,"Bald Point, Ochlockonee Bay, FL",29.9483,-84.3417,America/New_York
+8728262,"Ochlockonee Bay, FL",29.980199813842773,-84.3958969116211,America/New_York
+8728269,"Panacea, Dickerson Bay, FL",30.02829933166504,-84.38670349121094,America/New_York
+8728288,"Alligator Point, FL",29.9033,-84.4133,America/New_York
+8728360,"Turkey Point, FL",29.915,-84.5117,America/New_York
+8728408,"Dog Island, East End, FL",29.81,-84.585,America/New_York
+8728412,"Lanark, St. Georges Sound, FL",29.878299713134766,-84.59500122070312,America/New_York
+8728464,"Carrabelle River, St. George Sound, FL",29.85,-84.665,America/New_York
+8728486,"Ne End, St. George Island, FL",29.766695022583008,-84.69999694824219,America/New_York
+8728488,"South Carrabelle Beach, FL",29.801700592041016,-84.73670196533203,America/New_York
+8728548,"St. George Island,East End, FL",29.6867,-84.7867,America/New_York
+8728552,"St. George Is.,Rattlesnake Cove, FL",29.6917,-84.7917,America/New_York
+8728593,"East Bayou, FL",29.818899154663086,-84.85030364990234,America/New_York
+8728619,"Cat Point, Apalachicola Bay, FL",29.72330093383789,-84.88670349121094,America/New_York
+8728626,"St. George Island, Bayside, FL",29.6533,-84.8967,America/New_York
+8728669,"Sikes Cut, St. George Island, FL",29.613300323486328,-84.95829772949219,America/New_York
+8728690,"Apalachicola, FL",29.7244444,-84.9805556,America/New_York
+8728694,"White Beach, East Bay, FL",29.785,-84.8983,America/New_York
+8728711,"Apalachicola River, FL",29.7632999420166,-85.0333023071289,America/New_York
+8728728,"Little St George Island, FL",29.603599548339844,-85.04280090332031,America/New_York
+8728757,"Huckleberry Landing, Jackson River, FL",29.770000457763672,-85.08499908447266,America/New_York
+8728786,"Eleven Mile, St. Vincent Sound, FL",29.70669937133789,-85.1532974243164,America/New_York
+8728819,"Lake Wimico, FL",29.821399688720703,-85.17330169677734,America/Chicago
+8728852,"Indian Pass, FL",29.685100555419922,-85.22129821777344,America/New_York
+8728853,"White City, Icww, FL",29.880699157714844,-85.22139739990234,America/Chicago
+8728886,"White City, Gulf County Canal, FL",29.86680030822754,-85.27059936523438,America/New_York
+8728912,"Port St. Joe, FL",29.815,-85.3133,America/New_York
+8728957,"Overstreet, FL",29.996700286865234,-85.37000274658203,America/New_York
+8728958,"St. Joseph Point, St. Joseph Bay, FL",29.873300552368164,-85.38999938964844,America/New_York
+8728973,"Wetappo Creek, East Bay, FL",30.038299560546875,-85.39330291748047,America/Chicago
+8728978,"Cape San Blas, Western Cape, FL",29.764400482177734,-85.40249633789062,America/New_York
+8729015,"Allanton, East Bay, FL",30.030000686645508,-85.46499633789062,America/Chicago
+8729017,"Farmdale, East Bay, St. Andrew Bay, FL",30.016700744628906,-85.47000122070312,America/Chicago
+8729026,"East Bay, Goose Point, FL",30.061199188232422,-85.48860168457031,America/Chicago
+8729045,"Laird Bayou, East Bay, FL",30.1217,-85.5283,America/Chicago
+8729082,"Deer Point Lake, FL",30.26959991455078,-85.60790252685547,America/Chicago
+8729084,"Parker, East Bay, FL",30.1267,-85.6117,America/Chicago
+8729102,"Lynn Haven, North Bay, FL",30.255,-85.6483,America/Chicago
+8729108,"Panama City, FL",30.1497222,-85.6644444,America/Chicago
+8729132,"Courtney Point, St Andrew Bay, FL",30.15169906616211,-85.66670227050781,America/Chicago
+8729136,"New Entrance Channel, St. Andrew Bay, FL",30.125,-85.73,America/Chicago
+8729142,"Sulphur Point, Port Of Panama City, FL",30.183000564575195,-85.73280334472656,America/Chicago
+8729152,"Alligator Bayou, Panama City, FL",30.17,-85.755,America/Chicago
+8729197,"West Bay Creek West Bay, FL",30.29330062866211,-85.8582992553711,America/Chicago
+8729210,"Panama City Beach, FL",30.21375,-85.87858333333334,America/Chicago
+8729376,"Santa Rosa Hogtown Bayou, FL",30.399999618530273,-86.22830200195312,America/Chicago
+8729425,"Driftwood Point, Choctawhatcheee Bay, FL",30.389400482177734,-86.32879638671875,America/Chicago
+8729479,"Rocky Bayou, FL",30.50670051574707,-86.44670104980469,America/Chicago
+8729501,"Valparaiso, FL",30.503299713134766,-86.49330139160156,America/Chicago
+8729511,"Destin, East Pass, FL",30.395,-86.5133,America/Chicago
+8729538,"Garnier Bayou, Shalimar, FL",30.435,-86.5867,America/Chicago
+8729547,"Okaloosa Island, FL",30.391399383544922,-86.59320068359375,America/Chicago
+8729572,"Mary Esther, FL",30.4064998626709,-86.65049743652344,America/Chicago
+8729613,"Harris, Santa Rosa Sound, FL",30.4083,-86.7317,America/Chicago
+8729678,"Navarre Beach, FL",30.3767,-86.865,America/Chicago
+8729702,"East Bay, Holley, FL",30.450000762939453,-86.91829681396484,America/Chicago
+8729717,"Navarre, North Side, FL",30.443099975585938,-86.95140075683594,America/Chicago
+8729736,"Woodlawn Beach, FL",30.386699676513672,-86.99169921875,America/Chicago
+8729747,"Shield Point, Blackwater River, FL",30.58169937133789,-87.01499938964844,America/Chicago
+8729753,"Blackwater River, FL",30.636699676513672,-87.0282974243164,America/Chicago
+8729791,"Hernandez Point North, FL",30.454999923706055,-87.0999984741211,America/Chicago
+8729806,"Fishing Bend, Santa Rosa Sound, FL",30.336700439453125,-87.13999938964844,America/Chicago
+8729807,"Pensacola Beach Pier, FL",30.3275,-87.141944,America/Chicago
+8729816,"Lora Point, Escambia Bay, FL",30.514999389648438,-87.16169738769531,America/Chicago
+8729824,"Floridatown, Escambia Bay, FL",30.58169937133789,-87.18000030517578,America/Chicago
+8729840,"Pensacola, FL",30.404399871826172,-87.21119689941406,America/Chicago
+8729868,"Pensacola, Naval Air Station, FL",30.345,-87.2733,America/Chicago
+8729905,"Millview, Perdido Bay, FL",30.4183,-87.3567,America/Chicago
+8729909,"Big Lagoon, FL",30.32670021057129,-87.35669708251953,America/Chicago
+8729941,"Blue Angels Park, FL",30.38694444444445,-87.42880555555556,America/Chicago
+8729962,"Nix Point, Perdido Bay, FL",30.3933,-87.425,America/Chicago
+8730561,"Arnica Bay, Mill Point, AL",30.310199737548828,-87.51930236816406,America/Chicago
+8730667,"Alabama Point, AL",30.27861111111111,-87.55500030517578,America/Chicago
+8730849,"Wolf Bay, AL",30.354999542236328,-87.5999984741211,America/Chicago
+8731269,"Gulf State Park Pier, AL",30.248300552368164,-87.66829681396484,America/Chicago
+8731439,"Gulf Shores, Icww, AL",30.27988888888889,-87.68427777777778,America/Chicago
+8731952,"Bon Secour, AL",30.3033,-87.735,America/Chicago
+8732828,"Weeks Bay, Mobile Bay, AL",30.416900634765625,-87.82540130615234,America/Chicago
+8733502,"Fly Creek, Mobile Bay, AL",30.542800903320312,-87.9010009765625,America/Chicago
+8733821,"Point Clear, Mobile Bay, AL",30.48663888888889,-87.93452777777777,America/Chicago
+8733839,"Meaher State Park, Mobile Bay, AL",30.66716666666667,-87.93644444444445,America/Chicago
+8735180,"Dauphin Island, AL",30.25,-88.07499694824219,America/Chicago
+8735181,"Dauphin Island Hydro, AL",30.25131944444444,-88.07948611111111,America/Chicago
+8735391,"Dog River Bridge, AL",30.565200805664062,-88.08799743652344,America/Chicago
+8735523,"East Fowl River Bridge, AL",30.443700790405273,-88.11389923095703,America/Chicago
+8736897,"Coast Guard Sector Mobile, AL",30.6495,-88.05811111111112,America/Chicago
+8737048,"Mobile State Docks, AL",30.70461111111111,-88.03961111111111,America/Chicago
+8737138,"Chickasaw Creek, AL",30.78190040588379,-88.07360076904297,America/Chicago
+8737373,"Lower Bryant Landing, AL",30.9783,-87.8733,America/Chicago
+8738043,"West Fowl River Bridge, AL",30.37660026550293,-88.15859985351562,America/Chicago
+8739803,"Bayou La Batre Bridge, AL",30.40570068359375,-88.2477035522461,America/Chicago
+8740166,"Grand Bay Nerr, Mississippi Sound, MS",30.41319444444444,-88.4028888888889,America/Chicago
+8740405,"Petit Bois Island, Miss. Sound, MS",30.2033,-88.4417,America/Chicago
+8740448,"Point Of Pines, Bayou Cumbest, MS",30.3867,-88.44,America/Chicago
+8740993,"Pascagoula, South Side, MS",30.322200775146484,-88.50800323486328,America/Chicago
+8741041,"Dock E, Port Of Pascagoula, MS",30.3477778,-88.5058333,America/Chicago
+8741196,"Pascagoula Point, MS",30.34,-88.5333,America/Chicago
+8741533,"Pascagoula Noaa Lab, MS",30.36777777777778,-88.56305555555555,America/Chicago
+8742205,"Graveline Bayou Entrance, MS",30.3617,-88.6633,America/Chicago
+8742221,"Horn Island, MS",30.2383,-88.6667,America/Chicago
+8743081,"Hollingsworth Point, Davis Bayou, MS",30.3867,-88.7733,America/Chicago
+8743281,"Ocean Springs, MS",30.3917,-88.7983,America/Chicago
+8743735,"Biloxi (Cadet Point), MS",30.39,-88.8567,America/Chicago
+8744117,"Biloxi, MS",30.4117,-88.9033,America/Chicago
+8744756,"Ship Island, Mississippi Sound, MS",30.2133,-88.9717,America/Chicago
+8745101,"Handsboro Bridge, Bernard Bayou, MS",30.4067,-89.0267,America/Chicago
+8745375,"Turkey Creek, Bernard Bayou, MS",30.4267,-89.0533,America/Chicago
+8745557,"Gulfport Harbor, MS",30.36,-89.0817,America/Chicago
+8745799,"Cat Island, Mississippi Sound, MS",30.2317,-89.1167,America/Chicago
+8746819,"Pass Christian Yacht Club, Miss. Sound, MS",30.31,-89.245,America/Chicago
+8747437,"Bay Waveland Yacht Club, MS",30.32634166666667,-89.3258,America/Chicago
+8747766,"Waveland, MS",30.2817,-89.3667,America/Chicago
+8749704,"Pearlington, Pearl River, MS",30.24,-89.615,America/Chicago
+8760412,"North Pass, LA",29.205,-89.0367,America/Chicago
+8760417,"Devon Energy Facility, LA",29.20075,-89.04446666666666,America/Chicago
+8760551,"South Pass, LA",28.99,-89.14,America/Chicago
+8760595,"Breton Island, LA",29.4933,-89.1733,America/Chicago
+8760668,"Grand Pass, LA",30.126699447631836,-89.2217025756836,America/Chicago
+8760721,"Pilottown, LA",29.17930555555556,-89.25883333333333,America/Chicago
+8760742,"Comfort Island, LA",29.8233,-89.27,America/Chicago
+8760889,"Olga Compressor Station, Grand Bay, LA",29.38655555555556,-89.3801388888889,America/Chicago
+8760922,"Pilots Station East, S.W. Pass, LA",28.9322,-89.4075,America/Chicago
+8760943,"Sw Pass, LA",28.925,-89.4183,America/Chicago
+8761108,"Bay Gardene, LA",29.5983,-89.6183,America/Chicago
+8761115,"Bay Pomme D'Or, LA",29.35059928894043,-89.53990173339844,America/Chicago
+8761305,"Shell Beach, LA",29.86811111111111,-89.67325,America/Chicago
+8761402,"The Rigolets, LA",30.1667,-89.7367,America/Chicago
+8761431,"Rat Bayou, LA",29.56669444444444,-89.76336111111111,America/Chicago
+8761432,"Bayou Chene, LA",29.512699127197266,-89.7645034790039,America/Chicago
+8761473,"Rt. 433, Bayou Bonfouca, LA",30.2717,-89.7933,America/Chicago
+8761487,"Chef Menteur, Chef Menteur Pass, LA",30.065,-89.8,America/Chicago
+8761529,"Martello Castle, Lake Borgne, LA",29.945,-89.835,America/Chicago
+8761678,"Michoud Substation, Icww, LA",30.0067,-89.9367,America/Chicago
+8761724,"Grand Isle, LA",29.26333333333333,-89.95666666666666,America/Chicago
+8761742,"Mendicant Island, Barataria Bay, LA",29.318300247192383,-89.9800033569336,America/Chicago
+8761819,"Texaco Dock, Hackberry Bay, LA",29.4017,-90.0383,America/Chicago
+8761826,"Cheniere Caminada, Caminada Pass, LA",29.209999084472656,-90.04000091552734,America/Chicago
+8761899,"Lafitte, Barataria Waterway, LA",29.6667,-90.1117,America/Chicago
+8761927,"New Canal Station, LA",30.02722222222222,-90.11333333333333,America/Chicago
+8761993,"Tchefuncta River, Lake Pont, LA",30.3783,-90.16,America/Chicago
+8762075,"Port Fourchon, Belle Pass, LA",29.114200592041016,-90.19930267333984,America/Chicago
+8762084,"Leeville, Bayou Lafourche, LA",29.2483,-90.2117,America/Chicago
+8762184,"Golden Meadow, Plaisance Canal, LA",29.373300552368164,-90.26499938964844,America/Chicago
+8762223,"East Timbalier Island, Timbalier Bay, LA",29.0767,-90.285,America/Chicago
+8762329,"Bayou Faleau, LA",29.47038888888889,-90.34222222222222,America/Chicago
+8762372,"East Bank 1, Norco, B. Labranche, LA",30.05033333333333,-90.368,America/Chicago
+8762525,"Pointe Au Chien, Cut Off Canal, LA",29.41670036315918,-90.44670104980469,America/Chicago
+8762888,"E. Isle Dernieres, Lake Pelto, LA",29.0717,-90.64,America/Chicago
+8762928,"Cocodrie, LA",29.245,-90.6617,America/Chicago
+8763506,"Raccoon Point, Isle Dernieres, LA",29.0633,-90.9617,America/Chicago
+8763535,"Texas Gas Platform, Caillou Bay, LA",29.17477777777778,-90.97644444444444,America/Chicago
+8763843,"Fourleague Bay, LA",29.341800689697266,-91.135498046875,America/Chicago
+8764025,"Stouts Pass At Six Mile Lake, LA",29.7433,-91.23,America/Chicago
+8764044,"Berwick, Atchafalaya River, LA",29.6675,-91.23761111111111,America/Chicago
+8764165,"Shell Island,Atchafalaya Bay, LA",29.4733,-91.305,America/Chicago
+8764227,"Lawma, Amerada Pass, LA",29.449600219726562,-91.33809661865234,America/Chicago
+8764256,"Point Au Fer, LA",29.3333,-91.3533,America/Chicago
+8764314,"Eugene Island, North Of, Atchafalaya Bay, LA",29.36750030517578,-91.38390350341797,America/Chicago
+8765026,"Marsh Is., Atchafalaya Bay, LA",29.485,-91.7633,America/Chicago
+8765148,"Weeks Bay, LA",29.83722222222222,-91.8375,America/Chicago
+8765251,"Cypremort Point, LA",29.71336111111111,-91.88,America/Chicago
+8765746,"Bayou Fearman, Vermillion Bay, LA",29.674400329589844,-92.13520050048828,America/Chicago
+8765785,"Intracoastal City, LA",29.783000946044922,-92.15560150146484,America/Chicago
+8765969,"Freshwater Bayou, LA",29.655399322509766,-92.25070190429688,America/Chicago
+8765994,"Schooner Bayou, LA",29.758100509643555,-92.26380157470703,America/Chicago
+8766072,"Freshwater Canal Locks, LA",29.55169444444444,-92.30519444444444,America/Chicago
+8766941,"Joseph Harbor, LA",29.637500762939453,-92.76719665527344,America/Chicago
+8767095,"Catfish Point, LA",29.862899780273438,-92.8488998413086,America/Chicago
+8767403,"Mermentau River, Grand Chenier, LA",29.774999618530273,-93.00830078125,America/Chicago
+8767816,"Lake Charles, LA",30.2236111,-93.2216667,America/Chicago
+8767911,"East Calcasieu Lake, LA",29.993900299072266,-93.27050018310547,America/Chicago
+8767961,"Bulk Terminal, LA",30.19029998779297,-93.30069732666016,America/Chicago
+8768094,"Calcasieu Pass, LA",29.76816666666667,-93.3428888888889,America/Chicago
+8768772,"Gum Cove, Icww, LA",30.058700561523438,-93.52259826660156,America/Chicago
+8769858,"East Sabine Lake, LA",29.812700271606445,-93.86209869384766,America/Chicago
+8770475,"Port Arthur, TX",29.86669921875,-93.93000030517578,America/Chicago
+8770520,"Rainbow Bridge, TX",29.979999542236328,-93.88169860839844,America/Chicago
+8770542,"Buffalo Bayou, TX",29.761899948120117,-95.34429931640625,America/Chicago
+8770570,"Sabine Pass North, TX",29.7284,-93.8701,America/Chicago
+8770613,"Morgans Point, Barbours Cut, TX",29.6816667,-94.985,America/Chicago
+8770625,"Umbrella Point, Trinity Bay, TX",29.68,-94.8683,America/Chicago
+8770653,"Cypress, San Jacinto River, TX",29.84670066833496,-95.08830261230469,America/Chicago
+8770733,"Lynchburg Landing (Tcoon), TX",29.765,-95.0783,America/Chicago
+8770743,"Battleship Texas State Park, TX",29.75670051574707,-95.08999633789062,America/Chicago
+8770752,"Cox Wc-53 Platform, TX",29.62400054931641,-93.75,America/Chicago
+8770777,"Manchester, TX",29.726299285888672,-95.26580047607422,America/Chicago
+8770808,"High Island, TX",29.59469985961914,-94.39029693603516,America/Chicago
+8770822,"Texas Point, Sabine Pass, TX",29.689300537109375,-93.841796875,America/Chicago
+8770931,"Smith Point, Galveston Bay, TX",29.535,-94.7817,America/Chicago
+8770933,"Clear Lake, TX",29.5633,-95.0667,America/Chicago
+8770971,"Rollover Pass, TX",29.514999389648438,-94.51329803466797,America/Chicago
+8771013,"Eagle Point, Galveston Bay, TX",29.48130555555555,-94.91725277777778,America/Chicago
+8771050,"Renaissance Sa-13 Platform, TX",29.47900009155273,-93.63999938964844,Etc/GMT+6
+8771074,"Fieldwood Wc-289 Platform, TX",29.34700012207031,-93.63500213623047,Etc/GMT+6
+8771165,"Goat Island, TX",29.431100845336914,-94.71040344238281,America/Chicago
+8771262,"Texas City, TX",29.390600204467773,-94.88490295410156,America/Chicago
+8771328,"Port Bolivar, TX",29.365,-94.78,America/Chicago
+8771341,"Galveston Bay Entrance, North Jetty, TX",29.35746111111111,-94.724725,America/Chicago
+8771367,"Sabine Offshore Light, TX",29.4689998626709,-93.72000122070312,America/Chicago
+8771416,"Galveston Bay Entrance, South Jetty, TX",29.32670021057129,-94.69329833984375,America/Chicago
+8771450,"Galveston Pier 21, TX",29.31,-94.79330555555556,America/Chicago
+8771486,"Galveston Railroad Bridge, TX",29.302600860595703,-94.89710235595703,America/Chicago
+8771510,"Galveston Pleasure Pier, TX",29.2853,-94.7894,America/Chicago
+8771722,"Jamaica Beach, TX",29.19860076904297,-94.98829650878906,America/Chicago
+8771801,"Alligator Point, West Bay, TX",29.1667,-95.125,America/Chicago
+8771972,"San Luis Pass, TX",29.094999313354492,-95.11329650878906,America/Chicago
+8772132,"Christmas Bay, TX",29.0417,-95.175,America/Chicago
+8772391,"Old Brazos River Freeport, TX",28.96109962463379,-95.36740112304688,America/Chicago
+8772440,"Freeport, TX",28.9483,-95.3083,America/Chicago
+8772447,"Freeport, TX",28.94330555555555,-95.3025,America/Chicago
+8772471,"Freeport Harbor, TX",28.935699462890625,-95.29419708251953,America/Chicago
+8772479,"Freeport Entrance Jetty, TX",28.930299758911133,-95.30590057373047,America/Chicago
+8772985,"Sargent, TX",28.77163888888889,-95.61683333333333,America/Chicago
+8773037,"Seadrift, TX",28.40690040588379,-96.71240234375,America/Chicago
+8773146,"Matagorda City, TX",28.709999084472656,-95.91390228271484,America/Chicago
+8773259,"Port Lavaca, TX",28.640600204467773,-96.60980224609375,America/Chicago
+8773701,"Port O'Connor, TX",28.45170021057129,-96.38829803466797,America/Chicago
+8773767,"Matagorda Bay Entrance Channel, TX",28.42690086364746,-96.3301010131836,America/Chicago
+8773808,"Barroom Bay, TX",28.402999877929688,-96.48079681396484,America/Chicago
+8773896,"Shoalwater Flats, TX",28.364500045776367,-96.5802993774414,America/Chicago
+8774230,"Aransas Wildlife Refuge, TX",28.228300094604492,-96.79499816894531,America/Chicago
+8774513,"Copano Bay, TX",28.118305206298828,-97.02169799804688,America/Chicago
+8774652,"Bayside, Copano Bay, TX",28.068300247192383,-97.19560241699219,America/Chicago
+8774770,"Rockport, TX",28.0216667,-97.0466667,America/Chicago
+8775083,"Aransas Pass, Redfish Bay, TX",27.908100128173828,-97.13529968261719,America/Chicago
+8775131,"Portland, TX",27.88279914855957,-97.34310150146484,America/Chicago
+8775132,"La Quinta Channel North, TX",27.880399703979492,-97.27349853515625,America/Chicago
+8775222,"Viola Turning Basin, TX",27.846099853515625,-97.52069854736328,America/Chicago
+8775237,"Port Aransas, TX",27.83970069885254,-97.07250213623047,America/Chicago
+8775241,"Aransas, Aransas Pass, TX",27.836599349975586,-97.03910064697266,America/Chicago
+8775244,"Nueces Bay, TX",27.832799911499023,-97.48590087890625,America/Chicago
+8775270,"Port Aransas, H. Caldwell Pier, TX",27.82670021057129,-97.05000305175781,America/Chicago
+8775283,"Enbridge, Ingleside, TX",27.81861111111111,-97.20894444444444,America/Chicago
+8775296,"Uss Lexington, Corpus Christi Bay, TX",27.814899444580078,-97.38919830322266,America/Chicago
+8775421,"Naval Air Station, TX",27.704999923706055,-97.27999877929688,America/Chicago
+8775792,"Packery Channel, TX",27.63330078125,-97.23670196533203,America/Chicago
+8775870,"Bob Hall Pier, Corpus Christi, TX",27.579999923706055,-97.2166976928711,America/Chicago
+8778485,"Padre Island, Port Mansfield Channel Ent, TX",26.564199447631836,-97.27649688720703,America/Chicago
+8779280,"Realitos Peninsula, TX",26.262399673461914,-97.2853012084961,America/Chicago
+8779724,"Queen Isabella Causeway, TX",26.0783,-97.17,America/Chicago
+8779739,"W Queen Isabella Causeway, Port Isabel, TX",26.0717,-97.1917,America/Chicago
+8779748,"South Padre Island Cg Station, TX",26.07309913635254,-97.1675033569336,America/Chicago
+8779749,"Spi Brazos Santiago, TX",26.0674991607666,-97.15480041503906,America/Chicago
+8779750,"South Padre Island, Brazos Santiago Pass, TX",26.0683,-97.1567,America/Chicago
+8779768,"South Bay, TX",26.0517,-97.1817,America/Chicago
+8779770,"Port Isabel, TX",26.06116666666667,-97.21552777777778,America/Chicago
+8779911,"San Martin Lake Channel, TX",26.001800537109375,-97.29859924316406,America/Chicago
+9410032,"Wilson Cove, San Clemente Is., CA",33.005001068115234,-118.55699920654297,America/Los_Angeles
+9410079,"Avalon, Santa Catalina Island, CA",33.345001220703125,-118.32499694824219,America/Los_Angeles
+9410120,"Imperial Beach, Pacific Ocean, CA",32.5783,-117.135,America/Los_Angeles
+9410135,"South San Diego Bay, CA",32.62910079956055,-117.10780334472656,America/Los_Angeles
+9410170,"San Diego, CA",32.71555555555555,-117.1766666666667,America/Los_Angeles
+9410196,"Mission Bay, CA",32.793701171875,-117.22380065917969,America/Los_Angeles
+9410230,"La Jolla, CA",32.86688888888889,-117.2571388888889,America/Los_Angeles
+9410580,"Newport Beach, Newport Bay Entrance, CA",33.6033,-117.883,America/Los_Angeles
+9410650,"Cabrillo Beach, CA",33.7067,-118.273,America/Los_Angeles
+9410660,"Los Angeles, CA",33.72,-118.272,America/Los_Angeles
+9410680,"Long Beach, Terminal Island, CA",33.7517,-118.227,America/Los_Angeles
+9410738,"King Harbor, Santa Monica Bay, CA",33.8467,-118.398,America/Los_Angeles
+9410840,"Santa Monica, CA",34.0083,-118.5,America/Los_Angeles
+9410962,"Bechers Bay, Santa Rosa Island, CA",34.0083,-120.047,America/Los_Angeles
+9410971,"Prisoners Harbor, Santa Cruz Is., CA",34.02,-119.683,America/Los_Angeles
+9411270,"Rincon Island, Pacific Ocean, CA",34.3483,-119.443,America/Los_Angeles
+9411340,"Santa Barbara, CA",34.40458888888889,-119.6924944444445,America/Los_Angeles
+9411399,"Gaviota State Park, Pacific Ocean, CA",34.46938888888889,-120.2283055555556,America/Los_Angeles
+9411406,"Oil Platform Harvest, CA",34.46916666666667,-120.6819444444444,America/Los_Angeles
+9412110,"Port San Luis, CA",35.16888888888889,-120.7541666666667,America/Los_Angeles
+9412553,"San Simeon, CA",35.6417,-121.188,America/Los_Angeles
+9412802,"Mansfield Cone, CA",35.94952777777777,-121.4819444444445,America/Los_Angeles
+9413450,"Monterey, CA",36.6088889,-121.8913889,America/Los_Angeles
+9413616,"Moss Landing, CA",36.8017,-121.79,America/Los_Angeles
+9413623,"Elkhorn Slough, Entrance Bridge, CA",36.81,-121.785,America/Los_Angeles
+9413631,"Elkhorn Slough At Elkhorn, CA",36.81829833984375,-121.74700164794922,America/Los_Angeles
+9413643,"Tidal Creek, Elkhorn Slough, CA",36.83330154418945,-121.74500274658203,America/Los_Angeles
+9413651,"Kirby Park, Elkhorn Slough, CA",36.84130096435547,-121.74530029296875,America/Los_Angeles
+9413663,"Elkhorn Slough Railroad Bridge, CA",36.85667,-121.755,America/Los_Angeles
+9414131,"Pillar Point Harbor, CA",37.5025,-122.4821666666667,America/Los_Angeles
+9414290,"San Francisco, CA",37.80630555555555,-122.4658888888889,America/Los_Angeles
+9414305,"North Point, Pier 41, S.F.Bay, CA",37.81,-122.413,America/Los_Angeles
+9414317,"Pier 22 1/2, San Francisco, CA",37.79,-122.387,America/Los_Angeles
+9414358,"Hunters Point, S.F. Bay, CA",37.73,-122.357,America/Los_Angeles
+9414392,"Oyster Point Marina, San Francisco Bay, CA",37.665,-122.377,America/Los_Angeles
+9414458,"San Mateo Bridge, CA",37.58,-122.253,America/Los_Angeles
+9414501,"Redwood Creek,C.M. No. 8,S.F.Bay, CA",37.5333,-122.193,America/Los_Angeles
+9414506,"Newark Slough,S.F.Bay, CA",37.5133,-122.08,America/Los_Angeles
+9414509,"Dumbarton Bridge, CA",37.5067,-122.115,America/Los_Angeles
+9414519,"Mowry Slough, San Francisco Bay, CA",37.4933,-122.042,America/Los_Angeles
+9414523,"Redwood City, CA",37.50681388888889,-122.2119055555556,America/Los_Angeles
+9414525,"Palo Alto Yacht Harbor, S. F. Bay, CA",37.4583,-122.105,America/Los_Angeles
+9414551,"Gold Street Bridge, Alviso Slough, CA",37.4233,-121.975,America/Los_Angeles
+9414561,"Coyote Creek, Tributary #1, S. F. Bay, CA",37.4467,-121.963,America/Los_Angeles
+9414575,"Coyote Creek, CA",37.465,-122.023,America/Los_Angeles
+9414609,"South Bay Wreck,S.F.Bay, CA",37.5517,-122.162,America/Los_Angeles
+9414621,"Coyote Hills Slough,S.F.Bay, CA",37.5633,-122.128,America/Los_Angeles
+9414632,"Alameda Creek, San Francisco Bay, CA",37.595,-122.145,America/Los_Angeles
+9414637,"San Mateo Bridge,East End, CA",37.6083,-122.182,America/Los_Angeles
+9414688,"San Leandro Marina, CA",37.695,-122.192,America/Los_Angeles
+9414711,"Oakland Airport, San Francisco Bay, CA",37.7317,-122.208,America/Los_Angeles
+9414746,"Park Street Bridge, CA",37.7717,-122.235,America/Los_Angeles
+9414750,"Alameda, CA",37.77195277777778,-122.3002611111111,America/Los_Angeles
+9414764,"Oakland Inner Harbor, CA",37.79499816894531,-122.28199768066406,America/Los_Angeles
+9414767,"Alameda Nas, Navy Fuel Pier, CA",37.7933,-122.315,America/Los_Angeles
+9414777,"Oakland Middle Harbor, Pier 40, CA",37.805,-122.338,America/Los_Angeles
+9414779,"Oakland,Matson Wharf,S.F.Bay, CA",37.81,-122.327,America/Los_Angeles
+9414782,"Yerba Buena Island, San Francisco Bay, CA",37.81,-122.36,America/Los_Angeles
+9414785,"Grant Line Canal Brdg.,Old River, CA",37.82,-121.447,America/Los_Angeles
+9414806,"Sausalito, San Francisco Bay, CA",37.8467,-122.477,America/Los_Angeles
+9414811,"Bradmoor Island, CA",38.1833,-121.923,America/Los_Angeles
+9414816,"Berkeley,S.F.Bay, CA",37.8650016784668,-122.30699920654297,America/Los_Angeles
+9414818,"Angel Island, East Garrison, S.F. Bay, CA",37.8633,-122.42,America/Los_Angeles
+9414819,"Sausalito, Coe Dock, S.F. Bay, CA",37.865,-122.493,America/Los_Angeles
+9414835,"Borden Highway Bridge, Middle River, CA",37.8917,-121.488,America/Los_Angeles
+9414836,"Borden Hwy Bridge,Old River, CA",37.8833,-121.577,America/Los_Angeles
+9414837,"Point Chauncey, Richardson Bay, CA",37.8917,-122.443,America/Los_Angeles
+9414849,"Richmond Inner Harbor, San Francisco Bay, CA",37.91,-122.358,America/Los_Angeles
+9414863,"Richmond, CA",37.92829895019531,-122.4000015258789,America/Los_Angeles
+9414866,"Holt, Whiskey Slough, CA",37.935,-121.435,America/Los_Angeles
+9414868,"Orwood,Old River, CA",37.9383,-121.56,America/Los_Angeles
+9414873,"Point San Quentin, San Francisco Bay, CA",37.945,-122.475,America/Los_Angeles
+9414874,"Corte Madera Creek, CA",37.94329833984375,-122.51300048828125,America/Los_Angeles
+9414881,"Point Orient, CA",37.9583,-122.425,America/Los_Angeles
+9414883,"Stockton,San Joaquin River, CA",37.9583,-121.29,America/Los_Angeles
+9414958,"Bolinas, Bolinas Lagoon, CA",37.90800094604492,-122.67849731445312,America/Los_Angeles
+9415009,"Point San Pedro, San Francisco Bay, CA",37.9933,-122.447,America/Los_Angeles
+9415020,"Point Reyes, CA",37.9941667,-122.9736111,America/Los_Angeles
+9415021,"Blackslough Landing, San Joaquin River, CA",37.994998931884766,-121.41999816894531,America/Los_Angeles
+9415052,"Gallinas, Gallinas Creek, CA",38.015,-122.503,America/Los_Angeles
+9415053,"Dutch Slough, CA",38.0117,-121.638,America/Los_Angeles
+9415056,"Pinole Point, San Pablo Bay, CA",38.015,-122.363,America/Los_Angeles
+9415064,"Antioch, San Joaquin River, CA",38.02,-121.815,America/Los_Angeles
+9415074,"Hercules Wharf, CA",38.0233,-122.292,America/Los_Angeles
+9415096,"Pittsburg, New York Slough, Suisun Bay, CA",38.0367,-121.88,America/Los_Angeles
+9415102,"Martinez-Amorco Pier, CA",38.03463888888889,-122.1251944444445,America/Los_Angeles
+9415105,"Wards Island, San Joaquin River, CA",38.04999923706055,-121.49700164794922,America/Los_Angeles
+9415111,"Benicia, Carquinez Strait, CA",38.0433,-122.13,America/Los_Angeles
+9415112,"Mallard Island, Suisun Bay, CA",38.0433,-121.918,America/Los_Angeles
+9415117,"Bishop Cut, Dissapointment Slough, CA",38.045,-121.42,America/Los_Angeles
+9415143,"Crockett, Carquinez Strait, CA",38.0583,-122.223,America/Los_Angeles
+9415144,"Port Chicago, CA",38.056,-122.0395,America/Los_Angeles
+9415145,"Jersey Island, False River, CA",38.055,-121.657,America/Los_Angeles
+9415149,"Prisoners Point, San Joaquin River, CA",38.0617,-121.555,America/Los_Angeles
+9415165,"Mare Island Strait, CA",38.1117,-122.273,America/Los_Angeles
+9415176,"Collinsville,Sacramento River, CA",38.0733,-121.848,America/Los_Angeles
+9415193,"Three Mile Slough,San Joaquin R., CA",38.086700439453125,-121.68499755859375,America/Los_Angeles
+9415205,"Montezuma Slough, Suisun Bay, CA",38.0767,-121.885,America/Los_Angeles
+9415218,"Mare Island, CA",38.07,-122.25,America/Los_Angeles
+9415228,"Inverness, Tomales Bay, CA",38.1133,-122.868,America/Los_Angeles
+9415229,"Korths Hbr, San Joaquin River, CA",38.097599029541016,-121.56839752197266,America/Los_Angeles
+9415236,"Three Mile Slough,Sacramento R., CA",38.1067,-121.7,America/Los_Angeles
+9415252,"Petaluma River Entrance, CA",38.11530555555556,-122.5056666666667,America/Los_Angeles
+9415257,"Terminous,Mokelumne River, CA",38.11,-121.498,America/Los_Angeles
+9415265,"Suisun Slough Entrance, CA",38.1283,-122.073,America/Los_Angeles
+9415266,"Pierce Harbor,Goodyear Slough, CA",38.1267,-122.1,America/Los_Angeles
+9415287,"Georgiana Slough, Mokelumne River, CA",38.125,-121.578,America/Los_Angeles
+9415307,"Meins Landing, Montezuma Slough, CA",38.1367,-121.907,America/Los_Angeles
+9415316,"Rio Vista, CA",38.145,-121.692,America/Los_Angeles
+9415338,"Sonoma Creek Entrance, CA",38.1567,-122.407,America/Los_Angeles
+9415344,"Hog Is.,San Antonio Creek, CA",38.1617,-122.55,America/Los_Angeles
+9415379,"Joice Island, Suisun Slough, CA",38.18,-122.045,America/Los_Angeles
+9415396,"Blake Landing,Tomales Bay, CA",38.19,-122.917,America/Los_Angeles
+9415402,"Montezuma Slough Bridge, CA",38.1867,-121.98,America/Los_Angeles
+9415414,"Steamboat Slough, CA",38.1833,-121.655,America/Los_Angeles
+9415415,"Edgerley Island, Napa River, CA",38.1917,-122.312,America/Los_Angeles
+9415446,"Brazos Drawbridge,Napa River, CA",38.21,-122.307,America/Los_Angeles
+9415447,"Wingo, Sonoma Creek, CA",38.21,-122.427,America/Los_Angeles
+9415478,"New Hope Bridge, Mokelumne River, CA",38.2267,-121.49,America/Los_Angeles
+9415498,"Suisun City, Suisun Slough, CA",38.2367,-122.03,America/Los_Angeles
+9415565,"Snodgrass Slough, CA",38.2767,-121.495,America/Los_Angeles
+9415584,"Petaluma River, Upper Drawbridge, CA",38.2283,-122.613,America/Los_Angeles
+9415623,"Napa, Napa River, CA",38.2983,-122.28,America/Los_Angeles
+9415846,"Clarksburg,Sacramento River, CA",38.4167,-121.523,America/Los_Angeles
+9416131,"Port Of West Sacramento, Washington Lake, CA",38.56224822998047,-121.54630279541016,America/Los_Angeles
+9416174,"Sacramento, Sacramento River, CA",38.58,-121.507,America/Los_Angeles
+9416409,"Green Cove, CA",38.70433333333333,-123.4493888888889,America/Los_Angeles
+9416841,"Arena Cove, CA",38.91455555555556,-123.7110833333333,America/Los_Angeles
+9417426,"Noyo Harbor, CA",39.42577777777778,-123.8051111111111,America/Los_Angeles
+9418024,"Shelter Cove, CA",40.025001525878906,-124.05799865722656,America/Los_Angeles
+9418637,"Cockrobin Island Bridge, CA",40.63719940185547,-124.2822036743164,America/Los_Angeles
+9418686,"Hookton Slough,Humboldt Bay, CA",40.6867,-124.222,America/Los_Angeles
+9418723,"Fields Landing, Humboldt Bay, CA",40.7233,-124.222,America/Los_Angeles
+9418767,"North Spit, CA",40.76690555555555,-124.2173444444445,America/Los_Angeles
+9418778,"Bucksport, Humboldt Bay, CA",40.7783,-124.197,America/Los_Angeles
+9418801,"Eureka, CA",40.8067,-124.167,America/Los_Angeles
+9418802,"Eureka Slough, Humboldt Bay, CA",40.8067,-124.142,America/Los_Angeles
+9418817,"Samoa, Humboldt Bay, CA",40.8267,-124.18,America/Los_Angeles
+9418865,"Mad River Slough, Arcata Bay, CA",40.865,-124.148,America/Los_Angeles
+9419059,"Trinidad Harbor, CA",41.0567,-124.147,America/Los_Angeles
+9419750,"Crescent City, CA",41.74561111111111,-124.1843888888889,America/Los_Angeles
+9419945,"Pyramid Point, CA",41.94525,-124.2009166666667,America/Los_Angeles
+9431011,"Gold Beach, OR",42.42163888888889,-124.4187222222222,America/Los_Angeles
+9431647,"Port Orford, OR",42.73899841308594,-124.49829864501953,America/Los_Angeles
+9432373,"Bandon, Coquille River, OR",43.12,-124.413,America/Los_Angeles
+9432436,"Coquille River, OR",43.157901763916016,-124.18180084228516,America/Los_Angeles
+9432780,"Charleston, OR",43.345001220703125,-124.3219985961914,America/Los_Angeles
+9432879,"Sitka Dock, Coos Bay, OR",43.3767,-124.297,America/Los_Angeles
+9433445,"Half Moon Bay, OR",43.675,-124.192,America/Los_Angeles
+9433501,"Reedsport, OR",43.70830154418945,-124.0979995727539,America/Los_Angeles
+9434068,"Cushman, OR",43.98500061035156,-124.04499816894531,America/Los_Angeles
+9434098,"Florence Uscg Pier, Siuslaw River, OR",44.00210189819336,-124.12300109863281,America/Los_Angeles
+9434938,"Drift Creek, Alsea River, OR",44.4133,-123.99,America/Los_Angeles
+9434939,"Waldport, OR",44.43436111111111,-124.0580833333333,America/Los_Angeles
+9435308,"Weiser Point, Yaquina River, OR",44.5933,-124.008,America/Los_Angeles
+9435362,"Toledo, OR",44.6167,-123.937,America/Los_Angeles
+9435380,"South Beach, OR",44.62544444444445,-124.0449444444444,America/Los_Angeles
+9435385,"Yaquina Uscg Sta, Newport, OR",44.6267,-124.055,America/Los_Angeles
+9435992,"Chinook Bend, OR",44.880001068115234,-123.9636001586914,America/Los_Angeles
+9436031,"Kernville, Siletz River, OR",44.8967,-124.0,America/Los_Angeles
+9436381,"Cascade Head, Salmon River, OR",45.04794444444445,-124.0073055555556,America/Los_Angeles
+9437262,"Netarts, Netarts Bay, OR",45.43,-123.945,America/Los_Angeles
+9437381,"Dick Point, OR",45.4817,-123.902,America/Los_Angeles
+9437540,"Garibaldi, OR",45.55453,-123.9189444443915,America/Los_Angeles
+9437585,"North Jetty, Tillamook Bay, OR",45.56999969482422,-123.96499633789062,America/Los_Angeles
+9437954,"North Fork, OR",45.73379898071289,-123.87640380859375,America/Los_Angeles
+9438772,"Cathcart Landing, OR",46.12425,-123.8043333333333,America/Los_Angeles
+9439011,"Hammond, OR",46.2017,-123.945,America/Los_Angeles
+9439026,"Astoria, Youngs Bay, OR",46.1717,-123.842,America/Los_Angeles
+9439040,"Astoria, OR",46.207305908203125,-123.76830291748047,America/Los_Angeles
+9439069,"Knappa, OR",46.1867,-123.588,America/Los_Angeles
+9439099,"Wauna, OR",46.15999984741211,-123.40499877929688,America/Los_Angeles
+9439189,"Rocky Point, OR",45.6967,-122.868,America/Los_Angeles
+9439201,"St Helens, OR",45.8650016784668,-122.7969970703125,America/Los_Angeles
+9439221,"Portland Morrison Street Bridge, OR",45.51,-122.673,America/Los_Angeles
+9440047,"Washougal, Columbia River, WA",45.57830047607422,-122.38200378417969,America/Los_Angeles
+9440079,"Beacon Rock State Park, WA",45.62030029296875,-122.02030181884766,America/Los_Angeles
+9440083,"Vancouver, WA",45.63117222222222,-122.6957722222222,America/Los_Angeles
+9440171,"Knapp(Thornes)Lndg, Willow Bar, WA",45.74169921875,-122.75499725341797,America/Los_Angeles
+9440357,"Temco Kalama Terminal, WA",45.986698150634766,-122.83670043945312,America/Los_Angeles
+9440422,"Longview, WA",46.10609817504883,-122.9542007446289,America/Los_Angeles
+9440482,"Cape Horn, Columbia River, WA",46.15169906616211,-123.29000091552734,America/Los_Angeles
+9440483,"Barlow Point, WA",46.152198791503906,-123.03919982910156,America/Los_Angeles
+9440569,"Skamokawa, WA",46.27030555555555,-123.4565,America/Los_Angeles
+9440572,"Jetty A, Columbia River, WA",46.2683,-124.037,America/Los_Angeles
+9440574,"North Jetty, WA",46.2733,-124.072,America/Los_Angeles
+9440581,"Cape Disappointment, WA",46.28102777777778,-124.0462777777778,America/Los_Angeles
+9440650,"Greenhead Slough, WA",46.37220001220703,-123.95030212402344,America/Los_Angeles
+9440846,"Bay Center, Palix River, Willapa Bay, WA",46.6233,-123.945,America/Los_Angeles
+9440875,"South Bend, WA",46.6633,-123.798,America/Los_Angeles
+9440910,"Toke Point, WA",46.7075,-123.9669444,America/Los_Angeles
+9441102,"Westport, WA",46.90431,-124.1050833331214,America/Los_Angeles
+9441156,"Point Brown, WA",46.95,-124.128,America/Los_Angeles
+9441187,"Aberdeen, WA",46.9683,-123.853,America/Los_Angeles
+9442396,"La Push, Quillayute River, WA",47.91283611111111,-124.6357388888889,America/Los_Angeles
+9442705,"Tskawahyah Island, Cape Alava, WA",48.17110061645508,-124.73690032958984,America/Los_Angeles
+9442861,"Makah Bay, WA",48.2967,-124.672,America/Los_Angeles
+9443090,"Neah Bay, WA",48.37072222222222,-124.6015888888889,America/Los_Angeles
+9443361,"Sekiu, Clallam Bay, WA",48.2633,-124.297,America/Los_Angeles
+9443551,"Jim Creek, WA",48.187198638916016,-124.0625,America/Los_Angeles
+9443826,"Crescent Bay, WA",48.1617,-123.725,America/Los_Angeles
+9444090,"Port Angeles, WA",48.125,-123.44000244140625,America/Los_Angeles
+9444122,"Ediz Hook, WA",48.14,-123.413,America/Los_Angeles
+9444900,"Port Townsend, WA",48.11122222222222,-122.7596777777778,America/Los_Angeles
+9445016,"Foulweather Bluff, WA",47.9267,-122.617,America/Los_Angeles
+9445088,"Lofall, WA",47.815,-122.657,America/Los_Angeles
+9445133,"Bangor, WA",47.7483,-122.727,America/Los_Angeles
+9445246,"Whitney Point, WA",47.7617,-122.85,America/Los_Angeles
+9445272,"Quilcene, Dabob Bay, Hood Canal, WA",47.8,-122.858,America/Los_Angeles
+9445441,"Lynch Cove Dock, WA",47.4183,-122.9,America/Los_Angeles
+9445478,"Union, Hood Canal, WA",47.3583,-123.098,America/Los_Angeles
+9445526,"Hansville, WA",47.9183,-122.545,America/Los_Angeles
+9445719,"Poulsbo, WA",47.725,-122.638,America/Los_Angeles
+9445832,"Brownsville, WA",47.6517,-122.615,America/Los_Angeles
+9445938,"Clam Bay, WA",47.5733,-122.543,America/Los_Angeles
+9445958,"Bremerton, WA",47.56169891357422,-122.62300109863281,America/Los_Angeles
+9446281,"Allyn, WA",47.3833,-122.823,America/Los_Angeles
+9446291,"Wauna, WA",47.378299713134766,-122.63400268554688,America/Los_Angeles
+9446451,"Green Point, WA",47.3017,-122.682,America/Los_Angeles
+9446484,"Tacoma, WA",47.266700744628906,-122.41329956054688,America/Los_Angeles
+9446500,"Home, Puget Sound, WA",47.275,-122.758,America/Los_Angeles
+9446705,"Yoman Point, Anderson Island, WA",47.18,-122.675,America/Los_Angeles
+9446742,"Barron Point, Little Skookum Inlet Ent, WA",47.156700134277344,-123.00800323486328,America/Los_Angeles
+9446804,"Sandy Point Anderson Island, Puget Sound, WA",47.15299987792969,-122.67510223388672,America/Los_Angeles
+9446807,"Budd Inlet, South Of Gull Harbor, WA",47.0983,-122.895,America/Los_Angeles
+9446969,"Olympia, Bud Inlet, Puget Sound, WA",47.06,-122.903,America/Los_Angeles
+9447110,"Lockheed Shipyard, WA",47.585,-122.362,America/Los_Angeles
+9447130,"Seattle, WA",47.60263888888889,-122.3393055555556,America/Los_Angeles
+9447427,"Edmonds, WA",47.8133,-122.383,America/Los_Angeles
+9447659,"Everett, WA",47.98,-122.223,America/Los_Angeles
+9447717,"Priest Point, WA",48.03494444444444,-122.2271944444445,America/Los_Angeles
+9447773,"Tulalip, Tulalip Bay, WA",48.065,-122.288,America/Los_Angeles
+9447855,"Holly Harbor Farms, WA",48.0267,-122.535,America/Los_Angeles
+9447883,"Green Bank, WA",48.105,-122.57,America/Los_Angeles
+9447973,"Nas Whidbey Island, WA",48.34280014038086,-122.68579864501953,America/Los_Angeles
+9448009,"Spee-Bi-Dah, WA",48.08825,-122.3223333333333,America/Los_Angeles
+9448043,"Tulare Beach, Port Susan, WA",48.10680555555555,-122.3472777777778,America/Los_Angeles
+9448094,"Kayak Pt, Port Susan, WA",48.1367,-122.367,America/Los_Angeles
+9448558,"La Conner, Swinomish Slough, WA",48.3917,-122.497,America/Los_Angeles
+9448576,"Sneeoosh Point, WA",48.4,-122.548,America/Los_Angeles
+9448601,"Yokeko Point, WA",48.4133,-122.615,America/Los_Angeles
+9448614,"Bowman Bay, Fidalgo Island, WA",48.415000915527344,-122.6520004272461,America/Los_Angeles
+9448657,"Turner Bay, WA",48.445,-122.555,America/Los_Angeles
+9448682,"Swinomish, WA",48.45830154418945,-122.51300048828125,America/Los_Angeles
+9448794,"Anacortes, Fidalgo Island, WA",48.5183,-122.62,America/Los_Angeles
+9449161,"Village Point, Lummi Island, WA",48.7167,-122.708,America/Los_Angeles
+9449211,"Bellingham, WA",48.745,-122.495,America/Los_Angeles
+9449292,"Sandy Point, Lummi Bay, WA",48.79,-122.708,America/Los_Angeles
+9449424,"Cherry Point, WA",48.86271666666666,-122.7585833333333,America/Los_Angeles
+9449639,"Point Roberts, WA",48.974998474121094,-123.08300018310547,America/Los_Angeles
+9449679,"Blaine, Drayton Harbor, WA",48.9917,-122.765,America/Los_Angeles
+9449712,"Echo Bay, Sucia Islands, WA",48.7567,-122.897,America/Los_Angeles
+9449746,"Waldron Island, WA",48.686798095703125,-123.03759765625,America/Los_Angeles
+9449771,"Rosario, Orcas Island, WA",48.64670181274414,-122.87000274658203,America/Los_Angeles
+9449828,"Hanbury Point, San Juan Island, WA",48.5817,-123.17,America/Los_Angeles
+9449856,"Kanaka Bay, San Juan Island, WA",48.48500061035156,-123.08300018310547,America/Los_Angeles
+9449880,"Friday Harbor, WA",48.54527777777778,-123.0125,America/Los_Angeles
+9449911,"Upright Head, WA",48.57170104980469,-122.88500213623047,America/Los_Angeles
+9449932,"Armitage Island, WA",48.535,-122.797,America/Los_Angeles
+9449982,"Richardson, WA",48.4467,-122.9,America/Los_Angeles
+9449988,"Telegraph Bay, WA",48.44329833984375,-122.80500030517578,America/Los_Angeles
+9450296,"Custom House Cove, Mary Island, AK",55.1,-131.217,America/Sitka
+9450314,"Metlakatla, Port Chester, Ak, AK",55.1283,-131.567,America/Metlakatla
+9450364,"Hydaburg, Sukkwan Strait, AK",55.201698303222656,-132.822998046875,America/Sitka
+9450460,"Ketchikan, AK",55.3319444,-131.6261111,America/Sitka
+9450463,"Trocadero Bay, AK",55.35166666666667,-132.9380555555556,America/Sitka
+9450495,"Saltery Cove, AK",55.4017,-132.328,America/Sitka
+9450544,"Hollis Anchorage, Kasaan Bay, AK",55.48,-132.645,America/Sitka
+9450551,"Craig, AK",55.4883,-133.142,America/Sitka
+9450578,"Steamboat Bay, AK",55.5333,-133.637,America/Sitka
+9450581,"Kasaan Bay, AK",55.535,-132.397,America/Sitka
+9450625,"Lindeman Cove, AK",55.6017,-132.512,America/Sitka
+9450651,"Rudyerd Bay, AK",55.6417,-130.645,America/Sitka
+9450711,"Nossuk Bay, AK",55.72166666666666,-133.35,America/Sitka
+9450753,"Magnetic Point, Union Bay, Earnest Sound, AK",55.78828333333333,-132.1908833333334,America/Sitka
+9450815,"Ratz Harbor, AK",55.88,-132.595,America/Sitka
+9450831,"Hyder, AK",55.90449905395508,-130.01080322265625,America/Sitka
+9450906,"Beck Island, Clarence Strait, AK",56.0467,-132.862,America/Sitka
+9450913,"Kuiu Island, Affleck Canal, AK",56.0369,-134.115,America/Sitka
+9450914,"Burrough Bay, Behm Canal, AK",56.0383,-131.095,America/Sitka
+9450938,"Thorne Island, AK",56.0583,-132.968,America/Sitka
+9450970,"Thoms Point, AK",56.1183,-132.078,America/Sitka
+9450973,"Blashke Island, AK",56.1267,-132.895,America/Sitka
+9450982,"Shakan Bay Entrance, AK",56.14,-133.61,America/Sitka
+9450987,"Shakan Strait (Northeast End), AK",56.1483,-133.46,America/Sitka
+9450997,"El Capitan Passage, AK",56.1633,-133.33,America/Sitka
+9450998,"Dry Pass, El Capitan Passage, AK",56.1633,-133.413,America/Sitka
+9451005,"Point Harrington, Clarence Strait, AK",56.1783,-132.697,America/Sitka
+9451012,"Bradfield Canal, AK",56.195526123046875,-131.5574188232422,America/Sitka
+9451037,"Village Rock, AK",56.22,-132.297,America/Sitka
+9451054,"Port Alexander, AK",56.2467,-134.647,America/Sitka
+9451074,"Bushy Island, Snow Passage, AK",56.2767,-132.985,America/Sitka
+9451124,"Reef Point, Stikine Strait, AK",56.3533,-132.553,America/Sitka
+9451152,"Madan Bay, AK",56.3922,-132.169,America/Sitka
+9451204,"Wrangell, AK",56.47,-132.387,America/Sitka
+9451247,"Monte Carlo Island, AK",56.535,-133.767,America/Sitka
+9451263,"Point Lockwood, AK",56.5583,-132.963,America/Sitka
+9451281,"Blaquiere Point, AK",56.584693908691406,-132.5421905517578,America/Sitka
+9451287,"Beecher Pass, AK",56.595,-132.987,America/Sitka
+9451317,"Anchor Point, AK",56.6383,-132.927,America/Sitka
+9451321,"Castle Islands, Duncan Canal, AK",56.643306732177734,-133.15199279785156,America/Sitka
+9451335,"Cosmos Point, AK",56.6633,-132.617,America/Sitka
+9451346,"Papke'S Landing, AK",56.6767,-132.933,America/Sitka
+9451349,"The Summit, AK",56.68242222222222,-133.7369083333333,America/Sitka
+9451376,"Dorothy Cove, AK",56.7217,-135.075,America/Sitka
+9451421,"Golf Island, AK",56.7867,-135.393,America/Sitka
+9451422,"Leconte Bay, AK",56.7883,-132.502,America/Sitka
+9451434,"Turn Point, AK",56.8,-132.98,America/Sitka
+9451438,"Entrance Island, AK",56.8117,-133.787,America/Sitka
+9451467,"Red Bluff Bay, Baranof Island, AK",56.8567,-134.723,America/Sitka
+9451497,"Saginaw Bay, Kuiu Island, AK",56.90333333333334,-134.3030555555556,America/Sitka
+9451528,"Kake Harbor, Keku Strait, AK",56.94830555555556,-133.8947222222222,America/Sitka
+9451561,"Thomas Bay, AK",56.9966926574707,-132.78500366210938,America/Sitka
+9451600,"Sitka, AK",57.05169444444444,-135.342,America/Sitka
+9451625,"Baranof, Warm Spring Bay, AK",57.08833333333333,-134.825,America/Sitka
+9451634,"Herring Bay, Frederick Sound, AK",57.1133,-134.38,America/Juneau
+9451706,"Eliza Harbor, Frederick Sound, AK",57.1883,-134.287,America/Juneau
+9451741,"Whitestone Narrows, Neva Strait, AK",57.25,-135.567,America/Sitka
+9451781,"Cannery Cove, Pybus Bay, AK",57.3067,-134.133,America/Juneau
+9451785,"The Brothers, Stephens Passage, AK",57.295,-133.797,America/Juneau
+9451798,"Port Houghton (Inside), Stephens Passage, AK",57.32500076293945,-133.18299865722656,America/Juneau
+9451805,"Scraggy Island, AK",57.34,-135.707,America/Sitka
+9451853,"Sergius Narrows, AK",57.41,-135.627,America/Sitka
+9451936,"Provorotni Island, AK",57.515,-135.555,America/Sitka
+9451953,"Target Island, Mitchell Bay, AK",57.5333,-134.417,America/Juneau
+9452005,"North Shore Upper Endicott Arm, AK",57.52169418334961,-133.05499267578125,America/Juneau
+9452022,"Sawyer Island, Tracy Arm, Holkham Bay, AK",57.8783,-133.19,America/Juneau
+9452067,"Holkham Bay, Stephens Passage, AK",57.76,-133.603,America/Juneau
+9452081,"Port Snettisham, Speel River Arm, AK",58.116695404052734,-133.69000244140625,America/Juneau
+9452082,"Crib Point, Port Snettisham, Stephens Pa, AK",58.0967,-133.742,America/Juneau
+9452089,"Sharp Point, Speel Arm, AK",58.022335052490234,-133.80728149414062,America/Juneau
+9452123,"Taku Harbor, AK",58.0683,-134.012,America/Juneau
+9452124,"Taku Point, AK",58.408668518066406,-134.00613403320312,America/Juneau
+9452210,"Juneau, AK",58.2988,-134.4106,America/Juneau
+9452249,"Young Bay, AK",58.1833,-134.587,America/Juneau
+9452294,"Hawk Inlet, AK",58.085,-134.777,America/Juneau
+9452318,"Barlow Cove, AK",58.3217,-134.878,America/Juneau
+9452321,"Funter, Mansfield Peninsula, AK",58.255,-134.895,America/Juneau
+9452328,"False Bay, Chatham Strait, AK",57.9667,-134.935,America/Juneau
+9452336,"Lincoln Island, Favorite Channel, AK",58.4983,-134.965,America/Juneau
+9452346,"Cove Point, AK",58.7517,-135.028,America/Juneau
+9452368,"Swanson Harbor, AK",58.215,-135.127,America/Juneau
+9452386,"Tenakee, AK",57.77930555555555,-135.2194722222222,America/Juneau
+9452391,"William Henry Bay, AK",58.7133,-135.232,America/Juneau
+9452400,"Skagway, Taiya Inlet, AK",59.4508,-135.328,America/Juneau
+9452421,"Chilkat Inlet, AK",59.17,-135.4,America/Juneau
+9452434,"Taiyasanka Harbor, AK",59.3017,-135.428,America/Juneau
+9452437,"Excursion Inlet (South End), AK",58.4167,-135.447,America/Juneau
+9452438,"Hoonah, Port Fredrick, AK",58.10755555555556,-135.4441944444444,America/Juneau
+9452516,"Point Adolphus, AK",58.2867,-135.803,America/Juneau
+9452534,"Bartlett Cove, Glacier Bay, AK",58.45669937133789,-135.88299560546875,America/Juneau
+9452584,"Muir Inlet, Glacier Bay, AK",58.9133,-136.108,America/Juneau
+9452611,"Pelican Harbor, Lisianski Inlet, Ak, AK",57.95777777777778,-136.2267777777778,America/Juneau
+9452632,"Wachusett Inlet, Glacier Bay, AK",58.9467,-136.333,America/Juneau
+9452634,"Elfin Cove, AK",58.19472222222223,-136.3469444444444,America/Juneau
+9452682,"Composite Island, Glacier Bay, AK",58.8883,-136.573,America/Juneau
+9452749,"Tarr Inlet, Glacier Bay, AK",58.96477777777778,-136.8775833333333,America/Juneau
+9453208,"Redfield Cove, Yakutat Bay, AK",59.6117,-139.58,America/Yakutat
+9453210,"Point Latouche, Yakutat Bay, AK",59.9033,-139.627,America/Yakutat
+9453215,"Johnstone Passage, AK",59.5817,-139.702,America/Yakutat
+9453220,"Yakutat, Yakutat Bay, AK",59.548500061035156,-139.7333984375,America/Yakutat
+9453431,"Tyndall Glacier, Icy Bay, AK",60.07830047607422,-141.27499389648438,America/Anchorage
+9453443,"Moraine Bay, AK",59.93000030517578,-141.36300659179688,America/Yakutat
+9453456,"Riou Bay, AK",59.885,-141.457,America/Yakutat
+9454050,"Cordova, AK",60.55830001831055,-145.7530059814453,America/Anchorage
+9454124,"Sheep Bay, AK",60.67189025878906,-145.99217224121094,America/Anchorage
+9454153,"Gravina River, AK",60.766700744628906,-146.0845947265625,America/Anchorage
+9454240,"Valdez, AK",61.125,-146.36199951171875,America/Anchorage
+9454329,"Cape Hichinbrook, AK",60.23830032348633,-146.6479949951172,America/Anchorage
+9454363,"Rocky Pt, T-17, AK",60.94670104980469,-146.7550048828125,America/Anchorage
+9454374,"Busby Island, AK",60.8983,-146.782,America/Anchorage
+9454511,"Port Chalmers, AK",60.2418,-147.249,America/Anchorage
+9454561,"Perch Point, AK",60.1267,-147.395,America/Anchorage
+9454562,"Wooded Island, AK",59.875,-147.403,America/Anchorage
+9454564,"Seal Island, AK",60.425,-147.41,America/Anchorage
+9454616,"Montague Island, AK",60.025,-147.592,America/Anchorage
+9454642,"Louis Bay, AK",60.4617,-147.672,America/Anchorage
+9454652,"South Arm, Knight Island, Bay Of Isles, AK",60.3667,-147.7,America/Anchorage
+9454662,"Snug Harbor, AK",60.25,-147.717,America/Anchorage
+9454671,"Point Helen, Knight Island, AK",60.1533,-147.767,America/Anchorage
+9454672,"College Fiord, AK",61.2057991027832,-147.7613983154297,America/Anchorage
+9454673,"Port Audrey, AK",60.3433,-147.768,America/Anchorage
+9454674,"Macleod Harbor, AK",59.88999938964844,-147.7949981689453,America/Anchorage
+9454691,"Herring Point, Knight Island, Pr Wil Snd, AK",60.475,-147.792,America/Anchorage
+9454713,"Latouche, AK",60.0533,-147.907,America/Anchorage
+9454721,"Perry Island (South Bay), AK",60.6717,-147.932,America/Anchorage
+9454751,"Guguak, AK",60.1,-148.038,America/Anchorage
+9454755,"Bainbridge Point, AK",60.19670104980469,-148.04200744628906,America/Anchorage
+9454757,"Eshamy Lagoon, Knight Island Passage, AK",60.4617,-148.045,America/Anchorage
+9454777,"Chenega Island (S.W. End), AK",60.2833,-148.113,America/Anchorage
+9454794,"Applegate Island, AK",60.6233,-148.165,America/Anchorage
+9454814,"Point Erlington, Erlington Island, AK",59.9383,-148.227,America/Anchorage
+9454825,"Long Bay Entr, Culross Passage, AK",60.6917,-148.263,America/Anchorage
+9454949,"Whittier, AK",60.7783,-148.665,America/Anchorage
+9455090,"Seward, AK",60.1193,-149.4281083333333,America/Anchorage
+9455120,"Agnes Cove, AK",59.7733,-149.588,America/Anchorage
+9455128,"Bear Cove, Aialik Peninsula, Kenai Penin, AK",59.8017,-149.615,America/Anchorage
+9455145,"Aialik Bay, North End, AK",59.9533,-149.715,America/Anchorage
+9455146,"Aialik Sill, Aialik Bay, AK",59.885,-149.718,America/Anchorage
+9455151,"Camp Cove, Harris Penninsula, AK",59.6933,-149.748,America/Anchorage
+9455159,"Crater Bay, Harris Bay, AK",59.7133,-149.787,America/Anchorage
+9455204,"Upper Northwestern Fiord, AK",59.79,-150.032,America/Anchorage
+9455258,"Mccarty Fiord, AK",59.511600494384766,-150.35519409179688,America/Anchorage
+9455428,"Port Chatham, AK",59.2133,-151.728,America/Anchorage
+9455437,"Port Graham, AK",59.35,-151.8266666666667,America/Anchorage
+9455500,"Seldovia, AK",59.44049835205078,-151.7198944091797,America/Anchorage
+9455517,"Kasitsna Bay, Kachemak Bay, AK",59.46830555555555,-151.565,America/Anchorage
+9455558,"Coal Point, AK",59.60139846801758,-151.4105987548828,America/Anchorage
+9455595,"Bear Cove, Kachemak Bay, AK",59.725,-151.023,America/Anchorage
+9455606,"Anchor Point, Cook Inlet, AK",59.77197222222223,-151.8670277777778,America/Anchorage
+9455653,"Ninilchik, Cook Inlet, AK",60.055,-151.682,America/Anchorage
+9455711,"Cape Kasilof, AK",60.3367,-151.38,America/Anchorage
+9455732,"Kaligan Island (North End), Cook Inlet, AK",60.51169967651367,-151.95199584960938,America/Anchorage
+9455735,"Chinulna Point, Cook Inlet, AK",60.5033,-151.283,America/Anchorage
+9455760,"Nikiski, AK",60.68330001831055,-151.3979949951172,America/Anchorage
+9455866,"Point Possession, AK",61.0367,-150.413,America/Anchorage
+9455869,"North Foreland, AK",61.04330555555556,-151.163,America/Anchorage
+9455912,"Fire Island, Cook Inlet, AK",61.1733,-150.213,America/Anchorage
+9455920,"Anchorage, AK",61.2375,-149.8903888888889,America/Anchorage
+9455934,"Port Mackenzie, AK",61.2682991027832,-149.91700744628906,America/Anchorage
+9455963,"Goose Creek, Cook Inlet, AK",61.3933,-149.847,America/Anchorage
+9456173,"Snug Harbor, AK",60.10749816894531,-152.58169555664062,America/Anchorage
+9456525,"Sw Iniskin Bay, AK",59.65169906616211,-153.4680938720703,America/Anchorage
+9456717,"Nukshak Island, Shelikof Strait, AK",58.3917,-153.958,America/Anchorage
+9456901,"Aguchik Island, Kukak Bay, AK",58.29,-154.27,America/Anchorage
+9456992,"Takli Island, Shelikof Strait, AK",58.0633,-154.477,America/Anchorage
+9457152,"Tonki Bay, Afognak Island, AK",58.31669998168945,-152.06700134277344,America/Anchorage
+9457261,"Port Of Kodiak, AK",57.7833,-152.428,America/Anchorage
+9457283,"Kodiak, St Pauls Harbor, AK",57.745,-152.483,America/Anchorage
+9457287,"Ouzinkie, Spruce Island, AK",57.9217,-152.498,America/Anchorage
+9457292,"Kodiak Island, AK",57.7317,-152.512,America/Anchorage
+9457313,"Port William, Shuyak Island, AK",58.4902229309082,-152.58377075195312,America/Anchorage
+9457376,"Uzkosti Point, AK",57.9283,-152.812,America/Anchorage
+9457391,"Port Lions, Ak, AK",57.87347222222222,-152.8671111111111,America/Anchorage
+9457407,"Nachalni Island, AK",57.9783,-152.925,America/Anchorage
+9457493,"Sw Terror Bay, AK",57.74402777777778,-153.1954722222222,America/Anchorage
+9457527,"Old Harbor, Kodiak Island, AK",57.20277777777778,-153.3038888888889,America/Anchorage
+9457535,"West Raspberry Island, AK",58.10716666666666,-153.3401111111111,America/Anchorage
+9457634,"Japanese Bay, Kodiak Island, AK",56.96,-153.687,America/Anchorage
+9457724,"Larsen Bay, Kodiak Island, Ak, AK",57.5333,-153.99,America/Anchorage
+9457804,"Alitak, AK",56.89738888888889,-154.248,America/Anchorage
+9458209,"Puale Bay, AK",57.7067,-155.393,America/Anchorage
+9458293,"Chirikof Island, AK",55.8083,-155.74,America/Anchorage
+9458365,"Kanatak Lagoon, Portage Bay, AK",57.52000045776367,-156.052001953125,America/Anchorage
+9458519,"Chowiet Island, AK",56.0517,-156.698,America/Anchorage
+9458762,"Unavikshak Island, AK",56.4917,-157.74,America/Anchorage
+9458779,"Nakchamik Island, Chignik Bay, AK",56.3517,-157.812,America/Anchorage
+9458819,"Kujulik Bay (North Shore), AK",56.6133,-157.983,America/Anchorage
+9458849,"Chankliut Island, AK",56.1467,-158.107,America/Anchorage
+9458907,"Castle Bay, AK",56.2317,-158.347,America/Anchorage
+9458917,"Chignik, Anchorage Bay, AK",56.2967,-158.4,America/Anchorage
+9458964,"Hump Island, Kuiukta Bay, AK",56.1133,-158.598,America/Anchorage
+9459016,"Mitrofania Island, AK",55.89,-158.82,America/Anchorage
+9459163,"Herendeen Island, Shumagin Islands, AK",55.06555555555556,-159.4186666666667,America/Anchorage
+9459181,"Ivanof Bay, AK",55.90011215209961,-159.4912567138672,America/Anchorage
+9459251,"Bird Island, Shumagin Bank, AK",54.83522222222222,-159.7595555555556,America/Anchorage
+9459450,"Sand Point, AK",55.33172222222223,-160.5043333333333,America/Anchorage
+9459465,"Zachary Bay, Unga Is (N. Side), AK",55.334999084472656,-160.61700439453125,America/Anchorage
+9459758,"Dolgoi Harbor, Dolgoi Island, AK",55.121700286865234,-161.79200744628906,America/Anchorage
+9459881,"King Cove, AK",55.05988888888889,-162.3261111111111,America/Nome
+9459949,"Cold Bay, AK",55.2083,-162.698,America/Nome
+9461380,"Adak Island, AK",51.86063888888889,-176.6375833333333,America/Adak
+9461710,"Atka, AK",52.23194444444444,-174.1725,America/Adak
+9462450,"Nikolski, AK",52.94061,-168.8713055557675,America/Nome
+9462620,"Unalaska, AK",53.87919444444444,-166.5403055555556,America/Nome
+9462645,"Biorka Village, Biverly Inlet, AK",53.82891666666667,-166.21625,America/Nome
+9462662,"Reef Bight, AK",54.13072222222223,-166.0993333333333,America/Nome
+9462676,"Broad Bight, AK",54.06458333333333,-165.9370555555556,America/Nome
+9462694,"Akutan, Alaska, AK",54.13327777777778,-165.7773055555556,America/Nome
+9462705,"Green Bight, AK",54.11027777777778,-165.6613888888889,America/Nome
+9462711,"Surf Bay, Akutan Bay, AK",54.15083333333333,-165.615,America/Nome
+9462719,"Akun Cove, Akun Island, AK",54.2333,-165.533,America/Nome
+9462721,"Trident Bay, Akun Island, AK",54.14,-165.527,America/Nome
+9462723,"Rootok Island, AK",54.05222222222222,-165.5141666666667,America/Nome
+9462782,"Tigalda Bay, Tigalda Island, AK",54.12,-164.977,America/Nome
+9462786,"Se Tigalda Island, Pacific Ocean, AK",54.10180555555556,-164.9415833333333,America/Nome
+9462787,"Cape Sarichef, Unimak Island, AK",54.6,-164.928,America/Nome
+9462808,"Scotch Cap, Unimak Island, Ak, AK",54.39363888888889,-164.7457222222222,America/Nome
+9462941,"Cape Chunak, Ak, AK",55.06427777777778,-163.5341666666667,America/Nome
+9462948,"Neumans Cove, AK",54.9667,-163.44,America/Nome
+9462955,"False Pass, Unimak Island, AK",54.8583,-163.407,America/Nome
+9462961,"Isanotski Strait Entrance, AK",54.77844444444445,-163.3642777777778,America/Nome
+9463502,"Port Moller, AK",55.9858333,-160.5736111,America/Anchorage
+9463885,"Zapadni Bay, St. George Island, AK",56.56669998168945,-169.6667022705078,America/Nome
+9463888,"St. George, St. George Island, AK",56.60327777777778,-169.5495555555555,America/Nome
+9464075,"Meshik, Port Heiden, AK",56.90829849243164,-158.68490600585938,America/Anchorage
+9464212,"Village Cove, St Paul Island, AK",57.125301361083984,-170.2852020263672,America/Nome
+9464512,"Dago Creek Mouth, Ugashik Bay, AK",57.61479949951172,-157.60069274902344,America/Anchorage
+9464874,"Egegik, Egegik R, Bristol Bay, AK",58.21670150756836,-157.375,America/Anchorage
+9464961,"Cape Constantine, Nushagak Peninsula, AK",58.52170181274414,-159.15199279785156,America/Anchorage
+9465056,"Protection Point, Nushagak Bay, AK",58.5,-158.712,America/Anchorage
+9465137,"Cape Peirce, West Side, AK",58.62670135498047,-161.83700561523438,America/Anchorage
+9465149,"King Salmon Air Base, Naknek River, AK",58.671695709228516,-156.65699768066406,America/Anchorage
+9465182,"Black Rock, Walrus Is Bristol B, AK",58.70830154418945,-160.18800354003906,America/Anchorage
+9465203,"Naknek, AK",58.73210144042969,-156.98330688476562,America/Anchorage
+9465261,"Clarks Point, Nushagak Bay, AK",58.8483,-158.552,America/Anchorage
+9465265,"Kulukak Point, AK",58.84000015258789,-159.64700317382812,America/Anchorage
+9465374,"Snag Point, Dillingham, AK",59.04,-158.447,America/Anchorage
+9465396,"Platinum, AK",59.0467,-161.818,America/Anchorage
+9465419,"Levelock, Kvichak River, AK",59.11330032348633,-156.83200073242188,America/Anchorage
+9465438,"Goodnews Bay, AK",59.11439895629883,-161.5843963623047,America/Anchorage
+9465601,"Carter Bay, Kuskokwim Bay, AK",59.37801666666667,-162.0293333333333,America/Nome
+9465831,"Quinhagak (Kwinak), Kushkokwin River, AK",59.75055277777778,-161.9154361111111,America/Anchorage
+9465951,"Kipnuk, Kugkaktlik River, AK",59.943199157714844,-164.04339599609375,America/Nome
+9466057,"Popokamute (Kokokamute), Kuskokwim River, AK",60.12327777777778,-162.5003611111111,America/Nome
+9466084,"Chefornak, AK",60.159400939941406,-164.27259826660156,America/Nome
+9466153,"Helmick Point, AK",60.270301818847656,-162.4102020263672,America/Nome
+9466197,"Tuntutuliak, AK",60.34149932861328,-162.68600463867188,America/Nome
+9466217,"Mekoryuk, Mekoryuk River Entrance, AK",60.4167,-166.167,America/Nome
+9466298,"Nelson Island, Tooksook Bay, AK",60.5167,-165.133,America/Nome
+9466328,"Lomavik, AK",60.554298400878906,-162.29710388183594,America/Nome
+9466477,"Bethel, Kuskokwim River, Ak, AK",60.8,-161.75,America/Anchorage
+9466563,"Newtok, AK",60.93450164794922,-164.63870239257812,America/Nome
+9466931,"Dall Point, AK",61.5317,-166.148,America/Nome
+9467124,"Kun River, AK",61.84170150756836,-165.56700134277344,America/Nome
+9467551,"Nunam Iqua (Sheldon Point), AK",62.53294444444445,-164.8452777777778,America/Nome
+9467645,"Alakanuk, Yukon River, AK",62.687198638916016,-164.66690063476562,America/Nome
+9467701,"Emmonak, AK",62.77750015258789,-164.54690551757812,America/Nome
+9467861,"Kotlik, Ak, AK",63.037899017333984,-163.52650451660156,America/Nome
+9468039,"Northeast Cape, St. Lawrence Island, AK",63.3167,-168.967,America/Nome
+9468151,"Stebbins, Norton Sound, East, AK",63.525001525878906,-162.29299926757812,America/Nome
+9468258,"Savoonga, AK",63.67908333333333,-170.5371111111111,America/Nome
+9468333,"Unalakleet, AK",63.875,-160.78799438476562,America/Anchorage
+9468691,"Shaktoolik, AK",64.38022222222222,-161.2351388888889,America/Anchorage
+9468756,"Nome, Norton Sound, AK",64.49461111111111,-165.4396388888889,America/Nome
+9468793,"Golovin, Golovnin Lagoon Entrance, AK",64.54630279541016,-163.0316925048828,America/Nome
+9468841,"Upper Golovnin Lagoon, AK",64.62079620361328,-163.1490020751953,America/Nome
+9468877,"White Mountain, Ak, AK",64.68113708496094,-163.4119110107422,America/Nome
+9469031,"Koyuk, AK",64.93119812011719,-161.1508026123047,America/Anchorage
+9469146,"Imuruk Basin, AK",65.11840057373047,-165.47210693359375,America/Nome
+9469237,"Point Spencer, Port Clarence, AK",65.2567,-166.847,America/Nome
+9469239,"Teller, Port Clarence, AK",65.2667,-166.353,America/Nome
+9469338,"Lost River, Seward Peninsula, AK",65.39,-167.145,America/Nome
+9469439,"Tin City, Bering Sea, AK",65.55833333333334,-167.975,America/Nome
+9469677,"Buckland, AK",65.97550201416016,-161.125,America/Anchorage
+9469751,"Deering, AK",66.09716666666667,-162.7404722222222,America/Nome
+9469833,"Goodhope Bay, AK",66.23030090332031,-163.9040985107422,America/Nome
+9469854,"Shishmaref Inlet 2, AK",66.2633,-166.02,America/Nome
+9490096,"Cape Espenberg, Kotzebue Sound, AK",66.58569444444444,-164.2508333333333,America/Nome
+9490424,"Kotzebue, AK",66.9017,-162.582,America/Nome
+9490571,"Cape Krusenstern, AK",67.05419444444445,-163.3212777777778,America/Nome
+9491094,"Red Dog Dock, AK",67.57580555555556,-164.0643888888889,America/Nome
+9491253,"Kivalina, AK",67.7267,-164.592,America/Nome
+9491873,"Point Hope, AK",68.3417,-166.808,America/Nome
+9494212,"Wainwright, AK",70.643798828125,-160.06509399414062,America/Anchorage
+9494935,"Barrow Offshore, AK",71.36011111111111,-156.7298611111111,America/Anchorage
+9497645,"Prudhoe Bay, AK",70.4113889,-148.5316667,America/Anchorage
+9499176,"Barter Island, AK",70.12855555555555,-143.6110277777778,America/Anchorage
+9500966,"Madero, Tampico Harbor, Mexico, Mexico",22.261699676513672,-97.79499816894531,America/Monterrey
+9710441,"Settlement Point, Bahamas",26.71,-78.9967,America/Nassau
+9751082,"Grapetree Bay, PR",17.740699768066406,-64.60579681396484,America/St_Thomas
+9751084,"Teague Bay, PR",17.7549991607666,-64.60240173339844,America/St_Thomas
+9751219,"Fareham Bay, PR",17.709999084472656,-64.68280029296875,America/St_Thomas
+9751274,"Johns Folly Bay, PR",18.316999435424805,-64.70210266113281,America/St_Thomas
+9751309,"Leinster Point, Leinster Bay, St. John'S, Vi",18.36761111111111,-64.72072222222222,America/St_Thomas
+9751364,"Christiansted Harbor, St Croix, Vi",17.74769444444445,-64.69838888888889,America/St_Thomas
+9751373,"St John'S Island, Coral Harbor, Vi",18.34830093383789,-64.7166976928711,America/St_Thomas
+9751381,"Lameshur Bay, St John, Vi",18.31825,-64.72422222222222,America/St_Thomas
+9751389,"Salt River Bay, PR",17.775299072265625,-64.76229858398438,America/St_Thomas
+9751401,"Limetree Bay, Vi",17.694700241088867,-64.75379943847656,America/St_Thomas
+9751417,"Hawksnest Beach, PR",18.348899841308594,-64.77739715576172,America/St_Thomas
+9751419,"Haulover Bay, St. Johns, PR",18.349700927734375,-64.67960357666016,America/St_Thomas
+9751467,"Lovango Cay, St. John, Vi",18.36066666666667,-64.80352777777777,America/St_Thomas
+9751472,"Cruz Bay, PR",18.33289909362793,-64.79409790039062,America/St_Thomas
+9751494,"Dog Island, St. Thomas, Vi",18.29713888888889,-64.81775,America/St_Thomas
+9751540,"Redhook Bay, St Thomas, Usvi, Vi",18.3267,-64.8517,America/St_Thomas
+9751561,"Pavillion Point, PR",18.33989906311035,-64.85240173339844,America/St_Thomas
+9751574,"Jersey Bay, PR",18.318099975585938,-64.8594970703125,America/St_Thomas
+9751583,"Water Bay, Vi",18.34894444444445,-64.86416666666666,America/St_Thomas
+9751584,"Fredericksted, St. Croix, Vi",17.7133,-64.8833,America/St_Thomas
+9751639,"Charlotte Amalie, Vi",18.3305833,-64.9258056,America/St_Thomas
+9751693,"Magens Bay, PR",18.366300582885742,-64.9220962524414,America/St_Thomas
+9751749,"Crown Bay, PR",18.33289909362793,-64.95169830322266,America/St_Thomas
+9751768,"Dorothea Bay, Saint Thomas, Vi",18.37125,-64.96347222222222,America/St_Thomas
+9751774,"Botany Bay, St. Thomas, Vi",18.3633,-65.035,America/St_Thomas
+9752062,"Culebrita, PR",18.319400787353516,-65.23809814453125,America/Puerto_Rico
+9752235,"Culebra, PR",18.30086111111111,-65.30247222222222,America/Puerto_Rico
+9752426,"Playa La Plata, PR",18.116600036621094,-65.3729019165039,America/Puerto_Rico
+9752619,"Isabel Segunda, Vieques Island, PR",18.15252777777778,-65.44380555555556,America/Puerto_Rico
+9752695,"Esperanza, Vieques Island, PR",18.09386111111111,-65.47136111111111,America/Puerto_Rico
+9752813,"Mosquito Pier, PR",18.14889907836914,-65.51490020751953,America/Puerto_Rico
+9752962,"Isla Palominos, PR",18.34497222222222,-65.5695,America/Puerto_Rico
+9752998,"Punta Arenas, Vieques Island, PR",18.11240005493164,-65.57589721679688,America/Puerto_Rico
+9753182,"Ceiba, Roosevelt Road, PR",18.228099822998047,-65.61969757080078,America/Puerto_Rico
+9753216,"Fajardo, PR",18.3352778,-65.6311111,America/Puerto_Rico
+9753641,"Naguabo, PR",18.18705555555556,-65.71138888888889,America/Puerto_Rico
+9753766,"Luquillo, Pr, PR",18.38170051574707,-65.73650360107422,America/Puerto_Rico
+9754057,"Palmas Del Mar, PR",18.078100204467773,-65.79560089111328,America/Puerto_Rico
+9754228,"Yabucoa Harbor, PR",18.05508333333333,-65.833,America/Puerto_Rico
+9754487,"Puerto Maunabo, PR",17.99139976501465,-65.88880157470703,America/Puerto_Rico
+9754986,"Boca De Cangrejos, PR",18.456600189208984,-65.99150085449219,America/Puerto_Rico
+9755371,"San Juan, La Puntilla, San Juan Bay, PR",18.45894444444445,-66.11641666666667,America/Puerto_Rico
+9755679,"Las Mareas, PR",17.9283,-66.1583,America/Puerto_Rico
+9755971,"Central Aguirre, PR",17.950000762939453,-66.22640228271484,America/Puerto_Rico
+9756567,"Boca Del Cibuco, PR",18.485200881958008,-66.3843994140625,America/Puerto_Rico
+9756639,"Santa Isabel, PR",17.955,-66.4067,America/Puerto_Rico
+9757487,"Ponce, PR",17.969600677490234,-66.61990356445312,America/Puerto_Rico
+9757809,"Arecibo, PR",18.48052777777778,-66.70236111111112,America/Puerto_Rico
+9758053,"Penuelas (Punta Guayanilla), PR",17.97252777777778,-66.76177777777778,America/Puerto_Rico
+9758627,"Guanica, PR",17.95800018310547,-66.90679931640625,America/Puerto_Rico
+9759110,"Magueyes Island, PR",17.97011111111111,-67.04638888888888,America/Puerto_Rico
+9759173,"Boqueron, PR",18.02400016784668,-67.17310333251953,America/Puerto_Rico
+9759183,"Joyuda, PR",18.115800857543945,-67.18319702148438,America/Puerto_Rico
+9759189,"Puerto Real, PR",18.07480555555556,-67.18877777777777,America/Puerto_Rico
+9759197,"Bahia Salinas, PR",17.95144444444444,-67.19658333333334,America/Puerto_Rico
+9759394,"Mayaguez, PR",18.21883333333333,-67.16244444444445,America/Puerto_Rico
+9759412,"Aguadilla, Crashboat Beach, PR",18.45663888888889,-67.16458333333334,America/Puerto_Rico
+9759421,"Punta Guanajibo, Mayagues, PR",18.165000915527344,-67.18170166015625,America/Puerto_Rico
+9759866,"Southeast Mona Island, PR",18.06529998779297,-67.86609649658203,America/Puerto_Rico
+9759938,"Mona Island, PR",18.08928888888889,-67.93820833333334,America/Puerto_Rico
+9761115,"Barbuda, Antigua And Barbuda",17.59083366394043,-61.820556640625,America/Antigua

--- a/docs/superpowers/plans/2026-06-20-sunrise-sunset.md
+++ b/docs/superpowers/plans/2026-06-20-sunrise-sunset.md
@@ -1,0 +1,896 @@
+# Sunrise/Sunset + Local Times Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Each day of the downloaded PDF calendar shows a local-time `Rise HH:MM  Set HH:MM` line, and all tide times render in the station's local timezone (CHS converted UTC→local; NOAA already local).
+
+**Architecture:** Precompute each station's IANA timezone offline (timezonefinder) and bake it into the CSVs; a light startup sync copies it into the warm DB. At PDF-generation time, `sun_times.py` converts CHS tide times to local and computes sunrise/sunset (astral + zoneinfo); `get_tides` writes the sun line into the pcal events file.
+
+**Tech Stack:** Python 3.12, astral (runtime), timezonefinder (dev script only), stdlib zoneinfo, pcal/ghostscript.
+
+**Test command:** `cd app && ../venv/bin/python -m unittest discover -p 'test_*.py'`
+
+---
+
+## File Structure
+
+**Create:**
+- `app/sun_times.py` — timezone logic: `sun_times_for_month()`, `format_sun_line()`, `localize_and_filter_csv()`
+- `app/test_sun_times.py` — unit tests for the above
+- `scripts/fetch_station_timezones.py` — offline: bake `timezone` column into both CSVs
+- `scripts/test_fetch_station_timezones.py` — unit test for the pure transform
+
+**Modify:**
+- `requirements.txt` — add `astral`
+- `app/tide_stations_new.csv`, `app/canadian_tide_stations.csv` — gain `timezone` column (data)
+- `app/database.py` — migrate `timezone` column; read it on import; `get_station_info` returns it; add `backfill_timezones_from_csv()`
+- `app/run.py` — call `backfill_timezones_from_csv()` at startup
+- `app/tide_adapters.py` — CHS fetch padded ±1 day (UTC)
+- `app/get_tides.py` — localize CHS times, compute sun times, write sun line in pcal
+- `Dockerfile` — `COPY app/sun_times.py`
+- `CLAUDE.md` — document the script + feature
+
+---
+
+## Task 1: Add the astral runtime dependency
+
+**Files:** Modify: `requirements.txt`
+
+- [ ] **Step 1: Add astral** — append to `requirements.txt`:
+
+```
+astral==3.2
+```
+
+- [ ] **Step 2: Install into the venv**
+
+Run: `venv/bin/pip install astral==3.2`
+Expected: installs cleanly (no compiled deps).
+
+- [ ] **Step 3: Verify import + Python compat**
+
+Run: `venv/bin/python -c "import astral, astral.sun; print('astral', astral.__version__ if hasattr(astral,'__version__') else 'ok')"`
+Expected: prints ok / a version, no error. (astral 3.2 requires_python `>=3.7,<4.0` — fine for the 3.12 base image.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add requirements.txt
+git commit -m "Add astral dependency for sunrise/sunset computation"
+```
+
+---
+
+## Task 2: Timezone-baking script (`fetch_station_timezones.py`)
+
+**Files:**
+- Create: `scripts/fetch_station_timezones.py`
+- Create: `scripts/test_fetch_station_timezones.py`
+
+The pure transform (`add_timezone_column`) takes CSV rows + a lookup function and returns rows with a `timezone` field. The script wires it to `timezonefinder` and rewrites both CSVs.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# scripts/test_fetch_station_timezones.py
+import os, sys, unittest
+sys.path.insert(0, os.path.dirname(__file__))
+from fetch_station_timezones import add_timezone_column
+
+class AddTimezoneColumnTest(unittest.TestCase):
+    def test_adds_timezone_from_lookup(self):
+        rows = [{'station_id': '9449639', 'place_name': 'Point Roberts, WA',
+                 'latitude': '48.97', 'longitude': '-123.07'}]
+        # fake lookup: ignores inputs, returns a fixed zone
+        out = add_timezone_column(rows, lambda lat, lng: 'America/Vancouver')
+        self.assertEqual(out[0]['timezone'], 'America/Vancouver')
+        self.assertEqual(out[0]['station_id'], '9449639')  # original fields preserved
+
+    def test_blank_when_lookup_returns_none(self):
+        rows = [{'station_id': 'x', 'place_name': 'Ocean', 'latitude': '', 'longitude': ''}]
+        out = add_timezone_column(rows, lambda lat, lng: None)
+        self.assertEqual(out[0]['timezone'], '')
+
+if __name__ == '__main__':
+    unittest.main()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python scripts/test_fetch_station_timezones.py`
+Expected: FAIL — `ModuleNotFoundError: No module named 'fetch_station_timezones'`.
+
+- [ ] **Step 3: Write the script**
+
+```python
+# scripts/fetch_station_timezones.py
+"""Bake an IANA `timezone` column into the station CSVs from each station's
+lat/long, using timezonefinder.
+
+Dev-only: timezonefinder is heavy (numpy/h3) and is NOT a runtime dependency.
+Runtime uses the baked column via stdlib zoneinfo. Mirrors the coordinate /
+province precompute pattern.
+
+Usage:
+    pip install timezonefinder
+    python scripts/fetch_station_timezones.py
+"""
+import csv
+import logging
+import os
+import sys
+
+APP_DIR = os.path.join(os.path.dirname(__file__), '..', 'app')
+US_CSV = os.path.join(APP_DIR, 'tide_stations_new.csv')
+CA_CSV = os.path.join(APP_DIR, 'canadian_tide_stations.csv')
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+
+def add_timezone_column(rows, lookup):
+    """Pure transform: set row['timezone'] = lookup(lat, lng) (or '' if None).
+
+    lookup takes (lat: float|None, lng: float|None) and returns an IANA tz or None.
+    """
+    out = []
+    for row in rows:
+        try:
+            lat = float(row['latitude']) if row.get('latitude') else None
+            lng = float(row['longitude']) if row.get('longitude') else None
+        except (TypeError, ValueError):
+            lat = lng = None
+        tz = lookup(lat, lng) if (lat is not None and lng is not None) else None
+        new = dict(row)
+        new['timezone'] = tz or ''
+        out.append(new)
+    return out
+
+
+def _rewrite_csv(path, lookup):
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames)
+        rows = list(reader)
+    merged = add_timezone_column(rows, lookup)
+    if 'timezone' not in fieldnames:
+        fieldnames.append('timezone')
+    with open(path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, quoting=csv.QUOTE_MINIMAL)
+        writer.writeheader()
+        writer.writerows(merged)
+    matched = sum(1 for r in merged if r['timezone'])
+    logging.info("%s: %d/%d rows got a timezone", os.path.basename(path), matched, len(merged))
+
+
+def main():
+    from timezonefinder import TimezoneFinder
+    tf = TimezoneFinder()
+
+    def lookup(lat, lng):
+        return tf.timezone_at(lat=lat, lng=lng)
+
+    for path in (US_CSV, CA_CSV):
+        _rewrite_csv(path, lookup)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `python scripts/test_fetch_station_timezones.py`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/fetch_station_timezones.py scripts/test_fetch_station_timezones.py
+git commit -m "Add scripts/fetch_station_timezones.py to bake IANA tz into CSVs"
+```
+
+---
+
+## Task 3: Run the script to bake timezones (data change)
+
+**Files:** Modify: `app/tide_stations_new.csv`, `app/canadian_tide_stations.csv`
+
+- [ ] **Step 1: Install timezonefinder (dev only) and run**
+
+```bash
+venv/bin/pip install timezonefinder
+venv/bin/python scripts/fetch_station_timezones.py
+```
+Expected: logs like `tide_stations_new.csv: 2132/2132 rows got a timezone` and a similar line for the Canadian CSV (a few ocean/edge points may be blank — acceptable).
+
+- [ ] **Step 2: Verify the new column**
+
+Run: `head -2 app/tide_stations_new.csv && echo '---' && head -2 app/canadian_tide_stations.csv`
+Expected: both headers now end with `,timezone`; data rows show IANA zones (e.g. `America/Los_Angeles`, `America/Vancouver`).
+
+- [ ] **Step 3: Spot-check a known station**
+
+Run: `venv/bin/python -c "import csv; rows={r['station_id']:r for r in csv.DictReader(open('app/tide_stations_new.csv'))}; print(rows['9449639']['timezone'])"`
+Expected: `America/Vancouver` (Point Roberts, WA sits in the Vancouver zone) or `America/Los_Angeles` — either is a valid Pacific zone; just confirm it's a real `America/...` value.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/tide_stations_new.csv app/canadian_tide_stations.csv
+git commit -m "Bake IANA timezone column into station CSVs"
+```
+
+---
+
+## Task 4: DB — timezone column, import, get_station_info, startup backfill
+
+**Files:**
+- Modify: `app/database.py`
+- Modify: `app/run.py`
+- Test: `app/test_sun_times.py` (DB-facing tests live here for this feature)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# app/test_sun_times.py
+import os, sqlite3, tempfile, unittest, csv
+
+import database
+
+
+class TimezoneDBTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        database.DB_PATH = self.tmp.name
+        database.init_database()
+
+    def tearDown(self):
+        os.unlink(self.tmp.name)
+
+    def test_station_info_returns_timezone(self):
+        with sqlite3.connect(database.DB_PATH) as conn:
+            conn.execute("INSERT INTO tide_station_ids (station_id, place_name, country, timezone) "
+                         "VALUES ('9449639','Point Roberts, WA','USA','America/Vancouver')")
+            conn.commit()
+        info = database.get_station_info('9449639')
+        self.assertEqual(info['timezone'], 'America/Vancouver')
+
+    def test_backfill_timezones_from_csv(self):
+        # row exists with NULL timezone; a CSV provides one
+        with sqlite3.connect(database.DB_PATH) as conn:
+            conn.execute("INSERT INTO tide_station_ids (station_id, place_name, country) "
+                         "VALUES ('07735','Vancouver, BC','Canada')")
+            conn.commit()
+        csv_path = self.tmp.name + '.csv'
+        with open(csv_path, 'w', newline='', encoding='utf-8') as f:
+            w = csv.DictWriter(f, fieldnames=['station_id', 'timezone'])
+            w.writeheader()
+            w.writerow({'station_id': '07735', 'timezone': 'America/Vancouver'})
+        n = database.backfill_timezones_from_csv([csv_path])
+        self.assertEqual(n, 1)
+        self.assertEqual(database.get_station_info('07735')['timezone'], 'America/Vancouver')
+
+
+if __name__ == '__main__':
+    unittest.main()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd app && ../venv/bin/python -m unittest test_sun_times.TimezoneDBTest -v`
+Expected: FAIL — `get_station_info` has no `timezone` key / no `backfill_timezones_from_csv`.
+
+- [ ] **Step 3a: Add the column to the migration** — in `app/database.py`, in `init_database`'s `_migrate_columns(cursor, 'tide_station_ids', {...})` dict, add:
+
+```python
+                'timezone': 'TEXT',
+```
+
+- [ ] **Step 3b: Return timezone from `get_station_info`** — change its SELECT and dict:
+
+```python
+            result = cursor.execute('''
+                SELECT station_id, place_name, country, api_source, latitude, longitude, province, timezone
+                FROM tide_station_ids
+                WHERE station_id = ?
+            ''', (station_id,)).fetchone()
+
+            if result:
+                return {
+                    'station_id': result[0],
+                    'place_name': result[1],
+                    'country': result[2] if result[2] else 'USA',
+                    'api_source': result[3] if result[3] else 'NOAA',
+                    'latitude': result[4],
+                    'longitude': result[5],
+                    'province': result[6],
+                    'timezone': result[7],
+                }
+```
+
+- [ ] **Step 3c: Read timezone in the US importer** — in `_import_us_csv`, parse it and include in both statements:
+
+```python
+                    station_id = row['station_id']
+                    place_name = row['place_name']
+                    csv_station_ids.add(station_id)
+                    latitude = _parse_coord(row.get('latitude'), station_id, place_name, 'latitude')
+                    longitude = _parse_coord(row.get('longitude'), station_id, place_name, 'longitude')
+                    tz = (row.get('timezone') or '').strip() or None
+
+                    cursor.execute('''
+                        INSERT OR IGNORE INTO tide_station_ids
+                        (station_id, place_name, country, api_source, latitude, longitude, timezone, lookup_count, last_lookup)
+                        VALUES (?, ?, 'USA', 'NOAA', ?, ?, ?, 1, CURRENT_TIMESTAMP)
+                    ''', (station_id, place_name, latitude, longitude, tz))
+                    cursor.execute('''
+                        UPDATE tide_station_ids
+                        SET place_name = ?, country = 'USA', api_source = 'NOAA',
+                            latitude = ?, longitude = ?, timezone = COALESCE(?, timezone)
+                        WHERE station_id = ?
+                    ''', (place_name, latitude, longitude, tz, station_id))
+                    imported_count += 1
+```
+
+- [ ] **Step 3d: Read timezone in the Canadian CSV importer** — in `import_canadian_stations_from_csv`, after `alternative_name = row.get('alternative_name') or None`, add `tz = (row.get('timezone') or '').strip() or None` and add `timezone` to the INSERT column list/values and the UPDATE `SET` (use `timezone = COALESCE(?, timezone)`), mirroring Step 3c. Full INSERT becomes:
+
+```python
+                    cursor.execute('''
+                        INSERT OR IGNORE INTO tide_station_ids
+                        (station_id, place_name, country, api_source, latitude, longitude, province, alternative_name, timezone, lookup_count, last_lookup)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
+                    ''', (station_id, place_name, country, api_source, latitude, longitude, province, alternative_name, tz))
+                    cursor.execute('''
+                        UPDATE tide_station_ids
+                        SET place_name = ?, country = ?, api_source = ?, latitude = ?, longitude = ?, province = ?, alternative_name = ?, timezone = COALESCE(?, timezone)
+                        WHERE station_id = ?
+                    ''', (place_name, country, api_source, latitude, longitude, province, alternative_name, tz, station_id))
+```
+
+- [ ] **Step 3e: Add `backfill_timezones_from_csv`** — add to `app/database.py`:
+
+```python
+def backfill_timezones_from_csv(csv_paths=None):
+    """Fill NULL/empty `timezone` on existing DB rows from the shipped CSVs.
+
+    Needed because the US CSV import short-circuits on a warm DB, and Canadian
+    stations imported via the live CHS API have no timezone. Source is the
+    shipped CSV (no network, no heavy library). Idempotent. Returns rows updated.
+    """
+    if csv_paths is None:
+        here = os.path.dirname(__file__)
+        csv_paths = [os.path.join(here, 'tide_stations_new.csv'),
+                     os.path.join(here, 'canadian_tide_stations.csv')]
+    updated = 0
+    try:
+        with sqlite3.connect(DB_PATH) as conn:
+            for path in csv_paths:
+                if not os.path.exists(path):
+                    continue
+                with open(path, 'r', encoding='utf-8') as f:
+                    for row in csv.DictReader(f):
+                        tz = (row.get('timezone') or '').strip()
+                        sid = row.get('station_id')
+                        if not tz or not sid:
+                            continue
+                        cur = conn.execute(
+                            "UPDATE tide_station_ids SET timezone = ? "
+                            "WHERE station_id = ? AND (timezone IS NULL OR timezone = '')",
+                            (tz, sid))
+                        updated += cur.rowcount
+            conn.commit()
+        logging.info("Timezone backfill: set timezone on %d station(s)", updated)
+        return updated
+    except (sqlite3.Error, OSError) as e:
+        logging.error("Timezone backfill failed: %s", e)
+        return updated
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd app && ../venv/bin/python -m unittest test_sun_times.TimezoneDBTest -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire into startup** — in `app/run.py`, add after `backfill_missing_coordinates()`:
+
+```python
+from app.database import backfill_timezones_from_csv
+...
+backfill_missing_coordinates()
+backfill_timezones_from_csv()
+cleanup_previous_month_pdfs()
+```
+
+- [ ] **Step 6: Full suite + commit**
+
+Run: `cd app && ../venv/bin/python -m unittest discover -p 'test_*.py'`
+Expected: all pass.
+
+```bash
+git add app/database.py app/run.py app/test_sun_times.py
+git commit -m "DB: timezone column, import, get_station_info, startup backfill"
+```
+
+---
+
+## Task 5: `sun_times.py` — sunrise/sunset computation
+
+**Files:**
+- Create: `app/sun_times.py`
+- Test: `app/test_sun_times.py` (append)
+
+- [ ] **Step 1: Append the failing tests**
+
+```python
+class SunTimesTest(unittest.TestCase):
+    def test_point_roberts_june(self):
+        import sun_times
+        m = sun_times.sun_times_for_month(48.97, -123.07, 'America/Vancouver', 2026, 6)
+        self.assertEqual(len(m), 30)
+        rise, sset = m[15]  # mid-June
+        # 24h "HH:MM" strings; sunrise early morning, sunset late evening (PDT)
+        self.assertRegex(rise, r'^\d{2}:\d{2}$')
+        self.assertRegex(sset, r'^\d{2}:\d{2}$')
+        self.assertIn(int(rise[:2]), range(4, 7))    # ~05:xx
+        self.assertIn(int(sset[:2]), range(20, 23))  # ~21:xx
+
+    def test_polar_day_returns_note(self):
+        import sun_times
+        m = sun_times.sun_times_for_month(78.0, 15.0, 'Arctic/Longyearbyen', 2026, 6)
+        self.assertEqual(m[15], '24h daylight')
+
+    def test_missing_tz_returns_empty(self):
+        import sun_times
+        self.assertEqual(sun_times.sun_times_for_month(48.0, -123.0, None, 2026, 6), {})
+
+    def test_format_sun_line(self):
+        import sun_times
+        self.assertEqual(sun_times.format_sun_line(('05:14', '21:09')), 'Rise 05:14  Set 21:09')
+        self.assertEqual(sun_times.format_sun_line('24h daylight'), 'Sun: 24h daylight')
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd app && ../venv/bin/python -m unittest test_sun_times.SunTimesTest -v`
+Expected: FAIL — no module `sun_times`.
+
+- [ ] **Step 3: Implement `sun_times.py`**
+
+```python
+# app/sun_times.py
+"""Local-timezone helpers for the PDF calendar: sunrise/sunset computation and
+CHS UTC->local tide-time conversion.
+
+Runtime deps: astral (pure-Python) + stdlib zoneinfo. The IANA timezone per
+station is precomputed offline (scripts/fetch_station_timezones.py) and read
+from the DB; nothing here needs timezonefinder.
+"""
+import calendar as _calendar
+import logging
+from datetime import date as _date, datetime as _datetime, timezone as _utc
+from zoneinfo import ZoneInfo
+
+from astral import Observer
+from astral import sun as _astral_sun
+
+
+def _zone(iana_tz):
+    try:
+        return ZoneInfo(iana_tz) if iana_tz else None
+    except Exception:
+        logging.warning("Unknown timezone %r", iana_tz)
+        return None
+
+
+def _day_sun(observer, d, tz):
+    """Return ("HH:MM" rise, "HH:MM" set) or a polar note string for one day."""
+    try:
+        rise = _astral_sun.sunrise(observer, date=d, tzinfo=tz)
+        sset = _astral_sun.sunset(observer, date=d, tzinfo=tz)
+        return (rise.strftime('%H:%M'), sset.strftime('%H:%M'))
+    except ValueError:
+        # Polar day or night: classify by solar elevation at local noon.
+        noon = _datetime(d.year, d.month, d.day, 12, 0, tzinfo=tz)
+        try:
+            up = _astral_sun.elevation(observer, noon) > 0
+        except Exception:
+            return '24h daylight'  # benign default; extremely rare
+        return '24h daylight' if up else 'polar night'
+
+
+def sun_times_for_month(lat, lng, iana_tz, year, month):
+    """{day:int -> ("HH:MM","HH:MM") | note str}. Empty dict if tz/coords missing."""
+    tz = _zone(iana_tz)
+    if lat is None or lng is None or tz is None:
+        return {}
+    observer = Observer(latitude=lat, longitude=lng)
+    _, last = _calendar.monthrange(year, month)
+    return {day: _day_sun(observer, _date(year, month, day), tz)
+            for day in range(1, last + 1)}
+
+
+def format_sun_line(value):
+    """Render a day's sun value as the pcal cell text."""
+    if isinstance(value, tuple):
+        return f"Rise {value[0]}  Set {value[1]}"
+    return f"Sun: {value}"
+
+
+def localize_and_filter_csv(csv_data, api_source, iana_tz, year, month):
+    """Convert CHS (UTC) tide rows to local time and keep only the target local
+    month. NOAA rows (already local) pass through unchanged.
+
+    csv_data: header line + `YYYY-MM-DD HH:MM,value,Type` rows.
+    """
+    if (api_source or '').upper() != 'CHS':
+        return csv_data  # NOAA times are already local
+
+    tz = _zone(iana_tz)
+    lines = csv_data.splitlines()
+    if not lines:
+        return csv_data
+    header, body = lines[0], lines[1:]
+    out = [header]
+    for line in body:
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(',')
+        if len(parts) != 3:
+            continue
+        dt_str, value, ttype = parts
+        try:
+            naive = _datetime.strptime(dt_str.strip(), '%Y-%m-%d %H:%M')
+        except ValueError:
+            continue
+        if tz is None:
+            # No timezone known: keep UTC times but still drop the ±1-day pad so
+            # the month is bounded (status-quo behaviour, minus the pad rows).
+            local = naive
+        else:
+            local = naive.replace(tzinfo=_utc).astimezone(tz)
+        if local.year == year and local.month == month:
+            out.append(f"{local.strftime('%Y-%m-%d %H:%M')},{value},{ttype}")
+    return '\n'.join(out)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd app && ../venv/bin/python -m unittest test_sun_times.SunTimesTest -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/sun_times.py app/test_sun_times.py
+git commit -m "Add sun_times: sunrise/sunset + CHS UTC->local conversion"
+```
+
+---
+
+## Task 6: Test CHS localization + filtering
+
+**Files:** Test: `app/test_sun_times.py` (append)
+
+- [ ] **Step 1: Append the failing tests**
+
+```python
+class LocalizeCsvTest(unittest.TestCase):
+    HEADER = 'Date Time,Prediction,Type'
+
+    def test_chs_converts_and_crosses_midnight(self):
+        import sun_times
+        csv_in = self.HEADER + '\n2026-06-15 05:23,4.8,H'  # UTC
+        out = sun_times.localize_and_filter_csv(csv_in, 'CHS', 'America/Vancouver', 2026, 6)
+        # 05:23Z -> 22:23 the previous local day (PDT, UTC-7)
+        self.assertIn('2026-06-14 22:23,4.8,H', out)
+
+    def test_chs_recovers_last_day_evening_and_drops_prev_month(self):
+        import sun_times
+        csv_in = (self.HEADER
+                  + '\n2026-06-01 02:00,1.0,L'    # -> 2026-05-31 19:00 local: DROP
+                  + '\n2026-07-01 04:00,2.0,H')   # -> 2026-06-30 21:00 local: KEEP
+        out = sun_times.localize_and_filter_csv(csv_in, 'CHS', 'America/Vancouver', 2026, 6)
+        self.assertNotIn('05-31', out)
+        self.assertIn('2026-06-30 21:00,2.0,H', out)
+
+    def test_noaa_passthrough(self):
+        import sun_times
+        csv_in = self.HEADER + '\n2026-06-15 05:23,4.8,H'
+        self.assertEqual(sun_times.localize_and_filter_csv(csv_in, 'NOAA', None, 2026, 6), csv_in)
+```
+
+- [ ] **Step 2: Run to verify pass** (implementation already exists from Task 5)
+
+Run: `cd app && ../venv/bin/python -m unittest test_sun_times.LocalizeCsvTest -v`
+Expected: PASS (3 tests). (If `test_noaa_passthrough` or conversion fails, fix `localize_and_filter_csv` in `sun_times.py`, not the test.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/test_sun_times.py
+git commit -m "Test CHS UTC->local conversion, month filtering, NOAA passthrough"
+```
+
+---
+
+## Task 7: CHS fetch padded ±1 day (UTC)
+
+**Files:**
+- Modify: `app/tide_adapters.py` (`CHSAdapter.get_predictions`)
+- Test: `app/test_tide_adapters.py` (append) — or `app/test_sun_times.py` if simpler
+
+The padded window lets Task 6's local-month filter recover edge events. Compute the padded UTC range from the month.
+
+- [ ] **Step 1: Write the failing test** (append to `app/test_tide_adapters.py`)
+
+```python
+class CHSPaddingTest(unittest.TestCase):
+    def test_get_predictions_pads_one_day(self):
+        import tide_adapters
+        from unittest import mock
+        captured = {}
+
+        class FakeResp:
+            status_code = 200
+            text = '[]'
+        def fake_get(url, params=None, headers=None, timeout=None):
+            if url.endswith('/data'):
+                captured['params'] = params
+            return FakeResp()
+
+        a = tide_adapters.CHSAdapter()
+        with mock.patch.object(a, '_lookup_station_uuid', return_value='uuid'), \
+             mock.patch('tide_adapters.requests.get', side_effect=fake_get):
+            a.get_predictions('07735', 2026, 6)
+        # June 2026: padded from May 31 to July 1 (UTC)
+        self.assertEqual(captured['params']['from'], '2026-05-31T00:00:00Z')
+        self.assertEqual(captured['params']['to'], '2026-07-01T23:59:59Z')
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd app && ../venv/bin/python -m unittest test_tide_adapters.CHSPaddingTest -v`
+Expected: FAIL — current `from`/`to` are the exact month bounds.
+
+- [ ] **Step 3: Implement padding** — in `CHSAdapter.get_predictions`, replace the `from_date`/`to_date` construction:
+
+```python
+        # Calculate date range for the month, padded ±1 day in UTC. The pad lets
+        # the local-month filter (sun_times.localize_and_filter_csv) recover
+        # events that fall in the target LOCAL month but land in an adjacent UTC
+        # day after UTC->local conversion (west-of-UTC stations lose late-evening
+        # tides on the last day otherwise).
+        from datetime import date as _date, timedelta as _timedelta
+        _, last_day = calendar.monthrange(year, month)
+        pad_from = _date(year, month, 1) - _timedelta(days=1)
+        pad_to = _date(year, month, last_day) + _timedelta(days=1)
+        from_date = pad_from.strftime('%Y-%m-%dT00:00:00Z')
+        to_date = pad_to.strftime('%Y-%m-%dT23:59:59Z')
+```
+
+(Remove the now-duplicate `_, last_day = calendar.monthrange(year, month)` line above if present, or keep a single one.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd app && ../venv/bin/python -m unittest test_tide_adapters.CHSPaddingTest -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + commit**
+
+Run: `cd app && ../venv/bin/python -m unittest discover -p 'test_*.py'`
+Expected: all pass.
+
+```bash
+git add app/tide_adapters.py app/test_tide_adapters.py
+git commit -m "CHS: fetch padded ±1 day so local-month filter recovers edge tides"
+```
+
+---
+
+## Task 8: Integrate into `get_tides` (localize + sun line in pcal)
+
+**Files:**
+- Modify: `app/get_tides.py`
+- Test: `app/test_get_tides_sun.py` (new — keeps get_tides tests isolated)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# app/test_get_tides_sun.py
+import os, tempfile, unittest
+import get_tides
+
+
+class PcalSunLineTest(unittest.TestCase):
+    def test_writes_sun_line_before_tides(self):
+        csv_data = "Date Time,Prediction,Type\n2026-06-15 05:23,4.8,H\n2026-06-15 11:40,0.1,L"
+        sun = {15: ('05:14', '21:09')}
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'events.txt')
+            get_tides.convert_tide_data_to_pcal(csv_data, path, location_name='Test',
+                                                sun_times=sun)
+            text = open(path).read()
+        self.assertIn('6/15  Rise 05:14  Set 21:09', text)
+        # sun line appears before that day's tide lines
+        self.assertLess(text.index('Rise 05:14'), text.index('05:23 High'))
+
+    def test_no_sun_times_is_backward_compatible(self):
+        csv_data = "Date Time,Prediction,Type\n2026-06-15 05:23,4.8,H"
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'events.txt')
+            get_tides.convert_tide_data_to_pcal(csv_data, path, location_name='Test')
+            text = open(path).read()
+        self.assertNotIn('Rise', text)
+        self.assertIn('05:23 High', text)
+
+
+if __name__ == '__main__':
+    unittest.main()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd app && ../venv/bin/python -m unittest test_get_tides_sun.PcalSunLineTest -v`
+Expected: FAIL — `convert_tide_data_to_pcal` has no `sun_times` parameter.
+
+- [ ] **Step 3a: Add the dual import** near the top of `app/get_tides.py` (alongside the existing try/except imports):
+
+```python
+try:
+    from app.sun_times import sun_times_for_month, format_sun_line, localize_and_filter_csv
+except ImportError:
+    from sun_times import sun_times_for_month, format_sun_line, localize_and_filter_csv
+```
+
+- [ ] **Step 3b: Write the sun block in `convert_tide_data_to_pcal`** — change the signature and emit sun lines first. Replace the function signature line and add the sun block immediately after `with open(pcal_filename, 'w') as pcal_file:`:
+
+```python
+def convert_tide_data_to_pcal(csv_data, pcal_filename, location_name=None, station_id=None, sun_times=None):
+    """Convert tide CSV text to a pcal custom dates file.
+
+    sun_times: optional {day:int -> ("HH:MM","HH:MM") | note str} from
+    sun_times_for_month(); when present, a `Rise … Set …` line is written for
+    each day BEFORE that day's tide lines so it sits at the top of the cell.
+    """
+    lines = csv_data.splitlines()
+
+    with open(pcal_filename, 'w') as pcal_file:
+        # Sun lines first so pcal places them above the tide events for each day.
+        if sun_times:
+            # Derive month from the first data row (all rows share the month).
+            month_num = None
+            for line in lines[1:]:
+                if line.strip():
+                    try:
+                        month_num = int(line.strip().split(',')[0].split()[0].split('-')[1])
+                        break
+                    except (IndexError, ValueError):
+                        continue
+            if month_num is not None:
+                for day in sorted(sun_times):
+                    pcal_file.write(f"{month_num}/{day}  {format_sun_line(sun_times[day])}\n")
+
+        valid_lines = 0
+        skipped_lines = 0
+        # ... (existing tide-parsing loop unchanged) ...
+```
+
+Keep the rest of the existing function body (the tide-parsing loop and the trailing `note/1` write) exactly as-is.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd app && ../venv/bin/python -m unittest test_get_tides_sun.PcalSunLineTest -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire localization + sun computation into `generate_calendar`** — replace the body of `generate_calendar` up to the `convert_tide_data_to_pcal` call so it fetches station metadata once, localizes CHS data, and computes sun times:
+
+```python
+def generate_calendar(station_id, year, month, output_path, location_name=None):
+    """Fetch tide data and render a PDF calendar at output_path. See module docs."""
+    station_info = get_station_info(station_id) or {}
+    api_source = station_info.get('api_source')
+    iana_tz = station_info.get('timezone')
+    lat = station_info.get('latitude')
+    lng = station_info.get('longitude')
+
+    csv_data = download_tide_data(station_id, year, month)
+    # CHS times are UTC -> convert to the station's local zone and trim to the
+    # local month (NOAA passes through unchanged).
+    csv_data = localize_and_filter_csv(csv_data, api_source, iana_tz, year, month)
+    sun = sun_times_for_month(lat, lng, iana_tz, year, month)
+
+    os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
+    tmp_pdf = f"{output_path}.tmp.{os.getpid()}.{threading.get_ident()}"
+
+    try:
+        with tempfile.TemporaryDirectory(prefix='tidecal-') as tmpdir:
+            pcal_path = os.path.join(tmpdir, 'events.txt')
+            ps_path = os.path.join(tmpdir, 'calendar.ps')
+
+            convert_tide_data_to_pcal(csv_data, pcal_path,
+                                      location_name=location_name,
+                                      station_id=station_id,
+                                      sun_times=sun)
+
+            _run_tool(["pcal", "-f", pcal_path, "-o", ps_path,
+                       "-s", "0.0:0.0:1.0", "-n", "Helvetica-Narrow/9",
+                       "-m", "-C", "tidecalendar.xyz",
+                       str(month), str(year)])
+            _run_tool(["ps2pdf", ps_path, tmp_pdf])
+
+            if not os.path.exists(tmp_pdf) or os.path.getsize(tmp_pdf) == 0:
+                raise CalendarGenerationError("ps2pdf produced no output")
+            os.replace(tmp_pdf, output_path)
+    finally:
+        if os.path.exists(tmp_pdf):
+            os.remove(tmp_pdf)
+
+    logging.info(f"PDF file created: {output_path}")
+    return output_path
+```
+
+(`get_station_info` is already imported at the top of `get_tides.py`.)
+
+- [ ] **Step 6: Full suite + commit**
+
+Run: `cd app && ../venv/bin/python -m unittest discover -p 'test_*.py'`
+Expected: all pass.
+
+```bash
+git add app/get_tides.py app/test_get_tides_sun.py
+git commit -m "get_tides: localize CHS times and render sunrise/sunset line in pcal"
+```
+
+---
+
+## Task 9: Dockerfile — ship `sun_times.py`
+
+**Files:** Modify: `Dockerfile`
+
+- [ ] **Step 1: Add the COPY** — after `COPY app/station_coordinates.py /app/` in the Dockerfile, add:
+
+```dockerfile
+COPY app/sun_times.py /app/
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `docker build -t tide-calendar-app . && docker run --rm -w / tide-calendar-app python3 -c "import app.sun_times; print('ok')"`
+Expected: prints `ok` (confirms the module ships and astral is installed in the image).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "Ship app/sun_times.py in the Docker image"
+```
+
+---
+
+## Task 10: Docs (CLAUDE.md)
+
+**Files:** Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Document the script + feature** — add a Maintenance Scripts subsection for `scripts/fetch_station_timezones.py` (bakes the IANA `timezone` column into both CSVs from lat/long via timezonefinder; dev-only dep; run when stations are added). Add Important Notes bullets:
+  - Tide times render in the station's **local** timezone: NOAA is fetched `lst_ldt` (already local); CHS is UTC and converted via `sun_times.localize_and_filter_csv` (with a ±1-day padded fetch + local-month filter).
+  - Sunrise/sunset come from `app/sun_times.py` (astral + zoneinfo), shown as a 24h `Rise HH:MM  Set HH:MM` line per day; IANA tz is precomputed and stored in the DB `timezone` column; `backfill_timezones_from_csv()` populates it on the warm DB at startup.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "Document timezone/sunrise-sunset feature and the tz-baking script"
+```
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage:** tz data + script + bake (Tasks 2–3), DB column/import/backfill (4), sun computation incl. polar (5), CHS localize+filter (5–6), CHS padding (7), pcal render + integration (8), deps (1), Docker (9), docs (10), tests throughout. All spec sections mapped.
+- **Type consistency:** `sun_times_for_month` returns `{day: tuple|str}`; `format_sun_line` accepts tuple|str; `convert_tide_data_to_pcal(..., sun_times=)` consumes that dict; `localize_and_filter_csv(csv, api_source, iana_tz, year, month)` signature consistent across Tasks 5/6/8; `backfill_timezones_from_csv(csv_paths=None)` consistent across Tasks 4/run.py. `get_station_info` adds `timezone` (Task 4) consumed in Task 8.
+- **Placeholders:** none — all code blocks complete.
+- **Risk note:** Task 8 Step 5 rewrites `generate_calendar`; the existing atomic-rename/temp-dir logic is preserved verbatim. Full suite run guards regressions.
+```

--- a/docs/superpowers/specs/2026-06-20-sunrise-sunset-design.md
+++ b/docs/superpowers/specs/2026-06-20-sunrise-sunset-design.md
@@ -1,0 +1,118 @@
+# Sunrise/Sunset + Local Times on the PDF Calendar — Design Spec
+
+**Date:** 2026-06-20
+**Branch:** `feature/sunrise-sunset-times` (off `development`)
+**Status:** Approved for implementation
+**Goal:** A downloaded calendar on dev.tidecalendar.xyz shows correct local-time
+sunrise/sunset on each day, with all tide times in the station's local timezone,
+matching this spec.
+
+## Background
+
+Adds local sunrise/sunset times to each day of the printable PDF calendar (via
+`pcal`), and makes **all** tide times render in the tide station's local timezone.
+Motivated by David's issue #96 (daylight-restricted extreme tides), which depends on
+having sunrise/sunset data — this is that foundation.
+
+### Timezone reality (the crux)
+- **NOAA (US)** is requested with `time_zone=lst_ldt`, so US tide times are already
+  **local** (DST-aware). ✅
+- **CHS (Canada)** is requested/parsed in **UTC and kept as UTC** (`tide_adapters.py`
+  comment "CHS returns UTC times - we keep them as-is"). So Canadian calendars
+  currently show tide times in **UTC** — a pre-existing latent inaccuracy this feature
+  fixes, because local sunrise/sunset on a UTC-tide calendar would be inconsistent.
+- We now have **lat/long for every station** (from the map feature), which is what's
+  needed to derive each station's timezone.
+
+## Key decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Tide-time timezones | **All local** | Convert CHS UTC→local; NOAA already local; consistent calendars |
+| Timezone source | **Precompute IANA zone offline, bake into CSVs** | Matches coordinate/province pattern; keeps image lean (no runtime `timezonefinder`) |
+| Time format | **24h** (military) | Per request; 12h/24h web toggle is a later feature |
+| Day-cell display | Compact one-liner `Rise 05:14  Set 21:09` at top of cell | ASCII-safe for pcal's PostScript fonts; saves vertical space |
+| Sun computation | `astral` + stdlib `zoneinfo` at runtime | Small, pure-Python; no heavy deps in the image |
+
+## Non-goals (YAGNI)
+12h/24h web toggle (later — formatting kept centralized so it's easy), moon phases,
+twilight/golden-hour, daylight-restricted extreme tides (#96 — separate future feature
+that builds on this), changing the NOAA local-time behavior.
+
+## Architecture
+
+### 1. Timezone data (foundation)
+- **`scripts/fetch_station_timezones.py`** (new, dev-only): for every station in both
+  CSVs, derive the IANA zone from lat/long via `timezonefinder`, and write a
+  `timezone` column into `app/tide_stations_new.csv` and
+  `app/canadian_tide_stations.csv`. Run occasionally / when stations are added.
+- **DB**: add a `timezone` column to `tide_station_ids` via the existing
+  `_migrate_columns`. Both CSV importers read/persist it.
+- **Startup sync `backfill_timezones_from_csv()`** (in `database.py` or a small module,
+  wired in `run.py`): fills DB `timezone` from the shipped CSVs for any rows missing it.
+  Required because the US CSV import short-circuits on the warm prod DB — the source is
+  the shipped CSV, so **no runtime library and no network**. Idempotent; non-fatal.
+- `get_station_info()` returns `timezone`.
+
+### 2. Make all tide times local
+- New module **`app/sun_times.py`** owns timezone logic (and sun computation, §3).
+- **NOAA**: leave tide times unchanged (already local `lst_ldt`).
+- **CHS UTC→local**: in `get_tides`, convert each CHS event datetime to the station's
+  IANA zone (`zoneinfo`). Because UTC→local shifts the wall clock and can cross
+  midnight, the **CHS fetch is padded ±1 day in UTC**, then converted events are
+  **filtered to the target *local* month** so every local day is complete (without
+  padding, west-of-UTC stations lose late-evening tides on the last local day).
+  - Mechanism: CHS `get_predictions` fetches `[first_day−1 .. last_day+1]` in UTC;
+    `get_tides` localizes and drops events whose local date is outside the target month.
+  - NOAA needs no padding (`lst_ldt` returns local-dated events for the month).
+
+### 3. Sunrise/sunset computation
+- `sun_times.py`: `sun_times_for_month(lat, lng, iana_tz, year, month)` →
+  `{day:int -> ("HH:MM" rise, "HH:MM" set)}` using `astral` + `zoneinfo`, 24h local.
+- **Polar edge cases**: `astral` raises when the sun doesn't rise/set at high latitude.
+  Catch it and substitute a short ASCII note (`Sun: 24h daylight` / `Sun: polar night`)
+  for that day instead of times. Never crash.
+
+### 4. PDF rendering (pcal)
+- `convert_tide_data_to_pcal` writes one `M/D  Rise 05:14  Set 21:09` line per day,
+  emitted **before** that day's tide lines so it appears at the top of the cell.
+- Missing timezone (e.g., a brand-new station not yet in the tz script run) → **omit**
+  the sun line gracefully (logged); tides still render. For CHS specifically, a missing
+  tz falls back to current UTC behavior for that station (logged) rather than failing.
+
+### 5. Dependencies / Docker
+- Add **`astral`** to `requirements.txt` (runtime; verify `requires_python` against
+  `python:3.12-slim-bookworm` per the dep-check rule). `timezonefinder` is **dev-only**
+  (used by the script; not shipped).
+- Dockerfile must `COPY app/sun_times.py` (individual-file COPY list). CSVs already ship.
+
+## Testing
+- **Script**: `fetch_station_timezones.py` writes the expected `timezone` column shape
+  (mock/`timezonefinder` smoke).
+- **`sun_times.py`**:
+  - Known case: Point Roberts WA (48.97, −123.07, `America/Vancouver`), mid-June →
+    sunrise ~05:0x, sunset ~21:0x (assert within a sane window, not exact).
+  - 24h formatting (e.g., `21:09` not `9:09 PM`).
+  - Polar: a 78°N location in June → `24h daylight` note (no crash).
+- **CHS localization**: a UTC event that crosses midnight converts to the correct local
+  date+time (e.g., `2026-06-15 05:23Z` @ `America/Vancouver` → `2026-06-14 22:23`); and
+  local-month filtering keeps/drops the right edge events.
+- **pcal output**: generated events file contains a `Rise … Set …` line for a day.
+- **DB**: `get_station_info()` returns `timezone`; `backfill_timezones_from_csv()` fills
+  a NULL-tz row from the CSV.
+- Full suite stays green (`cd app && python -m unittest discover -p 'test_*.py'`).
+
+## Acceptance (the goal)
+On **dev.tidecalendar.xyz**, a downloaded calendar:
+- Shows `Rise HH:MM  Set HH:MM` (24h, local) on each day, plausible for the station's
+  location and season.
+- US calendar: tide times unchanged (local); sun line added.
+- Canadian calendar: tide times now **local** (not UTC) and consistent with the sun line.
+
+## Risks / notes
+- `astral`'s sunrise/sunset is "official" (standard refraction) — minutes-level accuracy,
+  fine for a printable calendar.
+- The CHS UTC→local fix changes existing Canadian calendars (correctly). Cached Canadian
+  PDFs predating this will differ; the monthly cache TTL / redeploy clears them.
+- IANA tz via `timezonefinder` is authoritative incl. DST; far better than the rejected
+  fixed-offset approach.

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ gunicorn==23.0.0
 requests==2.33.0
 urllib3==2.7.0
 python-dotenv==1.2.2
+astral==3.2

--- a/scripts/fetch_station_timezones.py
+++ b/scripts/fetch_station_timezones.py
@@ -1,0 +1,72 @@
+"""Bake an IANA `timezone` column into the station CSVs from each station's
+lat/long, using timezonefinder.
+
+Dev-only: timezonefinder is heavy (numpy/h3/cffi) and is NOT a runtime dependency.
+Runtime uses the baked column via stdlib zoneinfo. Mirrors the coordinate /
+province precompute pattern.
+
+Usage:
+    pip install timezonefinder
+    python scripts/fetch_station_timezones.py
+"""
+import csv
+import logging
+import os
+import sys
+
+APP_DIR = os.path.join(os.path.dirname(__file__), '..', 'app')
+US_CSV = os.path.join(APP_DIR, 'tide_stations_new.csv')
+CA_CSV = os.path.join(APP_DIR, 'canadian_tide_stations.csv')
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+
+def add_timezone_column(rows, lookup):
+    """Pure transform: set row['timezone'] = lookup(lat, lng) (or '' if None).
+
+    lookup takes (lat: float|None, lng: float|None) and returns an IANA tz or None.
+    """
+    out = []
+    for row in rows:
+        try:
+            lat = float(row['latitude']) if row.get('latitude') else None
+            lng = float(row['longitude']) if row.get('longitude') else None
+        except (TypeError, ValueError):
+            lat = lng = None
+        tz = lookup(lat, lng) if (lat is not None and lng is not None) else None
+        new = dict(row)
+        new['timezone'] = tz or ''
+        out.append(new)
+    return out
+
+
+def _rewrite_csv(path, lookup):
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames)
+        rows = list(reader)
+    merged = add_timezone_column(rows, lookup)
+    if 'timezone' not in fieldnames:
+        fieldnames.append('timezone')
+    with open(path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, quoting=csv.QUOTE_MINIMAL)
+        writer.writeheader()
+        writer.writerows(merged)
+    matched = sum(1 for r in merged if r['timezone'])
+    logging.info("%s: %d/%d rows got a timezone", os.path.basename(path), matched, len(merged))
+
+
+def main():
+    from timezonefinder import TimezoneFinder
+    tf = TimezoneFinder()
+
+    def lookup(lat, lng):
+        return tf.timezone_at(lat=lat, lng=lng)
+
+    for path in (US_CSV, CA_CSV):
+        _rewrite_csv(path, lookup)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/test_fetch_station_timezones.py
+++ b/scripts/test_fetch_station_timezones.py
@@ -1,0 +1,19 @@
+import os, sys, unittest
+sys.path.insert(0, os.path.dirname(__file__))
+from fetch_station_timezones import add_timezone_column
+
+class AddTimezoneColumnTest(unittest.TestCase):
+    def test_adds_timezone_from_lookup(self):
+        rows = [{'station_id': '9449639', 'place_name': 'Point Roberts, WA',
+                 'latitude': '48.97', 'longitude': '-123.07'}]
+        out = add_timezone_column(rows, lambda lat, lng: 'America/Vancouver')
+        self.assertEqual(out[0]['timezone'], 'America/Vancouver')
+        self.assertEqual(out[0]['station_id'], '9449639')
+
+    def test_blank_when_lookup_returns_none(self):
+        rows = [{'station_id': 'x', 'place_name': 'Ocean', 'latitude': '', 'longitude': ''}]
+        out = add_timezone_column(rows, lambda lat, lng: None)
+        self.assertEqual(out[0]['timezone'], '')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Promotes the sunrise/sunset feature (PR #100) from `development` to production.

## What ships
- **Sunrise/sunset** on each PDF day: a 24h `Rise HH:MM  Set HH:MM` line (astral + zoneinfo), polar-safe.
- **All tide times local**: NOAA already local; **CHS converted UTC→local** (fixes the latent Canadian-UTC bug), via a ±1-day padded fetch + local-month filter.
- IANA timezone precomputed per station (baked into CSVs) + DB `timezone` column + startup `backfill_timezones_from_csv()` for the warm volume. Runtime stays light (`astral` only; `timezonefinder` is dev-only).
- Also carries the earlier `CLAUDE.md` session-learnings doc (#99, docs-only).

## Verified on dev.tidecalendar.xyz
- US (Point Roberts) Sept 2026: `Rise 06:29 Set 19:53` → `07:11/18:52` across the month.
- Canada (Vancouver): near-identical sun times (~25 km apart ✓) AND tide times now **local** (no longer UTC).
- 114 unit tests; adversarial Sonnet review found no critical bugs; Docker image builds.

## Production note
This **changes Canadian calendars** (tide times UTC→local, correctly). Cached Canadian PDFs predating this will differ once regenerated (monthly cache TTL / redeploy clears old-month files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)