### PR TITLE
Resolve most of the #87 audit backlog

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,7 +2,10 @@ name: Playwright Smoke Tests
 
 on:
   push:
-    branches: [ main, development ]
+    # This job smoke-tests *production* (tidecalendar.xyz), so it only makes
+    # sense on pushes that actually deploy there. A development push doesn't
+    # trigger a prod deploy, so it would just re-test the previous deploy.
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   schedule:

--- a/app/database.py
+++ b/app/database.py
@@ -23,6 +23,11 @@ DB_PATH = os.getenv('DB_PATH', DEFAULT_DB_PATH)
 CLIENT_ERROR_DETAILS = ('unknown_station', 'station_not_found', 'no_station',
                         'invalid_input', 'junk_station_id')
 
+# Backstop against unbounded growth on a long-lived container: age-based
+# pruning (365 days) only runs at startup, so a container that never
+# redeploys could still accumulate rows indefinitely within that window.
+USAGE_EVENTS_MAX_ROWS = 100_000
+
 
 def _migrate_columns(cursor, table, columns_ddl):
     """Add any missing columns to a table (idempotent startup migration).
@@ -98,6 +103,19 @@ def init_database():
             ''')
             if cursor.rowcount > 0:
                 logging.info(f"Pruned {cursor.rowcount} usage_events older than 365 days")
+
+            # Age-based pruning alone only runs at startup, so a long-lived
+            # container that never redeploys could still accumulate an
+            # unbounded number of rows within the 365-day window. Cap the
+            # total row count too, keeping the most recent USAGE_EVENTS_MAX_ROWS.
+            cursor.execute('''
+                DELETE FROM usage_events
+                WHERE id NOT IN (
+                    SELECT id FROM usage_events ORDER BY timestamp DESC LIMIT ?
+                )
+            ''', (USAGE_EVENTS_MAX_ROWS,))
+            if cursor.rowcount > 0:
+                logging.info(f"Pruned {cursor.rowcount} usage_events over the {USAGE_EVENTS_MAX_ROWS}-row cap")
 
             conn.commit()
             logging.debug("Database initialized successfully")

--- a/app/routes.py
+++ b/app/routes.py
@@ -121,7 +121,7 @@ def index():
 
         response = make_response(send_file(result.pdf_path, as_attachment=True))
         if result.place_name:
-            response.set_cookie('last_place_name', result.place_name)
+            response.set_cookie('last_place_name', result.place_name, secure=True, samesite='Lax')
         return response
 
     # If GET request, read the last place name from the cookie, if available
@@ -203,7 +203,8 @@ def api_generate_quick():
 
         station_id = data['station_id']
         if not isinstance(station_id, str) or not station_id.strip().isdigit():
-            log_usage_event(str(station_id) or None, None, None, None, 'error', 'invalid_input', source='quick_api')
+            log_usage_event(station_id if isinstance(station_id, str) else None,
+                             None, None, None, 'error', 'invalid_input', source='quick_api')
             return jsonify({'error': 'Invalid station_id (USA: 7 digits, Canada: 5 digits)'}), 400
         station_id = station_id.strip()
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=DM+Serif+Display&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer">
     <script defer data-domain="tidecalendar.xyz" src="https://plausible.mattmanuel.ca/js/script.file-downloads.outbound-links.pageview-props.revenue.tagged-events.js"></script>
     <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4234134774434001"

--- a/app/tide_adapters.py
+++ b/app/tide_adapters.py
@@ -13,6 +13,7 @@ All adapters return tide data in a unified CSV format with columns:
 import logging
 import requests
 import calendar
+import time
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from typing import Optional
@@ -40,6 +41,77 @@ class TideServiceUnavailableError(Exception):
 
 def year_in_range(year: int) -> bool:
     return 2000 <= year <= datetime.now(timezone.utc).year + MAX_YEARS_AHEAD
+
+
+# Identifies this app to upstream APIs (NOAA/CHS) in their request logs.
+# canadian_station_sync.py has its own, deliberately different User-Agent
+# (a distinct startup-sync integration) — not shared with this one.
+USER_AGENT = {
+    'User-Agent': 'TideCalendarSite/1.0 (https://tidecalendar.xyz; contact@tidecalendar.xyz)'
+}
+
+
+def _get_with_retry(url, params, logger, label, max_retries=3, retry_delay=2):
+    """Single-endpoint GET with retry/backoff for gateway errors, timeouts,
+    and network errors. Shared by NOAAAdapter.get_predictions (one endpoint)
+    and CHSAdapter.get_predictions (called once per mirror endpoint).
+
+    A non-gateway HTTP status (e.g. 404) is a definitive answer, not
+    retried. An unexpected (non-requests) exception is logged and treated
+    like a definitive give-up for this endpoint, matching prior behavior.
+
+    Args:
+        label: short string used in log messages (e.g. "NOAA API", "CHS API").
+
+    Returns:
+        (response, transient_failure):
+        - Completed HTTP round trip (success or a definitive non-gateway
+          status): (response, False). Caller checks response.status_code.
+        - Every attempt failed for a transient/connectivity reason (gateway
+          5xx, timeout, network error) or an unexpected exception occurred:
+          (None, True) for transient/connectivity failures, (None, False)
+          for an unexpected exception.
+
+    Callers decide what `transient_failure` means for them: a single-endpoint
+    caller (NOAA) can raise TideServiceUnavailableError immediately; a
+    multi-mirror caller (CHS) should try the next mirror and only raise once
+    every mirror has failed transiently with no definitive answer anywhere.
+    """
+    for attempt in range(max_retries):
+        try:
+            if attempt > 0:
+                logger.info(f"Retry attempt {attempt + 1}/{max_retries} for {label}")
+                time.sleep(retry_delay * attempt)  # Exponential backoff: 0, 2, 4 seconds
+
+            logger.debug(f"Requesting {label}: {url}")
+            response = requests.get(url, params=params, headers=USER_AGENT, timeout=30)
+
+            if response.status_code in (502, 503, 504):
+                logger.warning(f"{label} returned {response.status_code} (gateway error), attempt {attempt + 1}/{max_retries}")
+                if attempt == max_retries - 1:
+                    logger.error(f"{label} request failed after {max_retries} attempts with status {response.status_code}")
+                    return None, True
+                continue
+
+            return response, False
+
+        except requests.exceptions.Timeout as e:
+            logger.warning(f"{label} timeout on attempt {attempt + 1}/{max_retries}: {e}")
+            if attempt == max_retries - 1:
+                logger.error(f"{label} timed out after {max_retries} attempts")
+                return None, True
+            continue
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"{label} request error on attempt {attempt + 1}/{max_retries}: {e}")
+            if attempt == max_retries - 1:
+                logger.error(f"{label} request failed after {max_retries} attempts: {e}")
+                return None, True
+            continue
+        except Exception as e:
+            logger.error(f"Unexpected error requesting {label}: {e}")
+            return None, False
+
+    return None, True
 
 
 class TideAdapter(ABC):
@@ -166,62 +238,20 @@ class NOAAAdapter(TideAdapter):
             "format": "csv",
         }
 
-        # Retry logic for handling transient API failures (504 timeouts, network errors)
-        import time
-        max_retries = 3
-        retry_delay = 2  # seconds
+        self.logger.debug(f"Requesting NOAA data for station {station_id}, {year}-{month:02d}")
+        response, transient_failure = _get_with_retry(
+            self.BASE_URL, params, self.logger, "NOAA API")
 
-        headers = {
-            'User-Agent': 'TideCalendarSite/1.0 (https://tidecalendar.xyz; contact@tidecalendar.xyz)'
-        }
+        if response is not None:
+            if response.status_code == 200:
+                return self.parse_response(response.text)
+            # Non-gateway error (e.g. 404) - not an outage, treat as no data
+            self.logger.error(f"NOAA API request failed with status {response.status_code}")
+            return None
 
-        for attempt in range(max_retries):
-            try:
-                if attempt > 0:
-                    self.logger.info(f"Retry attempt {attempt + 1}/{max_retries} for station {station_id}")
-                    time.sleep(retry_delay * attempt)  # Exponential backoff: 0, 2, 4 seconds
-
-                self.logger.debug(f"Requesting NOAA data for station {station_id}, {year}-{month:02d}")
-                response = requests.get(self.BASE_URL, params=params, headers=headers, timeout=30)
-
-                if response.status_code == 200:
-                    # Parse and validate response
-                    return self.parse_response(response.text)
-                elif response.status_code in [502, 503, 504]:
-                    # Gateway errors - retry, then signal an upstream outage
-                    self.logger.warning(f"NOAA API returned {response.status_code} (gateway error), attempt {attempt + 1}/{max_retries}")
-                    if attempt == max_retries - 1:
-                        self.logger.error(f"NOAA API request failed after {max_retries} attempts with status {response.status_code}")
-                        raise TideServiceUnavailableError(
-                            f"NOAA API returned {response.status_code} after {max_retries} attempts")
-                    continue
-                else:
-                    # Other errors (4xx etc.) - not an outage, treat as no data
-                    self.logger.error(f"NOAA API request failed with status {response.status_code}")
-                    return None
-
-            except requests.exceptions.Timeout as e:
-                self.logger.warning(f"NOAA API timeout on attempt {attempt + 1}/{max_retries}: {e}")
-                if attempt == max_retries - 1:
-                    self.logger.error(f"NOAA API request timed out after {max_retries} attempts")
-                    raise TideServiceUnavailableError(
-                        f"NOAA API timed out after {max_retries} attempts") from e
-                continue
-            except requests.exceptions.RequestException as e:
-                self.logger.warning(f"NOAA API request error on attempt {attempt + 1}/{max_retries}: {e}")
-                if attempt == max_retries - 1:
-                    self.logger.error(f"NOAA API request failed after {max_retries} attempts: {e}")
-                    raise TideServiceUnavailableError(
-                        f"NOAA API connection failed after {max_retries} attempts: {e}") from e
-                continue
-            except TideServiceUnavailableError:
-                # Our own outage signal (raised above) — must not be swallowed by
-                # the broad except below.
-                raise
-            except Exception as e:
-                self.logger.error(f"Unexpected error in NOAA API request: {e}")
-                return None
-
+        if transient_failure:
+            raise TideServiceUnavailableError(
+                f"NOAA API unreachable for station {station_id} after retries")
         return None
 
     def parse_response(self, response_data: str) -> Optional[str]:
@@ -367,9 +397,6 @@ class CHSAdapter(TideAdapter):
         """
         import json
 
