### PR TITLE
Handle upstream tide-service outages: clear message + raw-data cache

### DIFF
--- a/app/calendar_service.py
+++ b/app/calendar_service.py
@@ -17,10 +17,12 @@ try:
     from app.database import get_station_info, log_station_lookup, log_usage_event
     from app.get_tides import (CalendarGenerationError, TideDataError,
                                generate_calendar)
+    from app.tide_adapters import TideServiceUnavailableError
 except ImportError:
     from database import get_station_info, log_station_lookup, log_usage_event
     from get_tides import (CalendarGenerationError, TideDataError,
                            generate_calendar)
+    from tide_adapters import TideServiceUnavailableError
 
 # Default to app/calendars for local dev, override with PDF_OUTPUT_DIR env var
 # for production
@@ -88,7 +90,8 @@ class GenerateResult:
     download_name: str = None
     place_name: str = None
     location_display: str = None
-    # 'junk_station_id' | 'unknown_station' | 'no_predictions' | 'generation_failed'
+    # 'junk_station_id' | 'unknown_station' | 'no_predictions'
+    #   | 'upstream_unavailable' | 'generation_failed'
     error_code: str = None
 
 
@@ -138,6 +141,15 @@ def get_or_generate_pdf(station_id, year, month, source='web', unit='imperial'):
     logging.info(f"Generating new PDF for station {station_id}, {year}-{month:02d} (source={source})")
     try:
         generate_calendar(station_id, year, month, pdf_path, location_name=location_display, unit=unit)
+    except TideServiceUnavailableError as e:
+        # Upstream API outage (gateway 5xx/timeout/network) — distinct from a
+        # station genuinely having no predictions, so the user gets a "try again
+        # later" message instead of "pick a different station", and analytics can
+        # tell an upstream outage apart from real no-data.
+        logging.error(f"Tide service unavailable for station {station_id} {year}-{month:02d}: {e}")
+        log_usage_event(station_id, place_name, year, month, 'error', 'upstream_unavailable', source=source)
+        return GenerateResult(ok=False, error_code='upstream_unavailable',
+                              place_name=place_name, location_display=location_display)
     except TideDataError as e:
         logging.error(f"No tide data for station {station_id} {year}-{month:02d}: {e}")
         log_usage_event(station_id, place_name, year, month, 'error', 'no_predictions', source=source)
@@ -157,36 +169,59 @@ def get_or_generate_pdf(station_id, year, month, source='web', unit='imperial'):
                           place_name=place_name, location_display=location_display)
 
 
+def _sweep_previous_month_files(pattern, suffix_re, current_year, current_month, label):
+    """Delete files matching `pattern` whose `_YYYY_MM` stamp is before the
+    current month. `suffix_re` matches the trailing date+extension. Returns the
+    count deleted. Shared by the PDF and raw-data caches."""
+    deleted = 0
+    for path in glob.glob(pattern):
+        try:
+            match = re.search(suffix_re, path)
+            if not match:
+                continue
+            year, month = int(match.group(1)), int(match.group(2))
+            if year < current_year or (year == current_year and month < current_month):
+                os.remove(path)
+                deleted += 1
+                logging.info(f"Cleaned up old {label}: {path} ({year}-{month:02d})")
+        except (OSError, ValueError) as e:
+            logging.warning(f"Could not process {label} {path}: {e}")
+    return deleted
+
+
 def cleanup_previous_month_pdfs(directory=None):
-    """Delete cached PDFs from previous months. Called once at startup."""
+    """Delete cached PDFs and raw tide-data files from previous months.
+
+    Called once at startup. The raw-data cache lives in the RAW_CACHE_SUBDIR
+    under the same directory; both are swept on the same month boundary so the
+    persistent volume doesn't accumulate stale months.
+    """
     directory = directory or PDF_OUTPUT_DIR
     try:
         today = datetime.now()
         current_year = today.year
         current_month = today.month
 
-        pdf_pattern = os.path.join(directory, "tide_calendar_*.pdf")
-        deleted_count = 0
+        # Pattern: tide_calendar_<location>_<YYYY>_<MM>[_<unit>].pdf
+        # The optional _ft/_m unit token was added with the unit toggle; cleanup
+        # must still match those so old-month PDFs are swept.
+        deleted_count = _sweep_previous_month_files(
+            os.path.join(directory, "tide_calendar_*.pdf"),
+            r'_(\d{4})_(\d{2})(?:_(?:ft|m))?\.pdf$',
+            current_year, current_month, "PDF")
 
