### PR TITLE
Remove low-tide callout reordering; keep day-number colour highlighting

### DIFF
--- a/app/get_tides.py
+++ b/app/get_tides.py
@@ -38,8 +38,8 @@ except ImportError:
 # Per-invocation timeout for each external tool (pcal, ps2pdf)
 SUBPROCESS_TIMEOUT = 60
 
-# Tides below this height (metres) are marked with an asterisk so pcal
-# colour-codes the day
+# Tides below this height (metres) trigger pcal day-number colour-coding
+# (see convert_tide_data_to_pcal); the tide listing itself stays chronological
 LOW_TIDE_THRESHOLD = 0.3
 
 
@@ -193,6 +193,7 @@ def convert_tide_data_to_pcal(csv_data, pcal_filename, location_name=None, stati
 
         valid_lines = 0
         skipped_lines = 0
+        low_tide_days = set()
 
         # lines[0] is the header
         for line_num, line in enumerate(lines[1:], start=2):
@@ -230,11 +231,12 @@ def convert_tide_data_to_pcal(csv_data, pcal_filename, location_name=None, stati
 
                 tide_type_full = "High" if tide_type == "H" else "Low"
 
-                # Format the date for pcal (mm/dd); asterisk marks low tides
-                # so pcal colour-codes the day
-                pcal_date = f"{int(month)}/{int(day)}"
                 if prediction < LOW_TIDE_THRESHOLD:
-                    pcal_date += "*"
+                    low_tide_days.add(int(day))
+
+                # Format the date for pcal (mm/dd); tide lines are never
+                # starred so pcal keeps them in chronological file order
+                pcal_date = f"{int(month)}/{int(day)}"
 
                 pcal_file.write(f"{pcal_date}  {time} {tide_type_full} {_uconv(prediction, unit):.1f} {_usuf(unit)}\n")
                 valid_lines += 1
@@ -248,6 +250,14 @@ def convert_tide_data_to_pcal(csv_data, pcal_filename, location_name=None, stati
 
         if valid_lines == 0:
             raise TideDataError("No valid tide data found in API response")
+
+        # Text-less marker per low-tide day: pcal colour-codes the day number
+        # for any date with a "*"-flagged entry, but also renders starred
+        # entries before regular ones in that day's cell — starring these
+        # empty markers instead of the tide lines keeps every day's tides in
+        # chronological order while still colouring the day number.
+        for day in sorted(low_tide_days):
+            pcal_file.write(f"{month_num}/{day}*\n")
 
         pcal_file.write("\n")
 

--- a/app/get_tides.py
+++ b/app/get_tides.py
@@ -231,12 +231,12 @@ def convert_tide_data_to_pcal(csv_data, pcal_filename, location_name=None, stati
 
                 tide_type_full = "High" if tide_type == "H" else "Low"
 
-                if prediction < LOW_TIDE_THRESHOLD:
-                    low_tide_days.add(int(day))
-
                 # Format the date for pcal (mm/dd); tide lines are never
                 # starred so pcal keeps them in chronological file order
                 pcal_date = f"{int(month)}/{int(day)}"
+
+                if prediction < LOW_TIDE_THRESHOLD:
+                    low_tide_days.add((int(month), int(day)))
 
                 pcal_file.write(f"{pcal_date}  {time} {tide_type_full} {_uconv(prediction, unit):.1f} {_usuf(unit)}\n")
                 valid_lines += 1
@@ -255,9 +255,11 @@ def convert_tide_data_to_pcal(csv_data, pcal_filename, location_name=None, stati
         # for any date with a "*"-flagged entry, but also renders starred
         # entries before regular ones in that day's cell — starring these
         # empty markers instead of the tide lines keeps every day's tides in
-        # chronological order while still colouring the day number.
-        for day in sorted(low_tide_days):
-            pcal_file.write(f"{month_num}/{day}*\n")
+        # chronological order while still colouring the day number. Keyed by
+        # (month, day), not just day, so this can't mis-colour a same-numbered
+        # day in a different month if the CSV ever spanned a month boundary.
+        for month_of_day, day in sorted(low_tide_days):
+            pcal_file.write(f"{month_of_day}/{day}*\n")
 
         pcal_file.write("\n")
 

--- a/app/test_get_tides_sun.py
+++ b/app/test_get_tides_sun.py
@@ -86,5 +86,52 @@ class PcalExtremeTablesTest(unittest.TestCase):
         self.assertNotIn('note/3', text)
 
 
+class PcalLowTideOrderingTest(unittest.TestCase):
+    """Regression coverage for the removed low-tide "callout" behaviour.
+
+    pcal renders "*"-flagged entries before regular ones within a day's cell,
+    which is how the old code (starring the tide line itself) pulled a
+    below-threshold low tide ahead of earlier same-day events. These tests
+    verify the pcal input file's contract: tide lines are written in
+    chronological (CSV) order and are never starred; only a separate,
+    text-less "mm/dd*" marker line is starred, to colour the day number
+    without affecting pcal's within-day ordering. See get_tides.py
+    LOW_TIDE_THRESHOLD."""
+
+    def test_low_tide_stays_in_chronological_position(self):
+        csv_data = ("Date Time,Prediction,Type\n"
+                     "2026-06-15 09:00,3.0,H\n"
+                     "2026-06-15 21:00,0.1,L")
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'events.txt')
+            get_tides.convert_tide_data_to_pcal(csv_data, path, location_name='T',
+                                                unit='metric')
+            with open(path) as f:
+                text = f.read()
+        self.assertLess(text.index('09:00 High'), text.index('21:00 Low'))
+
+    def test_low_tide_day_gets_text_less_colour_marker(self):
+        csv_data = "Date Time,Prediction,Type\n2026-06-15 21:00,0.1,L"
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'events.txt')
+            get_tides.convert_tide_data_to_pcal(csv_data, path, location_name='T',
+                                                unit='metric')
+            with open(path) as f:
+                text = f.read()
+        self.assertIn('6/15*\n', text)
+        self.assertNotIn('6/15*  21:00', text)
+        self.assertIn('6/15  21:00 Low', text)
+
+    def test_day_without_low_tide_has_no_marker(self):
+        csv_data = "Date Time,Prediction,Type\n2026-06-15 09:00,3.0,H"
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'events.txt')
+            get_tides.convert_tide_data_to_pcal(csv_data, path, location_name='T',
+                                                unit='metric')
+            with open(path) as f:
+                text = f.read()
+        self.assertNotIn('*', text)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/app/test_get_tides_sun.py
+++ b/app/test_get_tides_sun.py
@@ -99,6 +99,13 @@ class PcalLowTideOrderingTest(unittest.TestCase):
     LOW_TIDE_THRESHOLD."""
 
     def test_low_tide_stays_in_chronological_position(self):
+        # NOTE: pcal's own reordering of starred entries happens at render
+        # time, not in this intermediate file, so this only proves the file
+        # itself is written in chronological (CSV) order — it would still
+        # pass against the old, buggy behaviour. The real regression guard
+        # for the "*" placement is test_low_tide_day_gets_text_less_colour_marker
+        # below; the actual rendered pcal cell order was verified manually
+        # (see PR description) since it isn't unit-testable without pcal.
         csv_data = ("Date Time,Prediction,Type\n"
                      "2026-06-15 09:00,3.0,H\n"
                      "2026-06-15 21:00,0.1,L")
@@ -121,6 +128,39 @@ class PcalLowTideOrderingTest(unittest.TestCase):
         self.assertIn('6/15*\n', text)
         self.assertNotIn('6/15*  21:00', text)
         self.assertIn('6/15  21:00 Low', text)
+
+    def test_multiple_low_tide_days_get_sorted_deduped_markers(self):
+        csv_data = ("Date Time,Prediction,Type\n"
+                     "2026-06-20 08:00,0.1,L\n"
+                     "2026-06-20 20:00,0.2,L\n"
+                     "2026-06-15 21:00,0.1,L")
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'events.txt')
+            get_tides.convert_tide_data_to_pcal(csv_data, path, location_name='T',
+                                                unit='metric')
+            with open(path) as f:
+                text = f.read()
+        # day 20 has two below-threshold tides but should get exactly one
+        # marker, and markers should be sorted (15 before 20)
+        self.assertEqual(text.count('6/20*\n'), 1)
+        self.assertIn('6/15*\n', text)
+        self.assertLess(text.index('6/15*'), text.index('6/20*'))
+
+    def test_low_tide_marker_uses_events_own_month(self):
+        # Regression test: markers must be keyed by each event's own
+        # (month, day), not a single CSV-wide month, so a low tide on the
+        # same day-of-month in a different month can't be mis-coloured.
+        csv_data = ("Date Time,Prediction,Type\n"
+                     "2026-08-31 23:50,0.1,L\n"
+                     "2026-09-01 00:20,0.1,L")
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'events.txt')
+            get_tides.convert_tide_data_to_pcal(csv_data, path, location_name='T',
+                                                unit='metric')
+            with open(path) as f:
+                text = f.read()
+        self.assertIn('8/31*\n', text)
+        self.assertIn('9/1*\n', text)
 
     def test_day_without_low_tide_has_no_marker(self):
         csv_data = "Date Time,Prediction,Type\n2026-06-15 09:00,3.0,H"


### PR DESCRIPTION
## Summary
- Removes the "low tide of the day gets pulled to the top of the cell" behaviour: pcal renders `*`-flagged entries before regular ones in a day's cell, and the old code starred the tide event line itself whenever it was below `LOW_TIDE_THRESHOLD` (0.3m), which both coloured the day number **and** reordered that tide ahead of earlier same-day events.
- Keeps the day-number colour highlighting (still driven by the same 0.3m threshold) by emitting a separate, text-less `mm/dd*` marker line instead of starring the tide line — this colours the day without affecting pcal's within-day ordering.
- Net effect: every day's tides now always render in chronological order in the PDF, with no special callout/reordering. This was mostly redundant now that the Top-5 monthly high/low tables (#96) already surface notable lows.

## Verification
- Full unit suite green (164 tests) + `scripts/test_usage_events.py` (6 tests).
- Added `PcalLowTideOrderingTest` in `app/test_get_tides_sun.py` asserting tide lines are never starred and the text-less colour marker is emitted separately.
- Built the Docker image locally and generated a real August 2026 Point Roberts (9449639) calendar via the running container. Cross-checked the container's cached raw tide-data CSV against the rendered PDF: the exact set of days with a prediction < 0.3m matches the blue day-numbers pixel-for-pixel, and every day's tide lines are in ascending time order (e.g. Aug 1: 02:32 → 06:55 → 13:45 → 21:02, with the 13:45 low correctly stayed in position instead of jumping to the top).

## Test plan
- [x] `cd app && python -m unittest discover -p 'test_*.py'`
- [x] `python scripts/test_usage_events.py`
- [x] Docker build + generate real calendar, visually confirm chronological order + colour retained
- [ ] Adversarial multi-model review (Opus + Codex)
- [ ] Verify live on dev.tidecalendar.xyz after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)