-        headers = {
-            'User-Agent': 'TideCalendarSite/1.0 (https://tidecalendar.xyz; contact@tidecalendar.xyz)'
-        }
         params = {"code": station_code}
 
         # Distinguish a transient outage (raise) from a definitive "not found"
@@ -384,7 +411,7 @@ class CHSAdapter(TideAdapter):
                 response = requests.get(
                     f"{base_url}/stations",
                     params=params,
-                    headers=headers,
+                    headers=USER_AGENT,
                     timeout=30
                 )
 
@@ -496,15 +523,6 @@ class CHSAdapter(TideAdapter):
             "to": to_date
         }
 
-        headers = {
-            'User-Agent': 'TideCalendarSite/1.0 (https://tidecalendar.xyz; contact@tidecalendar.xyz)'
-        }
-
-        # Retry logic with exponential backoff for each endpoint
-        import time
-        max_retries = 3
-        retry_delay = 2  # seconds
-
         # Distinguish a transient outage from a definitive answer. We raise only
         # when EVERY endpoint failed for a transient/connectivity reason (gateway
         # 5xx, timeout, network) AND none returned a definitive non-gateway HTTP
@@ -516,61 +534,24 @@ class CHSAdapter(TideAdapter):
         # Try each base URL until we get a successful response
         for base_url in self.BASE_URLS:
             endpoint = f"{base_url}/stations/{station_uuid}/data"