-        for pdf_file in glob.glob(pdf_pattern):
-            try:
-                # Pattern: tide_calendar_<location>_<YYYY>_<MM>[_<unit>].pdf
-                # The optional _ft/_m unit token was added with the unit toggle;
-                # cleanup must still match those so old-month PDFs are swept.
-                match = re.search(r'_(\d{4})_(\d{2})(?:_(?:ft|m))?\.pdf$', pdf_file)
-                if match:
-                    pdf_year = int(match.group(1))
-                    pdf_month = int(match.group(2))
-
-                    if pdf_year < current_year or (pdf_year == current_year and pdf_month < current_month):
-                        os.remove(pdf_file)
-                        deleted_count += 1
-                        logging.info(f"Cleaned up old PDF: {pdf_file} ({pdf_year}-{pdf_month:02d})")
-            except (OSError, ValueError) as e:
-                logging.warning(f"Could not process PDF {pdf_file}: {e}")
+        # Raw data cache: <dir>/rawdata/tidedata_<station>_<YYYY>_<MM>.csv
+        try:
+            from app.get_tides import RAW_CACHE_SUBDIR
+        except ImportError:
+            from get_tides import RAW_CACHE_SUBDIR
+        deleted_count += _sweep_previous_month_files(
+            os.path.join(directory, RAW_CACHE_SUBDIR, "tidedata_*.csv"),
+            r'_(\d{4})_(\d{2})\.csv$',
+            current_year, current_month, "tide data")
 
         if deleted_count > 0:
-            logging.info(f"Cleaned up {deleted_count} PDF(s) from previous months")
+            logging.info(f"Cleaned up {deleted_count} cached file(s) from previous months")
 
     except Exception as e:
-        logging.error(f"Error during previous month PDF cleanup: {e}")
+        logging.error(f"Error during previous month cache cleanup: {e}")

--- a/app/database.py
+++ b/app/database.py
@@ -242,13 +242,19 @@ def _import_us_csv(csv_path):
         with sqlite3.connect(DB_PATH) as conn:
             cursor = conn.cursor()
 
-            MIN_STATION_THRESHOLD = 100
-            result = cursor.execute(
-                'SELECT COUNT(*) FROM tide_station_ids WHERE place_name IS NOT NULL').fetchone()
-            if result[0] >= MIN_STATION_THRESHOLD:
-                logging.debug(f"Station place names already populated (count: {result[0]})")
-                return True
-
+            # No "already populated, skip" short-circuit on purpose. This importer
+            # is the only path that re-applies the canonical CSV's authoritative
+            # metadata (api_source, country, coordinates, timezone, place_name) to
+            # US rows, and it must keep doing so on a *warm* DB so that drifted
+            # rows self-heal. Production runs on a persistent-volume DB that
+            # survives restarts; if a US row's api_source ever drifts away from
+            # 'NOAA' it routes the station to the wrong adapter and every
+            # generation fails with "no_predictions" (e.g. Point Roberts 9449639),
+            # while dev — which rebuilds the DB from the CSV on every cold start —
+            # stays correct. The upsert below is idempotent and cheap (~2100 rows
+            # in one transaction), and never touches lookup_count, so re-syncing
+            # every startup is safe. Previously a `COUNT(place_name) >= 100`
+            # guard returned early here, which is exactly what blocked the heal.
             imported_count = 0
             csv_station_ids = set()
             with open(csv_path, 'r', encoding='utf-8') as csvfile:

--- a/app/get_tides.py
+++ b/app/get_tides.py
@@ -15,10 +15,10 @@ from datetime import datetime
 
 try:
     from app.database import log_station_lookup, get_station_info
-    from app.tide_adapters import get_adapter_for_station
+    from app.tide_adapters import get_adapter_for_station, TideServiceUnavailableError
 except ImportError:
     from database import log_station_lookup, get_station_info
-    from tide_adapters import get_adapter_for_station
+    from tide_adapters import get_adapter_for_station, TideServiceUnavailableError
 
 try:
     from app.sun_times import sun_times_for_month, format_sun_line, localize_and_filter_csv
@@ -79,6 +79,76 @@ def download_tide_data(station_id, year, month):
     if "No Predictions data was found." in lines[1]:
         raise TideDataError(
             f"No predictions data found for station {station_id} in {year}-{month:02d}")
