### PR TITLE
Extreme-tide tables: date ordering + month-letter day prefix

### DIFF
--- a/app/get_tides.py
+++ b/app/get_tides.py
@@ -78,10 +78,10 @@ def download_tide_data(station_id, year, month):
     return csv_data
 
 
-def _write_extreme_note(pcal_file, box, title, entries, empty_msg):
+def _write_extreme_note(pcal_file, box, title, entries, empty_msg, month=None):
     """Write a stacked pcal note table into the given empty-cell box."""
     pcal_file.write(f"note/{box} all {title}\n")
-    rows = format_extreme_rows(entries)
+    rows = format_extreme_rows(entries, month)
     if rows:
         for row in rows:
             pcal_file.write(f"note/{box} all {row}\n")
@@ -99,20 +99,22 @@ def convert_tide_data_to_pcal(csv_data, pcal_filename, location_name=None, stati
     """
     lines = csv_data.splitlines()
 
+    # Month number derived from the first data row (all rows share the month);
+    # used for both the per-day sun lines and the extreme-tide date prefixes.
+    month_num = None
+    for line in lines[1:]:
+        if line.strip():
+            try:
+                month_num = int(line.strip().split(',')[0].split()[0].split('-')[1])
+                break
+            except (IndexError, ValueError):
+                continue
+
     with open(pcal_filename, 'w') as pcal_file:
         # Sun lines first so pcal places them above the tide events for each day.
-        if sun_times:
-            month_num = None
-            for line in lines[1:]:
-                if line.strip():
-                    try:
-                        month_num = int(line.strip().split(',')[0].split()[0].split('-')[1])
-                        break
-                    except (IndexError, ValueError):
-                        continue
-            if month_num is not None:
-                for day in sorted(sun_times):
-                    pcal_file.write(f"{month_num}/{day}  {format_sun_line(sun_times[day])}\n")
+        if sun_times and month_num is not None:
+            for day in sorted(sun_times):
+                pcal_file.write(f"{month_num}/{day}  {format_sun_line(sun_times[day])}\n")
 
         valid_lines = 0
         skipped_lines = 0
@@ -177,10 +179,10 @@ def convert_tide_data_to_pcal(csv_data, pcal_filename, location_name=None, stati
         # Daylight extreme-tide tables in unused cells (note/2, note/3).
         if high_tides is not None:
             _write_extreme_note(pcal_file, 2, "Top 5 High Tides (daylight)",
-                                high_tides, "No daylight high tides")
+                                high_tides, "No daylight high tides", month_num)
         if low_tides is not None:
             _write_extreme_note(pcal_file, 3, "Top 5 Low Tides (daylight)",
-                                low_tides, "No daylight low tides")
+                                low_tides, "No daylight low tides", month_num)
 
         # Tide station note shown on the calendar page
         if location_name:

--- a/app/test_get_tides_sun.py
+++ b/app/test_get_tides_sun.py
@@ -38,10 +38,11 @@ class PcalExtremeTablesTest(unittest.TestCase):
                                                 high_tides=highs, low_tides=lows)
             with open(path) as f:
                 text = f.read()
+        # month derived from the data row (June) -> 'J' prefix on the day
         self.assertIn('note/2 all Top 5 High Tides (daylight)', text)
-        self.assertIn('note/2 all  4  09:00  4.8 m', text)
+        self.assertIn('note/2 all J04  09:00  4.8 m', text)
         self.assertIn('note/3 all Top 5 Low Tides (daylight)', text)
-        self.assertIn('note/3 all  1  13:00  0.2 m', text)
+        self.assertIn('note/3 all J01  13:00  0.2 m', text)
 
     def test_empty_tables_show_fallback(self):
         import os, tempfile, get_tides

--- a/app/test_tide_extremes.py
+++ b/app/test_tide_extremes.py
@@ -12,7 +12,7 @@ CSV = (
     "Date Time,Prediction,Type\n"
     "2026-06-01 07:00,4.6,H\n"
     "2026-06-01 13:00,0.2,L\n"
-    "2026-06-02 23:30,0.1,L\n"
+    "2026-06-02 23:30,0.1,L\n"   # night low — excluded by the daylight window
     "2026-06-03 08:00,4.4,H\n"
     "2026-06-03 14:00,0.5,L\n"
     "2026-06-04 09:00,4.8,H\n"
@@ -20,14 +20,15 @@ CSV = (
 
 
 class TopExtremeTidesTest(unittest.TestCase):
-    def test_highs_highest_first(self):
-        highs, _ = tide_extremes.top_extreme_tides(CSV, 1, 1, 'X', 2026, 6, n=5, window_fn=_day_window)
-        self.assertEqual([h['height'] for h in highs], [4.8, 4.6, 4.4])
+    def test_highs_selected_by_elevation_displayed_by_date(self):
+        # n=2: pick the 2 HIGHEST (4.8, 4.6 — drops 4.4), but DISPLAY by date.
+        highs, _ = tide_extremes.top_extreme_tides(CSV, 1, 1, 'X', 2026, 6, n=2, window_fn=_day_window)
+        self.assertEqual([(h['day'], h['height']) for h in highs], [(1, 4.6), (4, 4.8)])
 
-    def test_lows_lowest_first_and_excludes_night(self):
+    def test_lows_displayed_by_date_and_excludes_night(self):
         _, lows = tide_extremes.top_extreme_tides(CSV, 1, 1, 'X', 2026, 6, n=5, window_fn=_day_window)
-        self.assertEqual([l['height'] for l in lows], [0.2, 0.5])
-        self.assertEqual(lows[0], {'day': 1, 'time': '13:00', 'height': 0.2})
+        # 0.1 at 23:30 excluded (night); remaining daylight lows in DATE order
+        self.assertEqual([(l['day'], l['height']) for l in lows], [(1, 0.2), (3, 0.5)])
 
     def test_n_limits_count(self):
         highs, _ = tide_extremes.top_extreme_tides(CSV, 1, 1, 'X', 2026, 6, n=2, window_fn=_day_window)
@@ -36,28 +37,36 @@ class TopExtremeTidesTest(unittest.TestCase):
     def test_all_window_keeps_night(self):
         _, lows = tide_extremes.top_extreme_tides(CSV, 1, 1, 'X', 2026, 6, n=5,
                                                   window_fn=lambda *a: 'all')
-        self.assertEqual(lows[0]['height'], 0.1)
+        self.assertIn(0.1, [l['height'] for l in lows])  # night low now eligible
 
     def test_none_window_excludes_all(self):
         highs, lows = tide_extremes.top_extreme_tides(CSV, 1, 1, 'X', 2026, 6, n=5,
                                                       window_fn=lambda *a: None)
         self.assertEqual((highs, lows), ([], []))
 
-    def test_lows_with_negative_heights_most_negative_first(self):
+    def test_lows_select_most_negative_then_date_order(self):
+        # 4 lows; n=3 must drop the +0.5 (least extreme) and keep the 3 most
+        # negative, displayed in DATE order.
         csv = ("Date Time,Prediction,Type\n"
                "2026-06-01 10:00,-0.2,L\n"
                "2026-06-02 11:00,-1.8,L\n"
-               "2026-06-03 12:00,-1.5,L\n")
-        _, lows = tide_extremes.top_extreme_tides(csv, 1, 1, 'X', 2026, 6, n=5, window_fn=_day_window)
-        self.assertEqual([l['height'] for l in lows], [-1.8, -1.5, -0.2])
+               "2026-06-03 12:00,-1.5,L\n"
+               "2026-06-04 12:00,0.5,L\n")
+        _, lows = tide_extremes.top_extreme_tides(csv, 1, 1, 'X', 2026, 6, n=3, window_fn=_day_window)
+        self.assertEqual([(l['day'], l['height']) for l in lows],
+                         [(1, -0.2), (2, -1.8), (3, -1.5)])
 
-    def test_format_rows(self):
-        rows = tide_extremes.format_extreme_rows([{'day': 6, 'time': '13:30', 'height': 4.6}])
-        self.assertEqual(rows, [' 6  13:30  4.6 m'])
+    def test_format_rows_with_month_letter(self):
+        rows = tide_extremes.format_extreme_rows([{'day': 6, 'time': '13:30', 'height': 4.6}], 6)
+        self.assertEqual(rows, ['J06  13:30  4.6 m'])
 
     def test_format_negative_height(self):
-        rows = tide_extremes.format_extreme_rows([{'day': 13, 'time': '11:08', 'height': -1.2}])
-        self.assertEqual(rows, ['13  11:08  -1.2 m'])
+        rows = tide_extremes.format_extreme_rows([{'day': 13, 'time': '11:08', 'height': -1.2}], 6)
+        self.assertEqual(rows, ['J13  11:08  -1.2 m'])
+
+    def test_format_no_month_omits_letter(self):
+        rows = tide_extremes.format_extreme_rows([{'day': 6, 'time': '13:30', 'height': 4.6}])
+        self.assertEqual(rows, ['06  13:30  4.6 m'])
 
 
 if __name__ == '__main__':

--- a/app/tide_extremes.py
+++ b/app/tide_extremes.py
@@ -23,8 +23,13 @@ def _in_window(event_dt, window):
 
 
 def top_extreme_tides(local_csv, lat, lng, iana_tz, year, month, n=5, window_fn=_default_window):
-    """Return (highs, lows): lists of {'day','time','height'} for the top-n
-    daylight high tides (highest-first) and low tides (lowest-first)."""
+    """Return (highs, lows): lists of {'day','time','height'}.
+
+    Selection is by extremity (the n highest daylight high tides and the n lowest
+    daylight low tides), but the returned lists are ordered by **date** (day
+    ascending) for display — easier to scan/plan on a calendar, and extreme tides
+    cluster around spring tides so the dates usually form a tidy consecutive run.
+    Heights remain in each row so the ranking is still visible."""
     highs, lows = [], []
     window_cache = {}
     for line in local_csv.splitlines()[1:]:
@@ -52,15 +57,24 @@ def top_extreme_tides(local_csv, lat, lng, iana_tz, year, month, n=5, window_fn=
         elif ttype == 'L':
             lows.append(entry)
 
+    # Rank by extremity (highs descending, lows ascending), take the top n...
     highs.sort(key=lambda e: (-e['height'], e['_dt']))
     lows.sort(key=lambda e: (e['height'], e['_dt']))
 
-    def _clean(rows):
-        return [{'day': e['day'], 'time': e['time'], 'height': e['height']} for e in rows[:n]]
+    def _select(rows):
+        # ...then display the selected n in date order.
+        chosen = sorted(rows[:n], key=lambda e: e['_dt'])
+        return [{'day': e['day'], 'time': e['time'], 'height': e['height']} for e in chosen]
 
-    return _clean(highs), _clean(lows)
+    return _select(highs), _select(lows)
 
 
-def format_extreme_rows(entries):
-    """Render entries as ASCII pcal note rows: 'DD  HH:MM  X.X m' (day right-aligned)."""
-    return [f"{e['day']:>2}  {e['time']}  {e['height']:.1f} m" for e in entries]
+def format_extreme_rows(entries, month=None):
+    """Render entries as ASCII pcal note rows: 'Mdd  HH:MM  X.X m'.
+
+    The day is prefixed with the month's first letter (e.g. June 14 -> 'J14') so a
+    date can't be mistaken for the numeric tide height. `month` is 1-12; when None
+    the letter is omitted."""
+    import calendar as _calendar
+    letter = _calendar.month_abbr[month][0] if month else ''
+    return [f"{letter}{e['day']:02d}  {e['time']}  {e['height']:.1f} m" for e in entries]


### PR DESCRIPTION
Refines the #96 tables per feedback:

- **Hybrid ordering**: still *select* the top 5 by elevation (highest highs / lowest lows), but *display* them in **date order**. Easier to scan/plan, and because extreme tides cluster around spring tides the dates usually form a tidy consecutive run (e.g. July highs read J13→J17). Heights stay in each row so extremity is still visible.
- **Month-letter date prefix**: each day is prefixed with the month's first letter, e.g. `J14`, so a date can't be mistaken for the numeric tide height.

Example (Point Roberts, July 2026):
```
Top 5 High Tides (daylight)     Top 5 Low Tides (daylight)
J13 19:19 3.3 m                 J12 10:17 -1.0 m
J14 19:57 3.4 m                 J13 11:08 -1.2 m
J15 20:33 3.4 m                 J14 11:57 -1.2 m
J16 21:07 3.4 m                 J15 12:45 -1.0 m
J17 21:39 3.3 m                 J16 13:30 -0.8 m
```

130 unit tests pass (updated to assert date-ordered selection + `J##` format). Verified by rendering a real PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)