+            self.logger.debug(f"Trying CHS API endpoint: {endpoint}, params: {params}")
 
-            for attempt in range(max_retries):
-                try:
-                    if attempt > 0:
-                        self.logger.info(f"Retry attempt {attempt + 1}/{max_retries} for {base_url}")
-                        time.sleep(retry_delay * attempt)  # Exponential backoff: 0, 2, 4 seconds
+            response, endpoint_transient = _get_with_retry(
+                endpoint, params, self.logger, f"CHS API ({base_url})")
 
-                    self.logger.debug(f"Trying CHS API endpoint: {endpoint}")
-                    self.logger.debug(f"CHS API params: {params}")
-                    response = requests.get(endpoint, params=params, headers=headers, timeout=30)
-
-                    self.logger.debug(f"CHS API response status: {response.status_code}")
-
-                    if response.status_code == 200:
-                        self.logger.info(f"Successfully fetched data from {base_url}")
-                        self.logger.debug(f"CHS API response length: {len(response.text)} characters")
-                        # Parse JSON response
-                        return self.parse_response(response.text)
-                    elif response.status_code in [502, 503, 504]:
-                        # Gateway errors - retry same endpoint
-                        self.logger.warning(f"CHS API returned {response.status_code} (gateway error), attempt {attempt + 1}/{max_retries}")
-                        transient_failure = True
-                        if attempt < max_retries - 1:
-                            continue
-                        else:
-                            # Max retries reached for this endpoint, try next endpoint
-                            self.logger.warning(f"CHS API endpoint {base_url} failed after {max_retries} attempts, trying next endpoint")
-                            break
-                    else:
-                        self.logger.warning(f"CHS API endpoint {base_url} returned status {response.status_code}, trying next endpoint")
-                        self.logger.debug(f"Response: {response.text[:200]}")
-                        # Non-gateway errors (e.g. 404) are a definitive answer,
-                        # not an outage; don't retry, move to next endpoint.
-                        saw_definitive_answer = True
-                        break
-
-                except requests.exceptions.Timeout as e:
-                    self.logger.warning(f"CHS API timeout on attempt {attempt + 1}/{max_retries}: {e}")
-                    transient_failure = True
-                    if attempt < max_retries - 1:
-                        continue
-                    else:
-                        self.logger.warning(f"CHS API endpoint {base_url} timed out after {max_retries} attempts, trying next endpoint")
-                        break
-                except requests.exceptions.RequestException as e:
-                    self.logger.warning(f"CHS API request error on attempt {attempt + 1}/{max_retries}: {e}")
-                    transient_failure = True
-                    if attempt < max_retries - 1:
-                        continue
-                    else:
-                        self.logger.warning(f"CHS API endpoint {base_url} failed after {max_retries} attempts, trying next endpoint")
-                        break
-                except Exception as e:
-                    self.logger.warning(f"Unexpected error with {base_url}: {e}, trying next endpoint")
-                    break
+            if response is not None and response.status_code == 200:
+                self.logger.info(f"Successfully fetched data from {base_url}")
+                return self.parse_response(response.text)
+            elif response is not None:
+                # Non-gateway error (e.g. 404) is a definitive answer, not an
+                # outage; don't retry, move to the next mirror.
+                self.logger.warning(f"CHS API endpoint {base_url} returned status {response.status_code}, trying next endpoint")
+                saw_definitive_answer = True
+            elif endpoint_transient:
+                self.logger.warning(f"CHS API endpoint {base_url} failed after retries, trying next endpoint")
+                transient_failure = True
+            # else: unexpected error already logged inside _get_with_retry;
+            # move on to the next mirror without setting either flag.
 
         # If we get here, all endpoints failed
         self.logger.error(f"All CHS API endpoints failed for station UUID {station_uuid}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 blinker==1.9.0
-click==8.1.7
+click==8.4.2
 Flask==3.1.3
 itsdangerous==2.2.0
 Jinja2==3.1.6
-MarkupSafe==2.1.5
+MarkupSafe==3.0.3
 Werkzeug==3.1.6
 Flask-Limiter==4.1.1
 # Flask-Limiter transitive deps, pinned for reproducible image builds.

--- a/scripts/test_usage_events.py
+++ b/scripts/test_usage_events.py
@@ -165,6 +165,32 @@ def test_retention_prunes_old_events():
         os.remove(path)
 
 
+def test_row_count_cap_prunes_oldest_events():
+    print("\n=== test_row_count_cap_prunes_oldest_events ===")
+    db, path = _fresh_db()
+    try:
+        db.USAGE_EVENTS_MAX_ROWS = 3
+        with sqlite3.connect(path) as conn:
+            for i in range(5):
+                conn.execute("""
+                    INSERT INTO usage_events (timestamp, station_id, station_name, status, source)
+                    VALUES (datetime('now', ?), ?, 'Station', 'success', 'web')
+                """, (f'-{5 - i} days', f'S{i}'))
+            conn.commit()
+
+        # Re-initialize — the row-count cap runs in init_database
+        db.init_database()
+
+        with sqlite3.connect(path) as conn:
+            remaining = [row[0] for row in conn.execute(
+                'SELECT station_id FROM usage_events ORDER BY timestamp'
+            ).fetchall()]
+            assert remaining == ['S2', 'S3', 'S4'], remaining
+        print("  PASS: row-count cap prunes the oldest events, keeping the most recent N")
+    finally:
+        os.remove(path)
+
+
 def test_get_usage_stats_error_path():
     print("\n=== test_get_usage_stats_error_path ===")
     # Point to a path where we can't open a db (a directory)
@@ -195,6 +221,7 @@ def main():
         test_log_usage_event_swallows_db_errors,
         test_get_usage_stats_aggregates,
         test_retention_prunes_old_events,
+        test_row_count_cap_prunes_oldest_events,
         test_get_usage_stats_error_path,
     ]
     failed = []