+
+    return csv_data
+
+
+# Raw tide-data cache. Predictions for a given (station, year, month) are
+# unit-independent (the unit only affects display in convert_tide_data_to_pcal),
+# so caching the standardized CSV here lets the second unit's PDF render without
+# a second upstream call, and lets any later request survive an upstream outage
+# once the data has been fetched at least once. Lives under the same persistent
+# PDF cache dir so production's /data volume retains it across restarts.
+RAW_CACHE_SUBDIR = 'rawdata'
+
+
+def _raw_cache_dir():
+    # Imported lazily to avoid a circular import (calendar_service imports us).
+    try:
+        from app.calendar_service import PDF_OUTPUT_DIR
+    except ImportError:
+        from calendar_service import PDF_OUTPUT_DIR
+    return os.path.join(PDF_OUTPUT_DIR, RAW_CACHE_SUBDIR)
+
+
+def raw_cache_path_for(station_id, year, month):
+    return os.path.join(_raw_cache_dir(), f"tidedata_{station_id}_{year}_{month:02d}.csv")
+
+
+def _valid_cached_csv(csv_data):
+    """Cheap sanity check mirroring download_tide_data's acceptance criteria so a
+    truncated/garbage cache file is ignored rather than served."""
+    if not csv_data:
+        return False
+    lines = csv_data.splitlines()
+    return len(lines) >= 2 and "No Predictions data was found." not in lines[1]
+
+
+def get_tide_data(station_id, year, month):
+    """Standardized tide CSV, served from the raw-data disk cache when present,
+    else fetched live (download_tide_data) and cached on success.
+
+    The cache is what makes a cache-missed PDF resilient to an upstream outage:
+    on a cache hit we never touch the API, so TideServiceUnavailableError /
+    TideDataError can only surface on a *cold* miss that also fails live — which
+    then propagates unchanged to the caller.
+    """
+    cache_path = raw_cache_path_for(station_id, year, month)
+    try:
+        if os.path.exists(cache_path) and os.path.getsize(cache_path) > 0:
+            with open(cache_path, 'r', encoding='utf-8') as fh:
+                cached = fh.read()
+            if _valid_cached_csv(cached):
+                logging.info(f"Using cached tide data: {cache_path}")
+                return cached
+            logging.warning(f"Ignoring invalid cached tide data: {cache_path}")
+    except OSError as e:
+        logging.warning(f"Could not read cached tide data {cache_path}: {e}")
+
+    # Cold miss: fetch live. May raise TideDataError (no data) or
+    # TideServiceUnavailableError (upstream outage) — both propagate.
+    csv_data = download_tide_data(station_id, year, month)
+
+    # Persist atomically so a concurrent reader never sees a partial file.
+    try:
+        os.makedirs(os.path.dirname(cache_path) or '.', exist_ok=True)
+        tmp = f"{cache_path}.tmp.{os.getpid()}.{threading.get_ident()}"
+        with open(tmp, 'w', encoding='utf-8') as fh:
+            fh.write(csv_data)
+        os.replace(tmp, cache_path)
+        logging.info(f"Cached tide data: {cache_path}")
+    except OSError as e:
+        logging.warning(f"Could not write tide data cache {cache_path}: {e}")
 
     return csv_data
 
@@ -227,7 +297,7 @@ def generate_calendar(station_id, year, month, output_path, location_name=None, 
             "CHS station %s has no timezone; tide times will render in UTC and "
             "no sunrise/sunset line will be shown", station_id)
 
-    csv_data = download_tide_data(station_id, year, month)
+    csv_data = get_tide_data(station_id, year, month)
     # CHS times are UTC -> convert to the station's local zone and trim to the
     # local month (NOAA passes through unchanged).
     csv_data = localize_and_filter_csv(csv_data, api_source, iana_tz, year, month)
@@ -305,6 +375,9 @@ def main():
     try:
         generate_calendar(args.station_id, args.year, args.month, output_path,
                           location_name=args.location_name, unit=args.unit)
+    except TideServiceUnavailableError as e:
+        logging.error(f"Upstream tide service unavailable: {e}")
+        raise SystemExit(2)
     except (TideDataError, CalendarGenerationError) as e:
         logging.error(f"Could not generate calendar: {e}")
         raise SystemExit(1)

--- a/app/routes.py
+++ b/app/routes.py
@@ -44,6 +44,21 @@ def _no_predictions_message(where, year, month):
     )
 
 
+def _service_unavailable_message(where, year, month):
+    """Shown when the upstream prediction service is unreachable (an outage),
+    as opposed to the station simply having no data. Tells the user it's a
+    temporary upstream problem and not to bother changing station — so they
+    don't retry pointlessly against a service that's down.
+    """
+    return (
+        f"The tide prediction service (NOAA for US stations, CHS for Canadian) "
+        f"appears to be temporarily unavailable, so we couldn't retrieve the "
+        f"predictions for {where} for {year}-{month:02d}. This is an outage on "
+        f"the upstream service, not a problem with this station — please come "
+        f"back and try again in a few hours."
+    )
+
+
 @app.route('/', methods=['GET', 'POST'])
 @limiter.limit("10 per minute", methods=["POST"])
 def index():
@@ -96,6 +111,9 @@ def index():
             if result.error_code in ('unknown_station', 'junk_station_id'):
                 message = (f"Station ID '{station_id}' was not found. "
                            f"Please select a tide station from the autocomplete dropdown.")
+            elif result.error_code == 'upstream_unavailable':
+                message = _service_unavailable_message(
+                    result.location_display or station_id, year, month)
             else:
                 message = _no_predictions_message(
                     result.location_display or station_id, year, month)
@@ -204,6 +222,11 @@ def api_generate_quick():
                 return jsonify({'error': f"Invalid station_id '{station_id}'"}), 400
             if result.error_code == 'unknown_station':
                 return jsonify({'error': f"Unknown station_id '{station_id}'"}), 404
+            if result.error_code == 'upstream_unavailable':
+                # 503 Service Unavailable: the upstream prediction API is down,
+                # not a client error — signals the caller to retry later.
+                return jsonify({'error': _service_unavailable_message(
+                    result.location_display or station_id, today.year, today.month)}), 503
             return jsonify({'error': _no_predictions_message(
                 result.location_display or station_id, today.year, today.month)}), 500
 

--- a/app/test_tide_service_resilience.py
+++ b/app/test_tide_service_resilience.py
@@ -65,6 +65,35 @@ class TestAdapterOutageSignal(unittest.TestCase):
         with self.assertRaises(TideServiceUnavailableError):
             CHSAdapter().get_predictions(uuid, 2026, 8)
 
+    @patch('tide_adapters.requests.get')
+    def test_chs_numeric_code_lookup_outage_raises_unavailable(self, mock_get):
+        # Numeric codes (the common Canadian case) must resolve a UUID first; if
+        # that lookup endpoint is in outage, the outage must propagate — not
+        # degrade to a misleading "no predictions".
+        mock_get.return_value = Mock(status_code=504, text='gateway timeout')
+        with self.assertRaises(TideServiceUnavailableError):
+            CHSAdapter().get_predictions('07735', 2026, 8)
+
+    @patch('tide_adapters.requests.get')
+    def test_chs_numeric_code_genuinely_not_found_returns_none(self, mock_get):
+        # A definitive 200-with-empty-list (or 404) is "not found", not an outage.
+        mock_get.return_value = Mock(status_code=200, text='[]')
+        self.assertIsNone(CHSAdapter().get_predictions('07735', 2026, 8))
+
+    @patch('time.sleep', lambda *a, **k: None)
+    @patch('tide_adapters.requests.get')
+    def test_chs_definitive_answer_beats_transient_blip(self, mock_get):
+        # Endpoint 1 gives a definitive 404; endpoint 2 (mirror) times out. The
+        # definitive answer must win -> return None (no data), not raise outage.
+        mock_get.side_effect = [
+            Mock(status_code=404, text='not found'),          # endpoint 1: definitive
+            requests.exceptions.Timeout("blip"),               # endpoint 2: attempt 1
+            requests.exceptions.Timeout("blip"),               # endpoint 2: attempt 2
+            requests.exceptions.Timeout("blip"),               # endpoint 2: attempt 3
+        ]
+        uuid = '5cebf1df3d0f4a073c4bb9a8x'
+        self.assertIsNone(CHSAdapter().get_predictions(uuid, 2026, 8))
+
 
 class TestRawDataCache(unittest.TestCase):
     def setUp(self):