### PR DESCRIPTION
## Summary
Addresses most of #87 (deferred low-priority items from the June 2026 hardening audit):

- **Adapter retry-loop dedup** (the "biggest remaining cleanup" per #87): extracted a shared `_get_with_retry()` helper in `tide_adapters.py`, used by `NOAAAdapter.get_predictions` (single URL) and `CHSAdapter.get_predictions` (called once per mirror, preserving the existing transient-vs-definitive-answer tracking across mirrors exactly as before). Also hoisted the duplicated User-Agent literal into one module constant. `CHSAdapter._lookup_station_uuid`'s different shape (try-each-mirror-once, no retry/backoff) was intentionally left structurally alone — only its header literal points at the shared constant now.
- `last_place_name` cookie: `secure=True, samesite='Lax'`.
- Fixed `/api/generate_quick` logging the literal string `"None"` instead of a real NULL for a JSON `null` station_id.
- `usage_events` pruning: added a 100k row-count cap alongside the existing 365-day age cap.
- Font Awesome: pinned `6.0.0-beta3` (unpinned) → `6.7.2` with an SRI hash.
- Playwright's production smoke-test workflow no longer runs on push to `development` (which doesn't deploy to prod, so it was just re-testing the previous deploy) — only `main` pushes, PRs into `main`, and the daily cron.
- Bumped `click`/`MarkupSafe` to their latest versions compatible with the pinned Flask/Jinja2/Werkzeug and `python:3.12-slim-bookworm`.