--- a/app/test_tide_service_resilience.py
+++ b/app/test_tide_service_resilience.py
@@ -1,0 +1,120 @@
+"""
+Tests for upstream-outage handling and the raw tide-data cache.
+
+Two behaviours, both motivated by a real NOAA `datagetter` outage (all requests
+returning 504) that surfaced on production as a generic "no predictions" error:
+
+1. Adapters distinguish an *upstream outage* (gateway 5xx / timeout / network,
+   after retries) from a station genuinely having *no data*. The former raises
+   TideServiceUnavailableError; the latter returns None.
+
+2. get_tide_data caches the (unit-independent) standardized CSV per
+   (station, year, month), so a cache hit never touches the API — making a
+   cache-missed PDF resilient to an outage once the data has been fetched once.
+
+Run from the app/ directory:
+    python -m unittest test_tide_service_resilience
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import requests
+
+import get_tides
+from tide_adapters import NOAAAdapter, CHSAdapter, TideServiceUnavailableError
+
+VALID_CSV = "Date Time,Prediction,Type\n2026-08-01 02:42,0.605,H\n2026-08-01 09:10,2.1,L"
+
+
+class TestAdapterOutageSignal(unittest.TestCase):
+    @patch('time.sleep', lambda *a, **k: None)  # don't actually back off
+    @patch('tide_adapters.requests.get')
+    def test_noaa_persistent_504_raises_unavailable(self, mock_get):
+        resp = Mock(status_code=504, text='<html>504 Gateway Time-out</html>')
+        mock_get.return_value = resp
+        with self.assertRaises(TideServiceUnavailableError):
+            NOAAAdapter().get_predictions('9449639', 2026, 8)
+        self.assertEqual(mock_get.call_count, 3)  # all retries exhausted
+
+    @patch('time.sleep', lambda *a, **k: None)
+    @patch('tide_adapters.requests.get')
+    def test_noaa_timeout_raises_unavailable(self, mock_get):
+        mock_get.side_effect = requests.exceptions.Timeout("timed out")
+        with self.assertRaises(TideServiceUnavailableError):
+            NOAAAdapter().get_predictions('9449639', 2026, 8)
+
+    @patch('tide_adapters.requests.get')
+    def test_noaa_404_is_not_an_outage(self, mock_get):
+        # A definitive non-gateway HTTP error means "no usable data", not an
+        # outage — must return None, never raise.
+        mock_get.return_value = Mock(status_code=404, text='not found')
+        self.assertIsNone(NOAAAdapter().get_predictions('9449639', 2026, 8))
+
+    @patch('time.sleep', lambda *a, **k: None)
+    @patch('tide_adapters.requests.get')
+    def test_chs_all_endpoints_504_raises_unavailable(self, mock_get):
+        # UUID station id skips the code->UUID lookup and goes straight to /data.
+        mock_get.return_value = Mock(status_code=504, text='gateway timeout')
+        uuid = '5cebf1df3d0f4a073c4bb9a8x'
+        with self.assertRaises(TideServiceUnavailableError):
+            CHSAdapter().get_predictions(uuid, 2026, 8)
+
+
+class TestRawDataCache(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self._patch = patch.object(get_tides, '_raw_cache_dir', lambda: self.dir)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_caches_after_first_fetch(self):
+        calls = []
+
+        def fake_download(sid, y, m):
+            calls.append((sid, y, m))
+            return VALID_CSV
+
+        with patch.object(get_tides, 'download_tide_data', side_effect=fake_download):
+            a = get_tides.get_tide_data('9449639', 2026, 8)
+            b = get_tides.get_tide_data('9449639', 2026, 8)
+        self.assertEqual(a, VALID_CSV)
+        self.assertEqual(b, VALID_CSV)
+        self.assertEqual(len(calls), 1, "second call must hit the cache, not the API")
+        self.assertTrue(os.path.exists(get_tides.raw_cache_path_for('9449639', 2026, 8)))
+
+    def test_cache_hit_survives_upstream_outage(self):
+        # Warm the cache, then make every live fetch fail as if NOAA is down.
+        with patch.object(get_tides, 'download_tide_data', return_value=VALID_CSV):
+            get_tides.get_tide_data('9449639', 2026, 8)
+
+        def outage(*a, **k):
+            raise TideServiceUnavailableError("NOAA 504")
+
+        with patch.object(get_tides, 'download_tide_data', side_effect=outage):
+            # Same (cached) month: served from disk despite the outage.
+            self.assertEqual(get_tides.get_tide_data('9449639', 2026, 8), VALID_CSV)
+            # A cold month still propagates the outage.
+            with self.assertRaises(TideServiceUnavailableError):
+                get_tides.get_tide_data('9449639', 2026, 9)
+
+    def test_invalid_cache_file_is_ignored_and_refetched(self):
+        # A truncated/garbage cache file must not be served.
+        path = get_tides.raw_cache_path_for('9449639', 2026, 8)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w') as fh:
+            fh.write("garbage-no-newline")
+        with patch.object(get_tides, 'download_tide_data', return_value=VALID_CSV) as dl:
+            self.assertEqual(get_tides.get_tide_data('9449639', 2026, 8), VALID_CSV)
+            dl.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test_us_station_resync.py
+++ b/app/test_us_station_resync.py
@@ -1,0 +1,101 @@
+"""
+Regression test for warm-DB self-healing of US station metadata.
+
+Background: production runs on a persistent-volume SQLite DB that survives
+container restarts. If a US station row's metadata drifts away from the
+canonical CSV (most damagingly `api_source`, which selects the API adapter),
+the station routes to the wrong adapter and every calendar generation fails
+with "no_predictions" — even though the upstream API has the data. Dev never
+shows this because its DB is rebuilt from the CSV on every cold start.
+
+`import_stations_from_csv()` is the only path that re-applies the CSV's
+authoritative metadata to US rows, so it must run (not short-circuit) on a
+warm DB. These tests lock in that self-healing behavior.
+
+Run from the app/ directory:
+    python -m unittest test_us_station_resync
+"""
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+POINT_ROBERTS = "9449639"  # NOAA station, US demo/default station
+
+
+def fresh_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    os.environ["DB_PATH"] = path
+    if "database" in sys.modules:
+        del sys.modules["database"]
+    import database
+
+    database.DB_PATH = path  # tests reassign this dynamically
+    database.init_database()
+    return database, path
+
+
+class TestWarmDbSelfHeal(unittest.TestCase):
+    def setUp(self):
+        self.db, self.path = fresh_db()
+        self.assertTrue(self.db.import_stations_from_csv(), "cold CSV import failed")
+
+    def tearDown(self):
+        try:
+            os.remove(self.path)
+        except OSError:
+            pass
+        os.environ.pop("DB_PATH", None)
+
+    def _api_source(self, station_id):
+        info = self.db.get_station_info(station_id)
+        return info["api_source"] if info else None
+
+    def test_cold_import_marks_point_roberts_as_noaa(self):
+        self.assertEqual(self._api_source(POINT_ROBERTS), "NOAA")
+
+    def test_drifted_api_source_self_heals_on_reimport(self):
+        # Simulate a warm-DB row that has drifted (the production failure mode).
+        with sqlite3.connect(self.path) as conn:
+            conn.execute(
+                "UPDATE tide_station_ids SET api_source = 'CHS', country = 'Canada' "
+                "WHERE station_id = ?",
+                (POINT_ROBERTS,),
+            )
+            conn.commit()
+        self.assertEqual(self._api_source(POINT_ROBERTS), "CHS")  # drift present
+
+        # A warm-DB startup re-import must repair it (previously short-circuited).
+        self.assertTrue(self.db.import_stations_from_csv())
+
+        info = self.db.get_station_info(POINT_ROBERTS)
+        self.assertEqual(info["api_source"], "NOAA")
+        self.assertEqual(info["country"], "USA")
+
+    def test_reimport_preserves_lookup_count(self):
+        # Self-healing must not clobber usage counters on existing rows.
+        self.db.log_station_lookup(POINT_ROBERTS)
+        self.db.log_station_lookup(POINT_ROBERTS)
+        with sqlite3.connect(self.path) as conn:
+            before = conn.execute(
+                "SELECT lookup_count FROM tide_station_ids WHERE station_id = ?",
+                (POINT_ROBERTS,),
+            ).fetchone()[0]
+
+        self.assertTrue(self.db.import_stations_from_csv())
+
+        with sqlite3.connect(self.path) as conn:
+            after = conn.execute(
+                "SELECT lookup_count FROM tide_station_ids WHERE station_id = ?",
+                (POINT_ROBERTS,),
+            ).fetchone()[0]
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/tide_adapters.py
+++ b/app/tide_adapters.py
@@ -356,7 +356,14 @@ class CHSAdapter(TideAdapter):
             station_code: Numeric station code (e.g., "07735")
 
         Returns:
-            UUID string if found, None if lookup fails
+            UUID string if found, None if the station genuinely isn't found.
+
+        Raises:
+            TideServiceUnavailableError: if every endpoint failed for a
+            transient/connectivity reason (gateway 5xx / timeout / network).
+            Canadian stations are overwhelmingly looked up by numeric code, so
+            this lookup is on the hot path; without this, a CHS outage here
+            would surface as a misleading "no predictions" instead of an outage.
         """
         import json
 
@@ -364,6 +371,11 @@ class CHSAdapter(TideAdapter):
             'User-Agent': 'TideCalendarSite/1.0 (https://tidecalendar.xyz; contact@tidecalendar.xyz)'
         }
         params = {"code": station_code}
+
+        # Distinguish a transient outage (raise) from a definitive "not found"
+        # (return None), same policy as get_predictions below.
+        transient_failure = False
+        saw_definitive_answer = False
 
         # Try each base URL for station lookup
         for base_url in self.BASE_URLS:
@@ -377,6 +389,8 @@ class CHSAdapter(TideAdapter):
                 )
 
                 if response.status_code == 200:
+                    # A 200 is a definitive answer even if it lists no station.
+                    saw_definitive_answer = True
                     # Parse JSON response
                     stations = json.loads(response.text)
 
@@ -393,22 +407,35 @@ class CHSAdapter(TideAdapter):
 
                     self.logger.info(f"Found UUID {station_uuid} for station code {station_code}")
                     return station_uuid
+                elif response.status_code in [502, 503, 504]:
+                    self.logger.warning(f"Station lookup at {base_url} returned gateway error {response.status_code}")
+                    transient_failure = True
+                    continue
                 else:
+                    # Definitive non-gateway HTTP error (e.g. 404) — not an outage.
                     self.logger.warning(f"Station lookup at {base_url} returned status {response.status_code}")
+                    saw_definitive_answer = True
                     continue
 
             except json.JSONDecodeError as e:
+                # Server responded but the body was unparseable — not a connectivity outage.
                 self.logger.warning(f"Failed to parse station lookup response from {base_url}: {e}")
+                saw_definitive_answer = True
                 continue
             except requests.exceptions.RequestException as e:
                 self.logger.warning(f"Network error during station lookup at {base_url}: {e}")
+                transient_failure = True
                 continue
             except Exception as e:
                 self.logger.warning(f"Unexpected error during station lookup at {base_url}: {e}")
                 continue
 
-        # All endpoints failed
+        # All endpoints failed. Raise only if every failure was transient and no
+        # endpoint gave a definitive answer — otherwise it's a genuine not-found.
         self.logger.error(f"Failed to lookup UUID for station code {station_code} at all endpoints")