**Deliberately NOT included** (staying open on #87, will comment there with reasoning):
- Test-directory consolidation (`app/test_*.py` → `tests/`) — too invasive/risky for this pass; it would require reworking the documented dual-import test-runner convention (see CLAUDE.md). Worth a dedicated future pass, not a quick backlog item.
- The explicitly-accepted trade-offs from #87 (analytics `?token=` query fallback, no CSP) — not touched, per the issue's own reasoning.
- Redis-backed rate limiting — needs new infrastructure (a Redis service on CapRover), out of scope without an explicit go-ahead on infra changes.

## Review
Reviewed independently by a Sonnet-model code-reviewer agent focused specifically on the retry-dedup refactor's outage-detection contract (the highest-risk change here, since it touches production-incident-derived logic). No findings above low-nitpick; the one nitpick raised (a retry-attempt log line losing the mirror URL) was fixed for free.

## Test plan
- [x] Full unit suite green (166 tests, was 158) + `scripts/test_usage_events.py` (7 tests, was 6 — added a new row-count-cap test)
- [x] `test_tide_adapters.py` + `test_tide_service_resilience.py` (41 tests) verified unchanged behavior for the retry-dedup refactor, including exact retry counts and the "one mirror gives a definitive 404, the other times out" priority case
- [x] In-process smoke test: `GET /` renders the pinned Font Awesome URL; `GET /health` still healthy
- [x] Adversarial review by an independent Sonnet-model reviewer agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)