+        if transient_failure and not saw_definitive_answer:
+            raise TideServiceUnavailableError(
+                f"CHS station lookup unreachable for code {station_code}")
         return None
 
     def get_predictions(self, station_id: str, year: int, month: int) -> Optional[str]:
@@ -478,11 +505,13 @@ class CHSAdapter(TideAdapter):
         max_retries = 3
         retry_delay = 2  # seconds
 
-        # Track whether the failures we saw were transient/connectivity-related
-        # (gateway 5xx, timeout, network). If every endpoint failed for those
-        # reasons it's an upstream outage (raise), as opposed to a definitive
-        # non-gateway HTTP error which means no usable data (return None).
+        # Distinguish a transient outage from a definitive answer. We raise only
+        # when EVERY endpoint failed for a transient/connectivity reason (gateway
+        # 5xx, timeout, network) AND none returned a definitive non-gateway HTTP
+        # error. A definitive 404 from one endpoint must win over a transient
+        # blip on the mirror, so the user gets "no data" not "outage".
         transient_failure = False
+        saw_definitive_answer = False
 
         # Try each base URL until we get a successful response
         for base_url in self.BASE_URLS:
@@ -518,7 +547,9 @@ class CHSAdapter(TideAdapter):
                     else:
                         self.logger.warning(f"CHS API endpoint {base_url} returned status {response.status_code}, trying next endpoint")
                         self.logger.debug(f"Response: {response.text[:200]}")
-                        # Non-gateway errors don't retry, move to next endpoint
+                        # Non-gateway errors (e.g. 404) are a definitive answer,
+                        # not an outage; don't retry, move to next endpoint.
+                        saw_definitive_answer = True
                         break
 
                 except requests.exceptions.Timeout as e:
@@ -543,7 +574,7 @@ class CHSAdapter(TideAdapter):
 
         # If we get here, all endpoints failed
         self.logger.error(f"All CHS API endpoints failed for station UUID {station_uuid}")
-        if transient_failure:
+        if transient_failure and not saw_definitive_answer:
             raise TideServiceUnavailableError(
                 f"CHS API endpoints all unreachable for station UUID {station_uuid}")
         return None

--- a/app/tide_adapters.py
+++ b/app/tide_adapters.py
@@ -25,6 +25,19 @@ from typing import Optional
 MAX_YEARS_AHEAD = 4
 
 
+class TideServiceUnavailableError(Exception):
+    """The upstream prediction API was unreachable after retries — gateway 5xx
+    (502/503/504), timeout, or a network error.
+
+    Deliberately distinct from "this station has no predictions for the period":
+    an outage is transient and worth retrying later, whereas missing data means
+    the user should pick a different station/month. Adapters raise this (instead
+    of returning None) only when the failure was transient/connectivity-related,
+    so callers can show the right message and analytics can tell an upstream
+    outage apart from a genuine no-data result.
+    """
+
+
 def year_in_range(year: int) -> bool:
     return 2000 <= year <= datetime.now(timezone.utc).year + MAX_YEARS_AHEAD
 
@@ -175,14 +188,15 @@ class NOAAAdapter(TideAdapter):
                     # Parse and validate response
                     return self.parse_response(response.text)
                 elif response.status_code in [502, 503, 504]:
-                    # Gateway errors - retry
+                    # Gateway errors - retry, then signal an upstream outage
                     self.logger.warning(f"NOAA API returned {response.status_code} (gateway error), attempt {attempt + 1}/{max_retries}")
                     if attempt == max_retries - 1:
                         self.logger.error(f"NOAA API request failed after {max_retries} attempts with status {response.status_code}")
-                        return None
+                        raise TideServiceUnavailableError(
+                            f"NOAA API returned {response.status_code} after {max_retries} attempts")
                     continue
                 else:
-                    # Other errors - don't retry
+                    # Other errors (4xx etc.) - not an outage, treat as no data
                     self.logger.error(f"NOAA API request failed with status {response.status_code}")
                     return None
 
@@ -190,14 +204,20 @@ class NOAAAdapter(TideAdapter):
                 self.logger.warning(f"NOAA API timeout on attempt {attempt + 1}/{max_retries}: {e}")
                 if attempt == max_retries - 1:
                     self.logger.error(f"NOAA API request timed out after {max_retries} attempts")
-                    return None
+                    raise TideServiceUnavailableError(
+                        f"NOAA API timed out after {max_retries} attempts") from e
                 continue
             except requests.exceptions.RequestException as e:
                 self.logger.warning(f"NOAA API request error on attempt {attempt + 1}/{max_retries}: {e}")
                 if attempt == max_retries - 1:
                     self.logger.error(f"NOAA API request failed after {max_retries} attempts: {e}")
-                    return None
+                    raise TideServiceUnavailableError(
+                        f"NOAA API connection failed after {max_retries} attempts: {e}") from e
                 continue
+            except TideServiceUnavailableError:
+                # Our own outage signal (raised above) — must not be swallowed by
+                # the broad except below.
+                raise
             except Exception as e:
                 self.logger.error(f"Unexpected error in NOAA API request: {e}")
                 return None
@@ -458,6 +478,12 @@ class CHSAdapter(TideAdapter):
         max_retries = 3
         retry_delay = 2  # seconds
 
+        # Track whether the failures we saw were transient/connectivity-related
+        # (gateway 5xx, timeout, network). If every endpoint failed for those
+        # reasons it's an upstream outage (raise), as opposed to a definitive
+        # non-gateway HTTP error which means no usable data (return None).
+        transient_failure = False
+
         # Try each base URL until we get a successful response
         for base_url in self.BASE_URLS:
             endpoint = f"{base_url}/stations/{station_uuid}/data"
@@ -482,6 +508,7 @@ class CHSAdapter(TideAdapter):
                     elif response.status_code in [502, 503, 504]:
                         # Gateway errors - retry same endpoint
                         self.logger.warning(f"CHS API returned {response.status_code} (gateway error), attempt {attempt + 1}/{max_retries}")
+                        transient_failure = True
                         if attempt < max_retries - 1:
                             continue
                         else:
@@ -496,6 +523,7 @@ class CHSAdapter(TideAdapter):
 
                 except requests.exceptions.Timeout as e:
                     self.logger.warning(f"CHS API timeout on attempt {attempt + 1}/{max_retries}: {e}")
+                    transient_failure = True
                     if attempt < max_retries - 1:
                         continue
                     else:
@@ -503,6 +531,7 @@ class CHSAdapter(TideAdapter):
                         break
                 except requests.exceptions.RequestException as e:
                     self.logger.warning(f"CHS API request error on attempt {attempt + 1}/{max_retries}: {e}")
+                    transient_failure = True
                     if attempt < max_retries - 1:
                         continue
                     else:
@@ -514,6 +543,9 @@ class CHSAdapter(TideAdapter):
 
         # If we get here, all endpoints failed
         self.logger.error(f"All CHS API endpoints failed for station UUID {station_uuid}")
+        if transient_failure:
+            raise TideServiceUnavailableError(
+                f"CHS API endpoints all unreachable for station UUID {station_uuid}")
         return None
 
     def parse_response(self, response_data: str) -> Optional[str]:


### PR DESCRIPTION
## Summary

Debugged the production failure where **Point Roberts, WA (NOAA 9449639)** couldn't generate a calendar for 2026‑08 while dev worked.

**Root cause:** a global **NOAA `datagetter` outage** — every request returned `HTTP 504` (confirmed from both the prod container and an off-host laptop, for all stations/months). Prod surfaced it only because it lacked a cached *imperial* (`_ft`) PDF for that month and had to fetch live; dev served a cached PDF and never called NOAA. The prod DB row for 9449639 was pristine (`NOAA`, correct coords/timezone) — this was never data/code drift.

## Changes

**Distinguish an upstream outage from genuine no-data** (so users aren't told to "pick a different station" during an outage, and don't retry pointlessly):
- `tide_adapters.py`: new `TideServiceUnavailableError`, raised when the API is unreachable after retries (gateway 5xx / timeout / network). Genuine no-data still returns `None`.
- `calendar_service.py`: maps it to `error_code='upstream_unavailable'`, logged as a distinct analytics `error_detail`.
- `routes.py`: web form shows a clear "the tide service is temporarily unavailable, try again in a few hours" message; quick API returns **HTTP 503** instead of 500.

**Raw tide-data cache** (`get_tides.py`): caches the unit-independent standardized CSV per `(station, year, month)` under the persistent PDF cache dir. A cache hit never touches the API, so once a month's data is fetched (for either unit) the second unit renders without another call **and later requests survive an upstream outage**. Old months are swept at startup alongside the PDF cache.

**Warm-DB self-heal hardening** (`database.py`): the US CSV importer no longer short-circuits on a populated DB, so US station metadata re-syncs from the canonical CSV on every startup (defensive — not the cause of this incident).

## Tests
- New `test_tide_service_resilience.py`: adapter outage signal (NOAA 504/timeout, CHS all-endpoints-504), 404-is-not-an-outage, cache (warm reuse, survives outage on a cached month, propagates on a cold miss, ignores corrupt cache file).
- New `test_us_station_resync.py`: drifted warm-DB row self-heals; `lookup_count` preserved.
- Full suite green: 158 unit tests + 6 usage-event tests.

## Deploy notes
No Dockerfile/CapRover changes — modified modules already ship; the raw cache dir is created at runtime under the persistent `/data/calendars`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZAMBxWpKnFR8i8Wzp81HG)_